### PR TITLE
Lists: Nuking Zero Width Spaces

### DIFF
--- a/Aztec/Classes/Extensions/NSAttributedString+Analyzers.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Analyzers.swift
@@ -27,4 +27,15 @@ extension NSAttributedString {
 
         return attribute(NSLinkAttributeName, at: afterRange.location, effectiveRange: nil) != nil
     }
+
+    /// Returns the Substring at the specified range, whenever the received range is valid, or nil
+    /// otherwise.
+    ///
+    func safeSubstring(at range: NSRange) -> String? {
+        guard range.location >= 0 && range.endLocation <= length else {
+            return nil
+        }
+
+        return attributedSubstring(from: range).string
+    }
 }

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -105,7 +105,8 @@ extension AttributeFormatter {
         return result && enumerateAtLeastOnce
     }
 
-    @discardableResult func toggle(in attributes: [String: Any]) -> [String: Any] {
+    @discardableResult
+    func toggle(in attributes: [String: Any]) -> [String: Any] {
         if present(in: attributes) {
             return remove(from: attributes)
         } else {
@@ -117,7 +118,8 @@ extension AttributeFormatter {
     ///
     /// - Returns: the full range where the attributes where applied
     ///
-    @discardableResult func applyAttributes(to text: NSMutableAttributedString, at range: NSRange) -> NSRange {
+    @discardableResult
+    func applyAttributes(to text: NSMutableAttributedString, at range: NSRange) -> NSRange {
         var rangeToApply = applicationRange(for: range, in: text)
 
         if needsEmptyLinePlaceholder() && worksInEmptyRange() && ( rangeToApply.length == 0 || text.length == 0)   {
@@ -139,7 +141,8 @@ extension AttributeFormatter {
     ///
     /// - Returns: the full range where the attributes where removed
     ///
-    @discardableResult func removeAttributes(from text: NSMutableAttributedString, at range: NSRange) -> NSRange {
+    @discardableResult
+    func removeAttributes(from text: NSMutableAttributedString, at range: NSRange) -> NSRange {
         let rangeToApply = applicationRange(for: range, in: text)
         text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, stop) in
             let currentAttributes = text.attributes(at: range.location, effectiveRange: nil)

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -1,53 +1,75 @@
 import Foundation
 import UIKit
 
+
+// MARK: - Lists Formatter
+//
 class TextListFormatter: ParagraphAttributeFormatter {
-    
+
+    /// Style of the list
+    ///
     let listStyle: TextList.Style
+
+    /// Attributes to be added by default
+    ///
     let placeholderAttributes: [String : Any]?
 
+
+    /// Designated Initializer
+    ///
     init(style: TextList.Style, placeholderAttributes: [String : Any]? = nil) {
         self.listStyle = style
         self.placeholderAttributes = placeholderAttributes
     }
 
+
+    // MARK: - Overwriten Methods
+
     func apply(to attributes: [String : Any]) -> [String: Any] {
-        var resultingAttributes = attributes
         let newParagraphStyle = ParagraphStyle()
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
+
         if newParagraphStyle.textList == nil {
             newParagraphStyle.headIndent += Metrics.listTextIndentation
             newParagraphStyle.firstLineHeadIndent += Metrics.listTextIndentation
         }
+
         newParagraphStyle.textList = TextList(style: self.listStyle)
+
+        var resultingAttributes = attributes
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
+
         return resultingAttributes
     }
 
-    func remove(from attributes:[String: Any]) -> [String: Any] {
-        var resultingAttributes = attributes
-        let newParagraphStyle = ParagraphStyle()
-        guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
-            paragraphStyle.textList?.style == self.listStyle
-        else {
-            return resultingAttributes
+    func remove(from attributes: [String: Any]) -> [String: Any] {
+        guard present(in: attributes) else {
+            return attributes
         }
-        newParagraphStyle.setParagraphStyle(paragraphStyle)
+
+        let newParagraphStyle = ParagraphStyle()
+        if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
+            newParagraphStyle.setParagraphStyle(paragraphStyle)
+        }
         newParagraphStyle.headIndent -= Metrics.listTextIndentation
         newParagraphStyle.firstLineHeadIndent -= Metrics.listTextIndentation
         newParagraphStyle.textList = nil
+
+        var resultingAttributes = attributes
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
+
         return resultingAttributes
     }
 
     func present(in attributes: [String : Any]) -> Bool {
-        guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
-              let textList = paragraphStyle.textList else {
+        guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle, let list = style.textList else {
             return false
         }
-        return textList.style == listStyle
+
+        return list.style == listStyle
+    }
     }
 }
 

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -70,6 +70,9 @@ class TextListFormatter: ParagraphAttributeFormatter {
 
         return list.style == listStyle
     }
+
+    func needsEmptyLinePlaceholder() -> Bool {
+        return false
     }
 }
 

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -74,5 +74,10 @@ class TextListFormatter: ParagraphAttributeFormatter {
     func needsEmptyLinePlaceholder() -> Bool {
         return false
     }
+
+    static func listsOfAnyKindPresent(in attributes: [String: Any]) -> Bool {
+        let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle
+        return style?.textList != nil
+    }
 }
 

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -45,14 +45,14 @@ class TextListFormatter: ParagraphAttributeFormatter {
     }
 
     func remove(from attributes: [String: Any]) -> [String: Any] {
-        guard present(in: attributes) else {
+        guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
+            paragraphStyle.textList?.style == self.listStyle
+        else {
             return attributes
         }
 
         let newParagraphStyle = ParagraphStyle()
-        if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
-            newParagraphStyle.setParagraphStyle(paragraphStyle)
-        }
+        newParagraphStyle.setParagraphStyle(paragraphStyle)
         newParagraphStyle.headIndent -= Metrics.listTextIndentation
         newParagraphStyle.firstLineHeadIndent -= Metrics.listTextIndentation
         newParagraphStyle.textList = nil

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -108,17 +108,6 @@ private extension LayoutManager {
 
                 self.drawItem(number: markerNumber, in: lineRect, from: list, using: paragraphStyle, at: location)
             }
-
-            // Draw the Last Line's Item
-            guard range.endLocation == textStorage.rangeOfEntireString.endLocation, !extraLineFragmentRect.isEmpty else {
-                return
-            }
-
-            let location = range.endLocation - 1
-            let lineRect = extraLineFragmentRect.offsetBy(dx: origin.x, dy: origin.y)
-            let markerNumber = textStorage.itemNumber(in: list, at: location) + 1
-
-            drawItem(number: markerNumber, in: lineRect, from: list, using: paragraphStyle, at: location)
         }
     }
 

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -9,7 +9,7 @@ class LayoutManager: NSLayoutManager {
 
     /// Blockquote's Left Border Color
     ///
-    var blockquoteBorderColor: UIColor = UIColor(red: 0.52, green: 0.65, blue: 0.73, alpha: 1.0)
+    var blockquoteBorderColor = UIColor(red: 0.52, green: 0.65, blue: 0.73, alpha: 1.0)
 
     /// Blockquote's Background Color
     ///

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -713,7 +713,8 @@ open class TextStorage: NSTextStorage {
     }
     
     // MARK: - Styles: Toggling
-    @discardableResult func toggle(formatter: AttributeFormatter, at range: NSRange) -> NSRange {
+    @discardableResult
+    func toggle(formatter: AttributeFormatter, at range: NSRange) -> NSRange {
         let applicationRange = formatter.applicationRange(for: range, in: self)
         if applicationRange.length == 0, !formatter.worksInEmptyRange() {
             return applicationRange

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -497,7 +497,7 @@ open class TextView: UITextView {
     // MARK: - Formatting
 
     func toggle(formatter: AttributeFormatter, atRange range: NSRange) {
-        let applicationRange = storage.toggle(formatter: formatter, at: range)        
+        let applicationRange = storage.toggle(formatter: formatter, at: range)
         if applicationRange.length == 0 {
             typingAttributes = formatter.toggle(in: typingAttributes)
         } else {
@@ -568,20 +568,43 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleOrderedList(range: NSRange) {
+        insertText("\n")
+        selectedRange = NSRange(location: 0, length: 0)
+
         let formatter = TextListFormatter(style: .ordered, placeholderAttributes: typingAttributes)
         toggle(formatter: formatter, atRange: range)
-        forceRedrawCursorAfterDelay()
+
+//        forceRedrawCursorAfterDelay()
     }
 
+    override open var typingAttributes: [String : Any] {
+        get {
+            NSLog("### typingAttributes Getter")
+            if selectedRange.location == storage.length && selectedRange.length == 0 {
+                var updated = super.typingAttributes
+                updated.removeValue(forKey: NSParagraphStyleAttributeName)
+
+                return updated
+            }
+
+            return super.typingAttributes
+        }
+        set {
+            super.typingAttributes = newValue
+        }
+    }
 
     /// Adds or removes a unordered list style from the specified range.
     ///
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleUnorderedList(range: NSRange) {
+        insertText("\n")
+        selectedRange = NSRange(location: 0, length: 0)
+
         let formatter = TextListFormatter(style: .unordered, placeholderAttributes: typingAttributes)
         toggle(formatter: formatter, atRange: range)
-        forceRedrawCursorAfterDelay()
+//        forceRedrawCursorAfterDelay()
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -168,7 +168,7 @@ open class TextView: UITextView {
         storage.undoManager = undoManager
         commonInit()
     }
-    
+
     required public init?(coder aDecoder: NSCoder) {
 
         defaultFont = UIFont.systemFont(ofSize: 14)
@@ -573,8 +573,7 @@ open class TextView: UITextView {
 
         let formatter = TextListFormatter(style: .ordered, placeholderAttributes: typingAttributes)
         toggle(formatter: formatter, atRange: range)
-
-//        forceRedrawCursorAfterDelay()
+        forceRedrawCursorAfterDelay()
     }
 
     override open var typingAttributes: [String : Any] {
@@ -604,7 +603,7 @@ open class TextView: UITextView {
 
         let formatter = TextListFormatter(style: .unordered, placeholderAttributes: typingAttributes)
         toggle(formatter: formatter, atRange: range)
-//        forceRedrawCursorAfterDelay()
+        forceRedrawCursorAfterDelay()
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -787,11 +787,7 @@ open class TextView: UITextView {
         }
 
         let previousRange = NSRange(location: selectedRange.location - 1, length: 1)
-        guard previousRange.endLocation <= storage.length else {
-            return attributes
-        }
-
-        let previousString = storage.attributedSubstring(from: previousRange).string
+        let previousString = storage.safeSubstring(at: previousRange) ?? String(.newline)
         guard previousString == String(.newline) else {
             return attributes
         }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -638,8 +638,6 @@ open class TextView: UITextView {
     }()
 
     private lazy var paragraphFormatters: [AttributeFormatter] = [
-        TextListFormatter(style: .ordered),
-        TextListFormatter(style: .unordered),
         BlockquoteFormatter(),
         HeaderFormatter(headerLevel:.h1),
         HeaderFormatter(headerLevel:.h2),
@@ -661,14 +659,13 @@ open class TextView: UITextView {
         guard deletedText.string == String(.newline) || range.location == 0 else {
             return
         }
+
         for formatter in paragraphFormatters {
             if let locationBefore = storage.string.location(before: range.location),
                 formatter.present(in: textStorage, at: locationBefore) {
                 if range.endLocation < storage.length {
                     formatter.applyAttributes(to: storage, at: range)
                 }
-            } else if formatter.present(in: textStorage, at: range.location) || range.location == 0 {
-                formatter.removeAttributes(from: textStorage, at: range)
             }
         }
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -802,13 +802,14 @@ open class TextView: UITextView {
             return
         }
 
+        // Note: We *really* need to use super, so that we prevent recursive loops.
         let previousRange = selectedRange
-        let previousStyle = typingAttributes
+        let previousStyle = super.typingAttributes
 
-        insertText(String(.newline))
+        super.insertText(String(.newline))
 
         selectedRange = previousRange
-        typingAttributes = previousStyle
+        super.typingAttributes = previousStyle
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -763,6 +763,7 @@ open class TextView: UITextView {
     ///
     ///     A. The caret is at the very end of the document (+ there is no selected text)
     ///     B. There's a list!
+    ///     C. The previous character is a '\n'
     ///
     /// - Parameter attributes: Typing Attributes.
     ///
@@ -774,6 +775,16 @@ open class TextView: UITextView {
         }
 
         guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle, style.textList != nil else {
+            return attributes
+        }
+
+        let previousRange = NSRange(location: selectedRange.location - 1, length: 1)
+        guard previousRange.endLocation <= storage.length else {
+            return attributes
+        }
+
+        let previousString = storage.attributedSubstring(from: previousRange).string
+        guard previousString == String(.newline) else {
             return attributes
         }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -287,6 +287,14 @@ open class TextView: UITextView {
     // MARK: - Intercept keyboard operations
 
     open override func insertText(_ text: String) {
+
+        /// Insert `\n` characters whenever we're in a Text List, the user presses \n, and we're literally
+        /// at the End of the Document.
+        ///
+        if TextListFormatter.listsOfAnyKindPresent(in: typingAttributes) {
+            ensureInsertionOfNewlineOnEmptyDocuments()
+        }
+
         // Note:
         // Whenever the entered text causes the Paragraph Attributes to be removed, we should prevent the actual
         // text insertion to happen. Thus, we won't call super.insertText.
@@ -774,7 +782,7 @@ open class TextView: UITextView {
             return attributes
         }
 
-        guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle, style.textList != nil else {
+        guard TextListFormatter.listsOfAnyKindPresent(in: attributes) else {
             return attributes
         }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -735,9 +735,21 @@ open class TextView: UITextView {
             return false
         }
 
-        let formatters:[AttributeFormatter] = [TextListFormatter(style: .ordered), TextListFormatter(style: .unordered), BlockquoteFormatter()]
+        let formatters:[AttributeFormatter] = [
+            TextListFormatter(style: .ordered),
+            TextListFormatter(style: .unordered),
+            BlockquoteFormatter()
+        ]
+
+        let atEdgeOfDocument = range.location >= storage.length
+
         for formatter in formatters {
-            if formatter.present(in: textStorage, at: range.location) {
+            if atEdgeOfDocument && formatter.present(in: typingAttributes) {
+                typingAttributes = formatter.remove(from: typingAttributes)
+                return true
+            }
+
+            if !atEdgeOfDocument && formatter.present(in: textStorage, at: range.location) {
                 formatter.removeAttributes(from: textStorage, at: range)
                 return true
             }

--- a/AztecTests/Extensions/NSAttributedStringAnalyzerTests.swift
+++ b/AztecTests/Extensions/NSAttributedStringAnalyzerTests.swift
@@ -106,4 +106,21 @@ class NSAttributedStringAnalyzerTests: XCTestCase {
             XCTAssertTrue(fullString.isLocationSuccededByLink(i))
         }
     }
+
+    /// Verifies that *safeSubstring* returns nil, whenever the range parameter is not valid within the receiver.
+    ///
+    func testSafeSubstringAtRangeReturnsNilWhenQueriedWithOutOfBoundsRanges() {
+        let fullString = LinkedSample.fullString
+        let empty = NSAttributedString()
+
+        let ranges = [
+            NSRange(location: fullString.length, length: 1),
+            NSRange(location: -1, length: 1)
+        ]
+
+        for range in ranges {
+            XCTAssertNil(fullString.safeSubstring(at: range))
+            XCTAssertNil(empty.safeSubstring(at: range))
+        }
+    }
 }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -815,4 +815,28 @@ class AztecVisualTextViewTests: XCTestCase {
 
         XCTAssertFalse(TextListFormatter.listsOfAnyKindPresent(in: textView.typingAttributes))
     }
+
+    /// Verifies that a Text List gets removed, whenever the user types `\n` in an empty line.
+    ///
+    /// Input:
+    ///     - Ordered List
+    ///     - `\n` on the first line
+    ///
+    /// Ref. Scenario Mark IV on Issue https://github.com/wordpress-mobile/AztecEditor-iOS/pull/425
+    ///
+    func testListGetsRemovedWhenTypingNewLineOnAnEmptyBullet() {
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleOrderedList(range: .zero)
+        textView.insertText("\n")
+
+        let formatter = TextListFormatter(style: .ordered)
+        let attributedText = textView.attributedText!
+
+        for location in 0 ..< attributedText.length {
+            XCTAssertFalse(formatter.present(in: attributedText, at: location))
+        }
+
+        XCTAssertFalse(TextListFormatter.listsOfAnyKindPresent(in: textView.typingAttributes))
+    }
 }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -680,13 +680,63 @@ class AztecVisualTextViewTests: XCTestCase {
         XCTAssertEqual(textView.getHTML(), "<h1>Header<br></h1>1")
     }
 
+
+    /// Verifies that a Text List does not get removed, whenever the user presses backspace
+    ///
+    /// Input:
+    ///     - Ordered List
+    ///     - "First Item"
+    ///     - Backspace
+    ///
+    /// Ref. Scenario Mark I on Issue https://github.com/wordpress-mobile/AztecEditor-iOS/pull/425
+    ///
+    func testListDoesNotGetLostAfterPressingBackspace() {
+        let textView = createTextView(withHTML: "")
+
+
+        textView.toggleOrderedList(range: .zero)
+        textView.insertText("First Item")
+        textView.deleteBackward()
+
+        let formatter = TextListFormatter(style: .ordered)
+        let range = textView.storage.rangeOfEntireString
+        let present = formatter.present(in: textView.storage, at: range)
+
+        XCTAssertTrue(present)
+    }
+
+
+    /// Verifies that the Text List does get nuked whenever the only `\n` present in the document is deleted.
+    ///
+    /// Input:
+    ///     - Ordered List
+    ///     - Selection of the EOD
+    ///     - Backspace
+    ///
+    /// Ref. Scenario Mark II on Issue https://github.com/wordpress-mobile/AztecEditor-iOS/pull/425
+    ///
+    func testEmptyListGetsNukedWheneverTheOnlyNewlineCharacterInTheDocumentIsNuked() {
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleOrderedList(range: .zero)
+
+        let length = textView.storage.length
+        textView.selectedRange = NSRange(location: length, length: 0)
+
+        textView.deleteBackward()
+
+        XCTAssertFalse(TextListFormatter.listsOfAnyKindPresent(in: textView.typingAttributes))
+        XCTAssert(textView.storage.length == 0)
+    }
+
+
     /// Verifies that New Line Characters get effectively inserted after a Text List.
     ///
     /// Input:
     ///     - Ordered List
     ///     - \n at the end of the document
     ///
-    /// Ref. https://github.com/wordpress-mobile/AztecEditor-iOS/pull/425
+    /// Ref. Scenario Mark III on Issue https://github.com/wordpress-mobile/AztecEditor-iOS/pull/425
     ///
     func testNewLinesAreInsertedAfterEmptyList() {
         let newline = String(.newline)
@@ -713,7 +763,7 @@ class AztecVisualTextViewTests: XCTestCase {
     ///     - Selection of the `\n` at the EOD, and backspace
     ///     - Text: "\nSecond Item"
     ///
-    /// Ref. https://github.com/wordpress-mobile/AztecEditor-iOS/pull/425
+    /// Ref. Scenario Mark IV on Issue https://github.com/wordpress-mobile/AztecEditor-iOS/pull/425
     ///
     func testNewLinesGetBulletStyleEvenAfterDeletingEndOfDocumentNewline() {
         let firstItemText = "First Item"

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -681,6 +681,8 @@ class AztecVisualTextViewTests: XCTestCase {
     }
 
 
+    // MARK: - Lists
+
     /// Verifies that a Text List does not get removed, whenever the user presses backspace
     ///
     /// Input:
@@ -792,5 +794,25 @@ class AztecVisualTextViewTests: XCTestCase {
         let present = formatter.present(in: textView.storage, at: secondLineRange)
 
         XCTAssert(present)
+    }
+
+    /// Verifies that after selecting a newline below a TextList does, TextView wil not render (nor carry over)
+    /// the Text List formatting attributes.
+    ///
+    /// Input:
+    ///     - Ordered List
+    ///     - Selection of the `\n` at the EOD
+    ///
+    /// Ref. Scenario Mark V on Issue https://github.com/wordpress-mobile/AztecEditor-iOS/pull/425
+    ///
+    func testTypingAttributesLooseTextListWhenSelectingAnEmptyNewlineBelowTextList() {
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleOrderedList(range: .zero)
+
+        let length = textView.text.characters.count
+        textView.selectedRange = NSRange(location: length, length: 0)
+
+        XCTAssertFalse(TextListFormatter.listsOfAnyKindPresent(in: textView.typingAttributes))
     }
 }


### PR DESCRIPTION
### Description:
In this PR we're nuking Zero Width Spaces from the TextLists Formatter.

**All of the Testing Scenarios** are backed up by a unit test. Ain't that cool?

Needs Review: @diegoreymendez @SergioEstevao 
**Diego:** Thanks for the infinite help on this one!!

Closes #421
Ref.: #414


### Details:
- Yes. We're removing the Zero Width Spaces from the TextLists's inner working. Whenever a bullet must be rendered, and there's no text, we'll be inserting a `\n` character.  

  Hook points for this behavior are **insertText** and the formatter's toggle themselves.
- And yes. We're overriding **typingAttributes**, because the `didSet` observer of both, **selectedRange** and **selectedTextRange** is not being always triggered (ie. user touch).
- **TextListFormatter** got a new helper to verify if lists of any kind are present in a collection of attributes.
- Removed a workaround from **LayoutManager**, which was being used to render the *extra line fragment* (Bullets when there was no text).

--

### Testing:
Detailing below all of the test cases.

#### Scenario I: List after Backspace
1.	Empty Document
2.	Toggle List
3. 	Type something
4. 	Backspace

Verify that the list remains onscreen.

#### Scenario II: Deleting after List
1.	Empty Document
2.	Toggle List
3. 	Arrow Down
4. 	Backspace

Verify that the List is gone.

#### Scenario III: Newline Not Inserted
1.	Empty Document
2.	Toggle List
3. 	Arrow Down
4.	Enter

Verify that the Newline gets inserted.

#### Scenario IV: New List Item when at the edge of the document
1. 	Empty Document
2. 	Toggle List
3. 	Type something
4.	Arrow Down
5.	Backspace
6.	Enter

Verify that a new bullet gets added.

#### Scenario V: Typing Attributes on new line
1. Empty Document
2. Toggle List
3. Arrow Down

Verify that the Typing Attributes do not contain a Text List: indentation should be normal. Typing any character should not display a bullet.

#### Scenario VI: Empty Lines
1. Empty Document
2. Toggle List
3. Insert a newline

Verify that the bullet in the first line gets removed.
