### PR TITLE
Video attachments

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		FFD0FEB71DAE59A700430586 /* NSLayoutManager+Attachments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */; };
 		FFD436961E300EF800A0E26F /* FontFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD436951E300EF700A0E26F /* FontFormatter.swift */; };
 		FFD436981E3180A500A0E26F /* FontFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD436971E3180A500A0E26F /* FontFormatterTests.swift */; };
+		FFFEC7DB1EA7698900F4210F /* VideoAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFEC7DA1EA7698900F4210F /* VideoAttachment.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -256,6 +257,7 @@
 		FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLayoutManager+Attachments.swift"; sourceTree = "<group>"; };
 		FFD436951E300EF700A0E26F /* FontFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontFormatter.swift; sourceTree = "<group>"; };
 		FFD436971E3180A500A0E26F /* FontFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontFormatterTests.swift; sourceTree = "<group>"; };
+		FFFEC7DA1EA7698900F4210F /* VideoAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoAttachment.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -470,6 +472,7 @@
 				B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */,
 				FF7A1C501E5651EA00C4C7C8 /* LineAttachment.swift */,
 				599F25301D8BC9A1002871D6 /* TextAttachment.swift */,
+				FFFEC7DA1EA7698900F4210F /* VideoAttachment.swift */,
 				B5BC4FF51DA2D76600614582 /* TextList.swift */,
 				599F25311D8BC9A1002871D6 /* TextStorage.swift */,
 				599F25321D8BC9A1002871D6 /* TextView.swift */,
@@ -788,6 +791,7 @@
 				F1FA0E731E6EF25A009D98EE /* DOMEditor.swift in Sources */,
 				F1C05B9D1E37FA77007510EA /* String+CharacterName.swift in Sources */,
 				F1FA0E841E6EF514009D98EE /* LeafNode.swift in Sources */,
+				FFFEC7DB1EA7698900F4210F /* VideoAttachment.swift in Sources */,
 				F1288BB01DD0B1EF00E67ABC /* HTMLToAttributedString.swift in Sources */,
 				E11B77641DBA6ADC0024E455 /* AttributeFormatter.swift in Sources */,
 				599F25351D8BC9A1002871D6 /* CLinkedListToArrayConverter.swift in Sources */,

--- a/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
@@ -61,6 +61,13 @@ class ImageFormatter: StandardAttributeFormatter {
     }
 }
 
+class VideoFormatter: StandardAttributeFormatter {
+    init() {
+        super.init(attributeKey: NSAttachmentAttributeName, attributeValue: VideoAttachment(identifier: NSUUID().uuidString))
+    }
+}
+
+
 class HRFormatter: StandardAttributeFormatter {
     init() {
         super.init(attributeKey: NSAttachmentAttributeName, attributeValue: LineAttachment())

--- a/Aztec/Classes/Libxml2/DOM/Data/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/StandardElementType.swift
@@ -47,6 +47,7 @@ extension Libxml2 {
         case tr = "tr"
         case u = "u"
         case ul = "ul"
+        case video = "video"
 
         /// Returns an array with all block-level elements.
         ///
@@ -84,6 +85,8 @@ extension Libxml2 {
         func implicitRepresentation(withAttributes attributes: [String:Any]) -> NSAttributedString? {
             switch self {
             case .img:
+                return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
+            case .video:
                 return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
             case .br:
                 return NSAttributedString(.newline, attributes: attributes)

--- a/Aztec/Classes/Libxml2/EditContext.swift
+++ b/Aztec/Classes/Libxml2/EditContext.swift
@@ -42,7 +42,8 @@ extension Libxml2 {
             .strike,
             .strong,
             .u,
-            .ul
+            .ul,
+            .video
         ]
     }
 }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1041,13 +1041,13 @@ open class TextView: UITextView {
     ///
     /// - Returns: The associated TextAttachment.
     ///
-    open func attachmentAtPoint(_ point: CGPoint) -> TextAttachment? {
+    open func attachmentAtPoint(_ point: CGPoint) -> NSTextAttachment? {
         let index = layoutManager.characterIndex(for: point, in: textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
         guard index < textStorage.length else {
             return nil
         }
 
-        return textStorage.attribute(NSAttachmentAttributeName, at: index, effectiveRange: nil) as? TextAttachment
+        return textStorage.attribute(NSAttachmentAttributeName, at: index, effectiveRange: nil) as? NSTextAttachment
     }
 
     /// Move the selected range to the nearest character of the point specified in the textView
@@ -1079,7 +1079,7 @@ open class TextView: UITextView {
     open func isPointInsideAttachmentMargin(point: CGPoint) -> Bool {
         let index = layoutManager.characterIndex(for: point, in: textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
 
-        if let attachment = attachmentAtPoint(point) {
+        if let attachment = attachmentAtPoint(point) as? TextAttachment {
             let glyphRange = layoutManager.glyphRange(forCharacterRange: NSRange(location: index, length: 1), actualCharacterRange: nil)
             let rect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
             if point.y >= rect.origin.y && point.y <= (rect.origin.y + (2*attachment.imageMargin)) {
@@ -1326,7 +1326,7 @@ extension TextView: TextStorageAttachmentsDelegate {
             return
         }
 
-        currentSelectedAttachment = attachment
+        currentSelectedAttachment = attachment as? TextAttachment
         textView.mediaDelegate?.textView(textView, selectedAttachment: attachment, atPosition: locationInTextView)
     }
 }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -36,7 +36,7 @@ public protocol TextViewMediaDelegate: class {
     ///
     func textView(
         _ textView: TextView,
-        urlForAttachment attachment: TextAttachment) -> URL
+        urlForAttachment attachment: NSTextAttachment) -> URL
 
 
     /// Called when a attachment is removed from the storage.
@@ -53,7 +53,7 @@ public protocol TextViewMediaDelegate: class {
     ///   - attachment: the attachment that was selected.
     ///   - position: touch position relative to the textview.
     ///
-    func textView(_ textView: TextView, selectedAttachment attachment: TextAttachment, atPosition position: CGPoint)
+    func textView(_ textView: TextView, selectedAttachment attachment: NSTextAttachment, atPosition position: CGPoint)
 
     /// Called when an attachment is deselected with a single tap.
     ///
@@ -62,7 +62,7 @@ public protocol TextViewMediaDelegate: class {
     ///   - attachment: the attachment that was deselected.
     ///   - position: touch position relative to the textView
     ///
-    func textView(_ textView: TextView, deselectedAttachment attachment: TextAttachment, atPosition position: CGPoint)
+    func textView(_ textView: TextView, deselectedAttachment attachment: NSTextAttachment, atPosition position: CGPoint)
 }
 
 
@@ -1220,7 +1220,7 @@ extension TextView: TextStorageAttachmentsDelegate {
 
     func storage(
         _ storage: TextStorage,
-        attachment: TextAttachment,
+        attachment: NSTextAttachment,
         imageForURL url: URL,
         onSuccess success: @escaping (UIImage) -> (),
         onFailure failure: @escaping () -> ()) -> UIImage {
@@ -1233,11 +1233,11 @@ extension TextView: TextStorageAttachmentsDelegate {
         return placeholderImage
     }
 
-    func storage(_ storage: TextStorage, missingImageForAttachment: TextAttachment) -> UIImage {
+    func storage(_ storage: TextStorage, missingImageForAttachment: NSTextAttachment) -> UIImage {
         return defaultMissingImage
     }
     
-    func storage(_ storage: TextStorage, urlForAttachment attachment: TextAttachment) -> URL {
+    func storage(_ storage: TextStorage, urlForAttachment attachment: NSTextAttachment) -> URL {
         guard let mediaDelegate = mediaDelegate else {
             fatalError("This class requires a media delegate to be set.")
         }

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -1,0 +1,359 @@
+import Foundation
+import UIKit
+
+protocol VideoAttachmentDelegate: class {
+    func videoAttachment(
+        _ videoAttachment: VideoAttachment,
+        imageForURL url: URL,
+        onSuccess success: @escaping (UIImage) -> (),
+        onFailure failure: @escaping () -> ()) -> UIImage
+}
+
+/// Custom text attachment.
+///
+open class VideoAttachment: NSTextAttachment
+{
+    public struct Appearance {
+        public var overlayColor = UIColor(white: 0.6, alpha: 0.6)
+
+        /// The height of the progress bar for progress indicators
+        public var progressHeight = CGFloat(2.0)
+
+        /// The color to use when drawing the backkground of the progress indicators
+        ///
+        public var progressBackgroundColor = UIColor.cyan
+
+        /// The color to use when drawing progress indicators
+        ///
+        public var progressColor = UIColor.blue
+
+        /// The margin apply to the images being displayed. This is to avoid that two images in a row get glued together.
+        ///
+        public var margin = CGFloat(10.0)
+    }
+
+
+    /// This property allows the global customization of appearance properties of the TextAttachment
+    ///
+    open static var appearance: Appearance = Appearance()
+
+    /// Identifier used to match this attachment with a custom UIView subclass
+    ///
+    fileprivate(set) open var identifier: String
+    
+    /// Attachment video URL
+    ///
+    open var srcURL: URL?
+
+
+    /// Video poster image to show, while the video is not played.
+    ///
+    open var posterURL: URL?
+
+    fileprivate var lastRequestedURL: URL?
+
+    /// A progress value that indicates the progress of an attachment. It can be set between values 0 and 1
+    ///
+    open var progress: Double? = nil {
+        willSet {
+            assert(newValue == nil || (newValue! >= 0 && newValue! <= 1), "Progress must be value between 0 and 1 or nil")
+            if newValue != progress {
+                glyphImage = nil
+            }
+        }
+    }
+
+    /// The color to use when drawing the background overlay for messages, icons, and progress
+    ///
+    open var overlayColor: UIColor = TextAttachment.appearance.overlayColor
+
+    /// The height of the progress bar for progress indicators
+    open var progressHeight: CGFloat = TextAttachment.appearance.progressHeight
+
+    /// The color to use when drawing the backkground of the progress indicators
+    ///
+    open var progressBackgroundColor: UIColor = TextAttachment.appearance.progressBackgroundColor
+
+    /// The color to use when drawing progress indicators
+    ///
+    open var progressColor: UIColor = TextAttachment.appearance.progressColor
+
+    /// The margin apply to the images being displayed. This is to avoid that two images in a row get glued together.
+    ///
+    open var margin: CGFloat = VideoAttachment.appearance.margin
+
+    /// A message to display overlaid on top of the image
+    ///
+    open var message: NSAttributedString? {
+        willSet {
+            if newValue != message {
+                glyphImage = nil
+            }
+        }
+    }
+
+    /// An image to display overlaid on top of the image has an action icon.
+    ///
+    open var overlayImage: UIImage? {
+        willSet {
+            if newValue != overlayImage {
+                glyphImage = nil
+            }
+        }
+    }
+
+
+    /// Clears all overlay information that is applied to the attachment
+    ///
+    open func clearAllOverlays() {
+        progress = nil
+        message = nil
+        overlayImage = nil
+    }
+
+    fileprivate var glyphImage: UIImage?
+
+    weak var delegate: VideoAttachmentDelegate?
+    
+    var isFetchingImage: Bool = false
+
+    /// Creates a new attachment
+    ///
+    /// - parameter identifier: An unique identifier for the attachment
+    ///
+    required public init(identifier: String, srcURL: URL? = nil, posterURL: URL? = nil) {
+        self.identifier = identifier
+        self.srcURL = srcURL
+        self.posterURL = posterURL
+        
+        super.init(data: nil, ofType: nil)
+    }
+
+    /// Required Initializer
+    ///
+    required public init?(coder aDecoder: NSCoder) {
+        identifier = ""
+        super.init(coder: aDecoder)
+
+        if let decodedIndentifier = aDecoder.decodeObject(forKey: EncodeKeys.identifier.rawValue) as? String {
+            identifier = decodedIndentifier
+        }
+        if aDecoder.containsValue(forKey: EncodeKeys.srcURL.rawValue) {
+            srcURL = aDecoder.decodeObject(forKey: EncodeKeys.srcURL.rawValue) as? URL
+        }
+
+        if aDecoder.containsValue(forKey: EncodeKeys.posterURL.rawValue) {
+            posterURL = aDecoder.decodeObject(forKey: EncodeKeys.posterURL.rawValue) as? URL
+        }
+    }
+
+    override init(data contentData: Data?, ofType uti: String?) {
+        identifier = ""
+        srcURL = nil
+        posterURL = nil
+        super.init(data: contentData, ofType: uti)
+    }
+
+    fileprivate func setupDefaultAppearance() {
+        progressHeight = VideoAttachment.appearance.progressHeight
+        progressBackgroundColor = VideoAttachment.appearance.progressBackgroundColor
+        progressColor = VideoAttachment.appearance.progressColor
+        overlayColor = VideoAttachment.appearance.overlayColor
+    }
+
+    override open func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+        aCoder.encode(identifier, forKey: EncodeKeys.identifier.rawValue)
+        if let url = self.srcURL {
+            aCoder.encode(url, forKey: EncodeKeys.srcURL.rawValue)
+        }
+        if let url = self.posterURL {
+            aCoder.encode(url, forKey: EncodeKeys.posterURL.rawValue)
+        }
+    }
+
+    fileprivate enum EncodeKeys: String {
+        case identifier
+        case srcURL
+        case posterURL
+    }
+    // MARK: - Origin calculation
+
+    fileprivate func xPosition(forContainerWidth containerWidth: CGFloat) -> CGFloat {
+        let imageWidth = onScreenWidth(containerWidth)
+
+        return CGFloat(floor((containerWidth - imageWidth) / 2))
+    }
+
+    fileprivate func onScreenHeight(_ containerWidth: CGFloat) -> CGFloat {
+        if let image = image {
+            let targetWidth = onScreenWidth(containerWidth)
+            let scale = targetWidth / image.size.width
+
+            return floor(image.size.height * scale) + (margin * 2)
+        } else {
+            return 0
+        }
+    }
+
+    fileprivate func onScreenWidth(_ containerWidth: CGFloat) -> CGFloat {
+        if let image = image {
+            return floor(min(image.size.width, containerWidth))
+        } else {
+            return 0
+        }
+    }
+
+    // MARK: - NSTextAttachmentContainer
+
+    override open func image(forBounds imageBounds: CGRect, textContainer: NSTextContainer?, characterIndex charIndex: Int) -> UIImage? {
+        
+        updateImage(inTextContainer: textContainer)
+
+        guard let image = image else {
+            return nil
+        }
+
+        if let cachedImage = glyphImage, imageBounds.size.equalTo(cachedImage.size) {
+            return cachedImage
+        }
+
+        glyphImage = glyph(basedOnImage:image, forBounds: imageBounds)
+
+        return glyphImage
+    }
+
+    fileprivate func glyph(basedOnImage image:UIImage, forBounds bounds: CGRect) -> UIImage? {
+
+        let containerWidth = bounds.size.width
+        let origin = CGPoint(x: xPosition(forContainerWidth: bounds.size.width), y: margin)
+        let size = CGSize(width: onScreenWidth(containerWidth), height: onScreenHeight(containerWidth) - margin)
+
+        UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0)
+
+        image.draw(in: CGRect(origin: origin, size: size))
+
+        drawOverlay(at:origin, size: size)
+        drawProgress(at:origin, size: size)
+
+
+        var imagePadding: CGFloat = 0
+        if let overlayImage = overlayImage {
+            UIColor.white.set()
+            let center = CGPoint(x: round(origin.x + (size.width / 2.0)), y: round(origin.y + (size.height / 2.0)))
+            let radius = round(overlayImage.size.width * 2.0/3.0)
+            let path = UIBezierPath(arcCenter: center, radius: radius, startAngle: 0, endAngle: CGFloat.pi * 2, clockwise: true)
+            path.stroke()
+            overlayImage.draw(at: CGPoint(x: round(center.x - (overlayImage.size.width / 2.0)), y: round(center.y - (overlayImage.size.height / 2.0))))
+            imagePadding += radius * 2;
+        }
+
+        if let message = message {
+            let textRect = message.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
+            var y =  origin.y + ((size.height - textRect.height) / 2.0)
+            if imagePadding != 0 {
+                y = origin.y + ((size.height + imagePadding) / 2.0)
+            }
+            let textPosition = CGPoint(x: origin.x, y: y)
+            message.draw(in: CGRect(origin: textPosition , size: CGSize(width:size.width, height:textRect.size.height)))
+        }
+
+        let result = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return result;
+    }
+
+    fileprivate func drawOverlay(at origin: CGPoint, size:CGSize) {
+        guard message != nil || progress != nil else {
+            return
+        }
+        let box = UIBezierPath()
+        box.move(to: CGPoint(x:origin.x, y:origin.y))
+        box.addLine(to: CGPoint(x: origin.x + size.width, y: origin.y))
+        box.addLine(to: CGPoint(x: origin.x + size.width, y: origin.y + size.height))
+        box.addLine(to: CGPoint(x: origin.x, y: origin.y + size.height))
+        box.addLine(to: CGPoint(x: origin.x, y: origin.y))
+        box.lineWidth = 2.0
+        overlayColor.setFill()
+        box.fill()
+    }
+
+    fileprivate func drawProgress(at origin: CGPoint, size:CGSize) {
+        guard let progress = progress else {
+            return
+        }
+        let lineY = origin.y + (progressHeight / 2.0)
+
+        let backgroundPath = UIBezierPath()
+        backgroundPath.lineWidth = progressHeight
+        progressBackgroundColor.setStroke()
+        backgroundPath.move(to: CGPoint(x:origin.x, y: lineY))
+        backgroundPath.addLine(to: CGPoint(x: origin.x + size.width, y: lineY ))
+        backgroundPath.stroke()
+
+        let path = UIBezierPath()
+        path.lineWidth = progressHeight
+        progressColor.setStroke()
+        path.move(to: CGPoint(x:origin.x, y: lineY))
+        path.addLine(to: CGPoint(x: origin.x + (size.width * CGFloat(max(0,min(progress,1)))), y: lineY ))
+        path.stroke()
+    }
+
+    /// Returns the "Onscreen Character Size" of the attachment range. When we're in Alignment.None,
+    /// the attachment will be 'Inline', and thus, we'll return the actual Associated View Size.
+    /// Otherwise, we'll always take the whole container's width.
+    ///
+    override open func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
+        
+        updateImage(inTextContainer: textContainer)
+        
+        if image == nil {
+            return CGRect.zero
+        }
+
+        let padding = textContainer?.lineFragmentPadding ?? 0
+        let width = lineFrag.width - padding * 2
+
+        return CGRect(origin: CGPoint.zero, size: CGSize(width: width, height: onScreenHeight(width)))
+    }
+
+    func updateImage(inTextContainer textContainer: NSTextContainer? = nil) {
+
+        guard let delegate = delegate else {
+            assertionFailure("This class doesn't really support not having an updater set.")
+            return
+        }
+        
+        guard let url = posterURL, !isFetchingImage && url != lastRequestedURL else {
+            return
+        }
+        
+        isFetchingImage = true
+        
+        let image = delegate.videoAttachment(self, imageForURL: url, onSuccess: { [weak self] image in
+                guard let strongSelf = self else {
+                    return
+                }
+                strongSelf.lastRequestedURL = url
+                strongSelf.isFetchingImage = false
+                strongSelf.image = image
+                strongSelf.invalidateLayout(inTextContainer: textContainer)
+            }, onFailure: { [weak self] _ in
+                
+                guard let strongSelf = self else {
+                    return
+                }
+                
+                strongSelf.isFetchingImage = false
+                strongSelf.invalidateLayout(inTextContainer: textContainer)
+            })
+
+        if self.image == nil {
+            self.image = image
+        }
+    }
+    
+    fileprivate func invalidateLayout(inTextContainer textContainer: NSTextContainer?) {
+        textContainer?.layoutManager?.invalidateLayoutForAttachment(self)
+    }
+}

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import Gridicons
 
 protocol VideoAttachmentDelegate: class {
     func videoAttachment(
@@ -127,6 +128,8 @@ open class VideoAttachment: NSTextAttachment
         self.posterURL = posterURL
         
         super.init(data: nil, ofType: nil)
+
+        self.overlayImage = Gridicon.iconOfType(.video)
     }
 
     /// Required Initializer
@@ -264,7 +267,7 @@ open class VideoAttachment: NSTextAttachment
     }
 
     fileprivate func drawOverlay(at origin: CGPoint, size:CGSize) {
-        guard message != nil || progress != nil else {
+        guard message != nil || progress != nil || overlayImage != nil else {
             return
         }
         let box = UIBezierPath()

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -106,15 +106,15 @@ class TextStorageTests: XCTestCase
             deletedAttachmendIDCalledWithString = attachmentID
         }
 
-        func storage(_ storage: TextStorage, urlForAttachment attachment: TextAttachment) -> URL {
+        func storage(_ storage: TextStorage, urlForAttachment attachment: NSTextAttachment) -> URL {
             return URL(string:"test://")!
         }
 
-        func storage(_ storage: TextStorage, missingImageForAttachment: TextAttachment) -> UIImage {
+        func storage(_ storage: TextStorage, missingImageForAttachment: NSTextAttachment) -> UIImage {
             return UIImage()
         }
 
-        func storage(_ storage: TextStorage, attachment: TextAttachment, imageForURL url: URL, onSuccess success: @escaping (UIImage) -> (), onFailure failure: @escaping () -> ()) -> UIImage {
+        func storage(_ storage: TextStorage, attachment: NSTextAttachment, imageForURL url: URL, onSuccess success: @escaping (UIImage) -> (), onFailure failure: @escaping () -> ()) -> UIImage {
             return UIImage()
         }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -4,6 +4,8 @@ import Gridicons
 import Photos
 import UIKit
 import MobileCoreServices
+import AVFoundation
+import AVKit
 
 class EditorDemoController: UIViewController {
 
@@ -785,6 +787,10 @@ extension EditorDemoController: TextViewMediaDelegate {
         if let imgAttachment = attachment as? TextAttachment {
             selected(textAttachment: imgAttachment, atPosition: position)
         }
+
+        if let videoAttachment = attachment as? VideoAttachment {
+            selected(videoAttachment: videoAttachment, atPosition: position)
+        }
     }
 
     func textView(_ textView: TextView, deselectedAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
@@ -814,6 +820,24 @@ extension EditorDemoController: TextViewMediaDelegate {
     func deselected(textAttachment attachment: TextAttachment, atPosition position: CGPoint) {
         attachment.clearAllOverlays()
         richTextView.refreshLayoutFor(attachment: attachment)
+    }
+
+    func selected(videoAttachment attachment: VideoAttachment, atPosition position: CGPoint) {
+        guard let videoURL = attachment.srcURL else {
+            return
+        }
+        displayVideoPlayer(for: videoURL)
+    }
+
+    func displayVideoPlayer(for videoURL: URL) {
+        let asset = AVURLAsset(url: videoURL)
+        let controller = AVPlayerViewController()
+        let playerItem = AVPlayerItem(asset: asset)
+        let player = AVPlayer(playerItem: playerItem)
+        controller.showsPlaybackControls = true
+        controller.player = player
+        player.play()
+        present(controller, animated:true, completion: nil)
     }
 }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -758,7 +758,7 @@ extension EditorDemoController: TextViewMediaDelegate {
         return Gridicon.iconOfType(.image)
     }
     
-    func textView(_ textView: TextView, urlForAttachment attachment: TextAttachment) -> URL {
+    func textView(_ textView: TextView, urlForAttachment attachment: NSTextAttachment) -> URL {
         
         // TODO: start fake upload process
         if let image = attachment.image {
@@ -772,8 +772,19 @@ extension EditorDemoController: TextViewMediaDelegate {
         print("Attachment \(attachmentID) removed.\n")
     }
 
-    func textView(_ textView: TextView, selectedAttachment attachment: TextAttachment, atPosition position: CGPoint) {
+    func textView(_ textView: TextView, selectedAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
+        if let imgAttachment = attachment as? TextAttachment {
+            selected(textAttachment: imgAttachment, atPosition: position)
+        }
+    }
 
+    func textView(_ textView: TextView, deselectedAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
+        if let imgAttachment = attachment as? TextAttachment {
+            deselected(textAttachment: imgAttachment, atPosition: position)
+        }
+    }
+
+    func selected(textAttachment attachment: TextAttachment, atPosition position: CGPoint) {
         if (currentSelectedAttachment == attachment) {
             displayActions(forAttachment: attachment, position: position)
         } else {
@@ -791,7 +802,7 @@ extension EditorDemoController: TextViewMediaDelegate {
         }
     }
 
-    func textView(_ textView: TextView, deselectedAttachment attachment: TextAttachment, atPosition position: CGPoint) {
+    func deselected(textAttachment attachment: TextAttachment, atPosition position: CGPoint) {
         attachment.clearAllOverlays()
         richTextView.refreshLayoutFor(attachment: attachment)
     }

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -72,6 +72,13 @@ Image:<br/><br/>
 <img src="https://httpbin.org/image/jpeg" alt="Coyote" />
 </p>
 <p>
+Video:<br/><br/>
+
+<video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://i2.wp.com/videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg?ssl=1" alt="Video about bunnies" />
+<br/>
+</p>
+
+<p>
 Fanny pack Odd Future Intelligentsia lo-fi semiotics whatever. Selvage keffiyeh mustache sustainable ethnic, chambray mumblecore McSweeney's biodiesel Pitchfork four loko disrupt post-ironic art party American Apparel. Kitsch umami beard salvia, Vice before they sold out vegan tousled lomo jean shorts pickled PBR&amp;B. Tousled Wes Anderson Shoreditch flannel, 90's XOXO quinoa whatever mumblecore cliche Truffaut stumptown. Photo booth crucifix plaid Brooklyn. Authentic letterpress PBR&amp;B, sustainable VHS master cleanse ethnic High Life. Messenger bag umami pug flannel.
 </p>
 


### PR DESCRIPTION
Refs #165 

This PR is the first phase of implementing support for videos in the editor, at the moment it only implements the following:
 * Parsing of HTML `video` elements. NO support for WP shortcodes `[video] and [wpvideo]`
 * Display of videos in the visual editor with inline image with overlay icon
 * When tapped on the video image it displays a full screen video player
 * Then it can switch back do the editor by tapping on done

How to test:
 - Launch the demo app with pre filled content
 - Check the if the new video content shows in the visual editor
 - Tap on the video and see if the full screen preview shows correctly.

This PR still doesn't implement:
 - Insertion of videos through the toolbar
 - Allow changes in the visual to be reflected to the HTML