### PR TITLE
Blockquotes: Nuking Zero Width Spaces

### DIFF
--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -43,6 +43,12 @@ extension String
         return NSRange(location: location, length: length)
     }
 
+    /// Returns a NSRange with a starting location at the very end of the string
+    ///
+    func endOfStringNSRange() -> NSRange {
+        return NSRange(location: characters.count, length: 0)
+    }
+
     func indexFromLocation(_ location: Int) -> String.Index? {
         guard
             let unicodeLocation = utf16.index(utf16.startIndex, offsetBy: location, limitedBy: utf16.endIndex),

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -1,14 +1,25 @@
 import Foundation
 import UIKit
 
+
+// MARK: - Blockquote Formatter
+//
 class BlockquoteFormatter: ParagraphAttributeFormatter {
 
+    /// Attributes to be added by default
+    ///
     let placeholderAttributes: [String : Any]?
 
+
+    /// Designated Initializer
+    ///
     init(placeholderAttributes: [String : Any]? = nil) {
         self.placeholderAttributes = placeholderAttributes
     }
 
+
+    // MARK: - Overwriten Methods
+    
     func apply(to attributes: [String : Any]) -> [String: Any] {
         let newParagraphStyle = ParagraphStyle()
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -10,11 +10,11 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
     }
 
     func apply(to attributes: [String : Any]) -> [String: Any] {
-        var resultingAttributes = attributes
         let newParagraphStyle = ParagraphStyle()
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
+
         if newParagraphStyle.blockquote == nil {
             newParagraphStyle.headIndent += Metrics.defaultIndentation
             newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
@@ -22,27 +22,31 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.paragraphSpacing += Metrics.defaultIndentation
             newParagraphStyle.paragraphSpacingBefore += Metrics.defaultIndentation
         }
+
         newParagraphStyle.blockquote = Blockquote()
+
+        var resultingAttributes = attributes
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
         return resultingAttributes
     }
 
     func remove(from attributes:[String: Any]) -> [String: Any] {
-        var resultingAttributes = attributes
-        let newParagraphStyle = ParagraphStyle()
         guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
-            paragraphStyle.blockquote != nil else {
-            return resultingAttributes
+            paragraphStyle.blockquote != nil
+        else {
+            return attributes
         }
+
+        let newParagraphStyle = ParagraphStyle()
         newParagraphStyle.setParagraphStyle(paragraphStyle)
-        if newParagraphStyle.blockquote != nil {
-            newParagraphStyle.headIndent -= Metrics.defaultIndentation
-            newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
-            newParagraphStyle.tailIndent += Metrics.defaultIndentation
-            newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
-            newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
-        }
+        newParagraphStyle.headIndent -= Metrics.defaultIndentation
+        newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
+        newParagraphStyle.tailIndent += Metrics.defaultIndentation
+        newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
+        newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
         newParagraphStyle.blockquote = nil
+
+        var resultingAttributes = attributes
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
         return resultingAttributes
     }

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -63,9 +63,11 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
     }
 
     func present(in attributes: [String : Any]) -> Bool {
-        if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle {
-            return paragraphStyle.blockquote != nil
-        }
+        let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle
+        return style?.blockquote != nil
+    }
+
+    func needsEmptyLinePlaceholder() -> Bool {
         return false
     }
 }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -55,11 +55,6 @@ private extension LayoutManager {
                 let lineRect = rect.offsetBy(dx: origin.x, dy: origin.y)
                 self.drawBlockquote(in: lineRect, with: context)
             }
-
-            if range.endLocation == textStorage.rangeOfEntireString.endLocation {
-                let extraLineRect = extraLineFragmentRect.offsetBy(dx: origin.x, dy: origin.y)
-                drawBlockquote(in: extraLineRect, with: context)
-            }
         }
 
     }

--- a/AztecTests/StringRangeConversionTests.swift
+++ b/AztecTests/StringRangeConversionTests.swift
@@ -229,5 +229,21 @@ class StringRangeConversionTests: XCTestCase {
 
         XCTAssertEqual(nsRange, finalNSRange)
     }
-    
+
+    /// Tests that endOfStringNSRange returns a NSRange mapping to the edge of the string. (Also known as
+    /// "after the last character range).
+    ///
+    /// Input:
+    ///     - "Some random content here"
+    ///
+    /// Expected Output:
+    ///     -   NSRange(location: length of input, length: 0)
+    ///
+    func testEndOfStringNSRangeReturnsANSRangeThatStartsAtTheEndOfTheReceiver() {
+        let string = "Some random content here"
+        let endingRange = string.endOfStringNSRange()
+
+        XCTAssert(endingRange.length == 0)
+        XCTAssert(endingRange.location == string.characters.count)
+    }
 }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -750,18 +750,17 @@ class AztecVisualTextViewTests: XCTestCase {
 
         // Toggle List + Move the selection to the EOD
         textView.toggleOrderedList(range: .zero)
-
-        var expectedLength = textView.text.characters.count
-        textView.selectedRange = NSRange(location: expectedLength, length: 0)
+        textView.selectedRange = textView.text.endOfStringNSRange()
 
         // Insert Newline
+        var expectedLength = textView.text.characters.count
         textView.insertText(newline)
         expectedLength += newline.characters.count
 
         XCTAssertEqual(textView.text.characters.count, expectedLength)
     }
 
-    /// Verifies that New List Items do get their bulet, even when the ending `\n` character was deleted.
+    /// Verifies that New List Items do get their bullet, even when the ending `\n` character was deleted.
     ///
     /// Input:
     ///     - Ordered List
@@ -799,7 +798,7 @@ class AztecVisualTextViewTests: XCTestCase {
         XCTAssert(present)
     }
 
-    /// Verifies that after selecting a newline below a TextList does, TextView wil not render (nor carry over)
+    /// Verifies that after selecting a newline below a TextList, TextView wil not render (nor carry over)
     /// the Text List formatting attributes.
     ///
     /// Input:
@@ -957,4 +956,58 @@ class AztecVisualTextViewTests: XCTestCase {
         
         XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.newline))
     }
+
+    /// Verifies that after selecting a newline below a Blockquote, TextView wil not render (nor carry over)
+    /// the Blockquote formatting attributes.
+    ///
+    /// Input:
+    ///     - Blockquote
+    ///     - Selection of the `\n` at the EOD
+    ///
+    func testTypingAttributesLooseBlockquoteWhenSelectingAnEmptyNewlineBelowTextList() {
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleBlockquote(range: .zero)
+        textView.selectedRange = textView.text.endOfStringNSRange()
+
+        XCTAssertFalse(BlockquoteFormatter().present(in: textView.typingAttributes))
+    }
+
+    /// Verifies that New Line Characters get effectively inserted after a Blockquote.
+    ///
+    /// Input:
+    ///     - Blockquote
+    ///     - \n at the end of the document
+    ///
+    func testNewLinesAreInsertedAfterEmptyBlockquote() {
+        let newline = String(.newline)
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleBlockquote(range: .zero)
+        textView.selectedRange = textView.text.endOfStringNSRange()
+
+        var expectedLength = textView.text.characters.count
+        textView.insertText(newline)
+        expectedLength += newline.characters.count
+
+        XCTAssertEqual(textView.text.characters.count, expectedLength)
+    }
+
+    ///
+    func testBlockquoteGetsRemovedWhenTypingNewLineOnAnEmptyBullet() {
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleBlockquote(range: .zero)
+        textView.insertText(String(.newline))
+
+        let formatter = BlockquoteFormatter()
+        let attributedText = textView.attributedText!
+
+        for location in 0 ..< attributedText.length {
+            XCTAssertFalse(formatter.present(in: attributedText, at: location))
+        }
+
+        XCTAssertFalse(formatter.present(in: textView.typingAttributes))
+    }
 }
+

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -764,33 +764,32 @@ class AztecVisualTextViewTests: XCTestCase {
     ///
     /// Input:
     ///     - Ordered List
-    ///     - Text: "First Item"
+    ///     - Text: Constants.sampleText0
     ///     - Selection of the `\n` at the EOD, and backspace
-    ///     - Text: "\nSecond Item"
+    ///     - Text: "\n"
+    ///     - Text: Constants.sampleText1
     ///
     /// Ref. Scenario Mark IV on Issue https://github.com/wordpress-mobile/AztecEditor-iOS/pull/425
     ///
     func testNewLinesGetBulletStyleEvenAfterDeletingEndOfDocumentNewline() {
-        let firstItemText = "First Item"
-        let secondItemText = "Second Item"
         let newline = String(.newline)
 
         let textView = createTextView(withHTML: "")
 
         textView.toggleOrderedList(range: .zero)
 
-        textView.insertText(firstItemText)
+        textView.insertText(Constants.sampleText0)
 
         // Select the end of the document
         textView.selectedRange = textView.text.endOfStringNSRange()
 
         // Delete + Insert Newline
         textView.deleteBackward()
-        textView.insertText(newline + secondItemText)
+        textView.insertText(newline + Constants.sampleText1)
 
         // Verify it's still present
-        let secondLineIndex = firstItemText.characters.count + newline.characters.count
-        let secondLineRange = NSRange(location: secondLineIndex, length: secondItemText.characters.count)
+        let secondLineIndex = Constants.sampleText0.characters.count + newline.characters.count
+        let secondLineRange = NSRange(location: secondLineIndex, length: sampleText1.characters.count)
 
         let formatter = TextListFormatter(style: .ordered)
         let present = formatter.present(in: textView.storage, at: secondLineRange)
@@ -985,7 +984,7 @@ class AztecVisualTextViewTests: XCTestCase {
         XCTAssertEqual(textView.text.characters.count, expectedLength)
     }
 
-    /// Verifies that New List Items do get their bullet, even when the ending `\n` character was deleted.
+    /// Verifies that New Blockquote Lines do get their style, even when the ending `\n` character was deleted.
     ///
     /// Input:
     ///     - Blockquote
@@ -1079,9 +1078,12 @@ class AztecVisualTextViewTests: XCTestCase {
     /// Verifies that toggling a Blockquote, when editing the end of a non empty document, inserts a Newline.
     ///
     /// Input:
-    ///     - "Something Here"
+    ///     - Text: Constants.sampleText0
     ///     - Selection of the end of document
-    ///     - Ordered List
+    ///     - Blockquote
+    ///     - Backspace
+    ///     - Text: Constants.sampleText1
+    ///     - Text: newline
     ///
     /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/422
     ///

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -3,7 +3,12 @@ import XCTest
 import Gridicons
 
 class AztecVisualTextViewTests: XCTestCase {
-    
+
+    struct Constants {
+        static let sampleText0 = "Lorem ipsum sarasum naradum taradum insumun"
+        static let sampleText1 = " patronum sitanum elanum zoipancoiamum."
+    }
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -13,6 +18,7 @@ class AztecVisualTextViewTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
+
 
     // MARK: - TextView construction
 
@@ -138,6 +144,7 @@ class AztecVisualTextViewTests: XCTestCase {
         XCTAssert(identifiers.count == 0)
     }
 
+
     // MARK: - Toggle Attributes
 
     func testToggleBold() {
@@ -260,6 +267,7 @@ class AztecVisualTextViewTests: XCTestCase {
         // The test not crashing would be successful.
     }
 
+
     // MARK: - Test Attributes Exist
 
     func check(textView: TextView, range:NSRange, forIndentifier identifier: FormattingIdentifier) -> Bool {
@@ -381,6 +389,7 @@ class AztecVisualTextViewTests: XCTestCase {
         XCTAssert(!textView.formatIdentifiersAtIndex(1).contains(.blockquote))
     }
 
+
     // MARK: - Adding newlines
 
     /// Tests that entering a newline in an empty editor does not crash it.
@@ -404,6 +413,7 @@ class AztecVisualTextViewTests: XCTestCase {
 
         XCTAssertEqual(textView.text, "Testing bold newlines\n")
     }
+
 
     // MARK: - Deleting newlines
 
@@ -653,7 +663,6 @@ class AztecVisualTextViewTests: XCTestCase {
         XCTAssertEqual(textView.getHTML(), "<h1>Header</h1>")
     }
 
-
     /// Tests that there is no HTML Corruption when editing text, after toggling H1 and entering two lines of text.
     ///
     /// Input:
@@ -706,7 +715,6 @@ class AztecVisualTextViewTests: XCTestCase {
 
         XCTAssertTrue(present)
     }
-
 
     /// Verifies that the Text List does get nuked whenever the only `\n` present in the document is deleted.
     ///
@@ -908,4 +916,43 @@ class AztecVisualTextViewTests: XCTestCase {
     }
 
 
+    // MARK: - Blockquotes
+
+
+    /// Verifies that toggling a Blockquote, when editing an empty document, inserts a Newline.
+    ///
+    /// Input:
+    ///     - Blockquote
+    ///
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/414
+    ///
+    func testTogglingBlockquoteOnEmptyDocumentsInsertsNewline() {
+        let textView = createTextView(withHTML: "")
+        textView.toggleBlockquote(range: .zero)
+
+        XCTAssertEqual(textView.text, "\n")
+    }
+
+    /// Verifies that toggling a Blockquote, when editing the end of a non empty document, inserts a Newline.
+    ///
+    /// Input:
+    ///     - "Something Here"
+    ///     - Selection of the end of document
+    ///     - Ordered List
+    ///
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/414
+    ///
+    func testTogglingBlockquoteOnNonEmptyDocumentsWhenSelectedRangeIsAtTheEndOfDocumentWillInsertNewline() {
+        let textView = createTextView(withHTML: Constants.sampleText0)
+
+        textView.selectedRange = textView.text.endOfStringNSRange()
+        textView.toggleBlockquote(range: .zero)
+        XCTAssertEqual(textView.text, Constants.sampleText0 + "\n")
+
+        textView.selectedRange = textView.text.endOfStringNSRange()
+        textView.deleteBackward()
+        textView.insertText(Constants.sampleText1)
+        
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + "\n")
+    }
 }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -829,7 +829,7 @@ class AztecVisualTextViewTests: XCTestCase {
         let textView = createTextView(withHTML: "")
 
         textView.toggleOrderedList(range: .zero)
-        textView.insertText("\n")
+        textView.insertText(String(.newline))
 
         let formatter = TextListFormatter(style: .ordered)
         let attributedText = textView.attributedText!
@@ -852,7 +852,7 @@ class AztecVisualTextViewTests: XCTestCase {
         let textView = createTextView(withHTML: "")
 
         textView.toggleUnorderedList(range: .zero)
-        XCTAssertEqual(textView.text, "\n")
+        XCTAssertEqual(textView.text, String(.newline))
     }
 
     /// Verifies that toggling an Unordered List, when editing the end of a non empty document, inserts a Newline.
@@ -869,13 +869,14 @@ class AztecVisualTextViewTests: XCTestCase {
 
         textView.selectedRange = textView.text.endOfStringNSRange()
         textView.toggleUnorderedList(range: .zero)
-        XCTAssertEqual(textView.text, Constants.sampleText0 + "\n")
+        XCTAssertEqual(textView.text, Constants.sampleText0 + String(.newline))
 
         textView.selectedRange = textView.text.endOfStringNSRange()
         textView.deleteBackward()
         textView.insertText(Constants.sampleText1)
+        textView.insertText(String(.newline))
 
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + "\n")
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.newline))
     }
 
     /// Verifies that toggling an Ordered List, when editing an empty document, inserts a Newline.
@@ -889,7 +890,7 @@ class AztecVisualTextViewTests: XCTestCase {
         let textView = createTextView(withHTML: "")
 
         textView.toggleOrderedList(range: .zero)
-        XCTAssertEqual(textView.text, "\n")
+        XCTAssertEqual(textView.text, String(.newline))
     }
 
     /// Verifies that toggling an Ordered List, when editing the end of a non empty document, inserts a Newline.
@@ -906,18 +907,18 @@ class AztecVisualTextViewTests: XCTestCase {
 
         textView.selectedRange = textView.text.endOfStringNSRange()
         textView.toggleOrderedList(range: .zero)
-        XCTAssertEqual(textView.text, Constants.sampleText0 + "\n")
+        XCTAssertEqual(textView.text, Constants.sampleText0 + String(.newline))
 
         textView.selectedRange = textView.text.endOfStringNSRange()
         textView.deleteBackward()
         textView.insertText(Constants.sampleText1)
+        textView.insertText(String(.newline))
 
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + "\n")
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.newline))
     }
 
 
     // MARK: - Blockquotes
-
 
     /// Verifies that toggling a Blockquote, when editing an empty document, inserts a Newline.
     ///
@@ -930,7 +931,7 @@ class AztecVisualTextViewTests: XCTestCase {
         let textView = createTextView(withHTML: "")
         textView.toggleBlockquote(range: .zero)
 
-        XCTAssertEqual(textView.text, "\n")
+        XCTAssertEqual(textView.text, String(.newline))
     }
 
     /// Verifies that toggling a Blockquote, when editing the end of a non empty document, inserts a Newline.
@@ -947,12 +948,13 @@ class AztecVisualTextViewTests: XCTestCase {
 
         textView.selectedRange = textView.text.endOfStringNSRange()
         textView.toggleBlockquote(range: .zero)
-        XCTAssertEqual(textView.text, Constants.sampleText0 + "\n")
+        XCTAssertEqual(textView.text, Constants.sampleText0 + String(.newline))
 
         textView.selectedRange = textView.text.endOfStringNSRange()
         textView.deleteBackward()
         textView.insertText(Constants.sampleText1)
+        textView.insertText(String(.newline))
         
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + "\n")
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.newline))
     }
 }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -839,4 +839,80 @@ class AztecVisualTextViewTests: XCTestCase {
 
         XCTAssertFalse(TextListFormatter.listsOfAnyKindPresent(in: textView.typingAttributes))
     }
+
+    /// Verifies that toggling an Unordered List, when editing an empty document, inserts a Newline.
+    ///
+    /// Input:
+    ///     - Unordered List
+    ///
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/414
+    ///
+    func testTogglingUnorderedListsOnEmptyDocumentsInsertsNewline() {
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleUnorderedList(range: .zero)
+        XCTAssertEqual(textView.text, "\n")
+    }
+
+    /// Verifies that toggling an Unordered List, when editing the end of a non empty document, inserts a Newline.
+    ///
+    /// Input:
+    ///     - "Something Here"
+    ///     - Selection of the end of document
+    ///     - Unordered List
+    ///
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/414
+    ///
+    func testTogglingUnorderedListsOnNonEmptyDocumentsWhenSelectedRangeIsAtTheEndOfDocumentWillInsertNewline() {
+        let textView = createTextView(withHTML: Constants.sampleText0)
+
+        textView.selectedRange = textView.text.endOfStringNSRange()
+        textView.toggleUnorderedList(range: .zero)
+        XCTAssertEqual(textView.text, Constants.sampleText0 + "\n")
+
+        textView.selectedRange = textView.text.endOfStringNSRange()
+        textView.deleteBackward()
+        textView.insertText(Constants.sampleText1)
+
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + "\n")
+    }
+
+    /// Verifies that toggling an Ordered List, when editing an empty document, inserts a Newline.
+    ///
+    /// Input:
+    ///     - Ordered List
+    ///
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/414
+    ///
+    func testTogglingOrderedListsOnEmptyDocumentsInsertsNewline() {
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleOrderedList(range: .zero)
+        XCTAssertEqual(textView.text, "\n")
+    }
+
+    /// Verifies that toggling an Ordered List, when editing the end of a non empty document, inserts a Newline.
+    ///
+    /// Input:
+    ///     - "Something Here"
+    ///     - Selection of the end of document
+    ///     - Ordered List
+    ///
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/414
+    ///
+    func testTogglingOrderedListsOnNonEmptyDocumentsWhenSelectedRangeIsAtTheEndOfDocumentWillInsertNewline() {
+        let textView = createTextView(withHTML: Constants.sampleText0)
+
+        textView.selectedRange = textView.text.endOfStringNSRange()
+        textView.toggleOrderedList(range: .zero)
+        XCTAssertEqual(textView.text, Constants.sampleText0 + "\n")
+
+        textView.selectedRange = textView.text.endOfStringNSRange()
+        textView.deleteBackward()
+        textView.insertText(Constants.sampleText1)
+
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + "\n")
+    }
+
+
 }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -721,16 +721,12 @@ class AztecVisualTextViewTests: XCTestCase {
         let textView = createTextView(withHTML: "")
 
         textView.toggleOrderedList(range: .zero)
-
-        let length = textView.storage.length
-        textView.selectedRange = NSRange(location: length, length: 0)
-
+        textView.selectedRange = textView.text.endOfStringNSRange()
         textView.deleteBackward()
 
         XCTAssertFalse(TextListFormatter.listsOfAnyKindPresent(in: textView.typingAttributes))
         XCTAssert(textView.storage.length == 0)
     }
-
 
     /// Verifies that New Line Characters get effectively inserted after a Text List.
     ///
@@ -779,8 +775,7 @@ class AztecVisualTextViewTests: XCTestCase {
         textView.insertText(firstItemText)
 
         // Select the end of the document
-        let length = textView.text.characters.count
-        textView.selectedRange = NSRange(location: length, length: 0)
+        textView.selectedRange = textView.text.endOfStringNSRange()
 
         // Delete + Insert Newline
         textView.deleteBackward()
@@ -809,9 +804,7 @@ class AztecVisualTextViewTests: XCTestCase {
         let textView = createTextView(withHTML: "")
 
         textView.toggleOrderedList(range: .zero)
-
-        let length = textView.text.characters.count
-        textView.selectedRange = NSRange(location: length, length: 0)
+        textView.selectedRange = textView.text.endOfStringNSRange()
 
         XCTAssertFalse(TextListFormatter.listsOfAnyKindPresent(in: textView.typingAttributes))
     }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -789,7 +789,7 @@ class AztecVisualTextViewTests: XCTestCase {
 
         // Verify it's still present
         let secondLineIndex = Constants.sampleText0.characters.count + newline.characters.count
-        let secondLineRange = NSRange(location: secondLineIndex, length: sampleText1.characters.count)
+        let secondLineRange = NSRange(location: secondLineIndex, length: Constants.sampleText1.characters.count)
 
         let formatter = TextListFormatter(style: .ordered)
         let present = formatter.present(in: textView.storage, at: secondLineRange)

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -716,7 +716,7 @@ class AztecVisualTextViewTests: XCTestCase {
         XCTAssertTrue(present)
     }
 
-    /// Verifies that the Text List does get nuked whenever the only `\n` present in the document is deleted.
+    /// Verifies that the List gets nuked whenever the only `\n` present in the document is deleted.
     ///
     /// Input:
     ///     - Ordered List
@@ -919,58 +919,48 @@ class AztecVisualTextViewTests: XCTestCase {
 
     // MARK: - Blockquotes
 
-    /// Verifies that toggling a Blockquote, when editing an empty document, inserts a Newline.
+    /// Verifies that a Blockquote does not get removed whenever the user presses backspace
     ///
     /// Input:
     ///     - Blockquote
+    ///     - Text: Constants.sampleText0
+    ///     - Backspace
     ///
-    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/414
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/422
     ///
-    func testTogglingBlockquoteOnEmptyDocumentsInsertsNewline() {
+    func testBlockquoteDoesNotGetLostAfterPressingBackspace() {
         let textView = createTextView(withHTML: "")
-        textView.toggleBlockquote(range: .zero)
 
-        XCTAssertEqual(textView.text, String(.newline))
+        textView.toggleBlockquote(range: .zero)
+        textView.insertText(Constants.sampleText0)
+        textView.deleteBackward()
+
+        let formatter = BlockquoteFormatter()
+        let range = textView.storage.rangeOfEntireString
+
+        XCTAssertTrue(formatter.present(in: textView.storage, at: range))
     }
 
-    /// Verifies that toggling a Blockquote, when editing the end of a non empty document, inserts a Newline.
+    /// Verifies that the Blockquote gets nuked whenever the only `\n` present in the document is deleted.
     ///
     /// Input:
-    ///     - "Something Here"
-    ///     - Selection of the end of document
-    ///     - Ordered List
+    ///     - Blockquote
+    ///     - Selection of the EOD
+    ///     - Backspace
     ///
-    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/414
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/422
     ///
-    func testTogglingBlockquoteOnNonEmptyDocumentsWhenSelectedRangeIsAtTheEndOfDocumentWillInsertNewline() {
-        let textView = createTextView(withHTML: Constants.sampleText0)
+    func testEmptyBlockquoteGetsNukedWheneverTheOnlyNewlineCharacterInTheDocumentIsNuked() {
+        let textView = createTextView(withHTML: "")
 
-        textView.selectedRange = textView.text.endOfStringNSRange()
         textView.toggleBlockquote(range: .zero)
-        XCTAssertEqual(textView.text, Constants.sampleText0 + String(.newline))
-
         textView.selectedRange = textView.text.endOfStringNSRange()
         textView.deleteBackward()
-        textView.insertText(Constants.sampleText1)
-        textView.insertText(String(.newline))
-        
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.newline))
-    }
 
-    /// Verifies that after selecting a newline below a Blockquote, TextView wil not render (nor carry over)
-    /// the Blockquote formatting attributes.
-    ///
-    /// Input:
-    ///     - Blockquote
-    ///     - Selection of the `\n` at the EOD
-    ///
-    func testTypingAttributesLooseBlockquoteWhenSelectingAnEmptyNewlineBelowTextList() {
-        let textView = createTextView(withHTML: "")
+        let formatter = BlockquoteFormatter()
 
-        textView.toggleBlockquote(range: .zero)
-        textView.selectedRange = textView.text.endOfStringNSRange()
-
-        XCTAssertFalse(BlockquoteFormatter().present(in: textView.typingAttributes))
+        XCTAssertFalse(formatter.present(in: textView.typingAttributes))
+        XCTAssert(textView.storage.length == 0)
     }
 
     /// Verifies that New Line Characters get effectively inserted after a Blockquote.
@@ -978,6 +968,8 @@ class AztecVisualTextViewTests: XCTestCase {
     /// Input:
     ///     - Blockquote
     ///     - \n at the end of the document
+    ///
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/422
     ///
     func testNewLinesAreInsertedAfterEmptyBlockquote() {
         let newline = String(.newline)
@@ -993,8 +985,68 @@ class AztecVisualTextViewTests: XCTestCase {
         XCTAssertEqual(textView.text.characters.count, expectedLength)
     }
 
+    /// Verifies that New List Items do get their bullet, even when the ending `\n` character was deleted.
     ///
-    func testBlockquoteGetsRemovedWhenTypingNewLineOnAnEmptyBullet() {
+    /// Input:
+    ///     - Blockquote
+    ///     - Text: Constants.sampleText0
+    ///     - Selection of the `\n` at the EOD, and backspace
+    ///     - Text: "\n"
+    ///     - Text: Constants.sampleText1
+    ///
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/422
+    ///
+    func testNewLinesGetBlockquoteStyleEvenAfterDeletingEndOfDocumentNewline() {
+        let newline = String(.newline)
+
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleBlockquote(range: .zero)
+        textView.insertText(Constants.sampleText0)
+        textView.selectedRange = textView.text.endOfStringNSRange()
+
+        // Delete + Insert Newline
+        textView.deleteBackward()
+        textView.insertText(newline)
+        textView.insertText(Constants.sampleText1)
+
+        // Verify it's still present
+        let secondLineIndex = Constants.sampleText0.characters.count + newline.characters.count
+        let secondLineRange = NSRange(location: secondLineIndex, length: Constants.sampleText1.characters.count)
+
+        let formatter = BlockquoteFormatter()
+        let present = formatter.present(in: textView.storage, at: secondLineRange)
+        
+        XCTAssert(present)
+    }
+
+    /// Verifies that after selecting a newline below a Blockquote, TextView wil not render (nor carry over)
+    /// the Blockquote formatting attributes.
+    ///
+    /// Input:
+    ///     - Blockquote
+    ///     - Selection of the `\n` at the EOD
+    ///
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/422
+    ///
+    func testTypingAttributesLooseBlockquoteWhenSelectingAnEmptyNewlineBelowBlockquote() {
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleBlockquote(range: .zero)
+        textView.selectedRange = textView.text.endOfStringNSRange()
+
+        XCTAssertFalse(BlockquoteFormatter().present(in: textView.typingAttributes))
+    }
+
+    /// Verifies that Blockquotes get removed whenever the user types `\n` in an empty line.
+    ///
+    /// Input:
+    ///     - Ordered List
+    ///     - `\n` on the first line
+    ///
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/422
+    ///
+    func testBlockquoteGetsRemovedWhenTypingNewLineOnAnEmptyBlockquoteLine() {
         let textView = createTextView(withHTML: "")
 
         textView.toggleBlockquote(range: .zero)
@@ -1008,6 +1060,44 @@ class AztecVisualTextViewTests: XCTestCase {
         }
 
         XCTAssertFalse(formatter.present(in: textView.typingAttributes))
+    }
+
+    /// Verifies that toggling a Blockquote, when editing an empty document, inserts a Newline.
+    ///
+    /// Input:
+    ///     - Blockquote
+    ///
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/422
+    ///
+    func testTogglingBlockquoteOnEmptyDocumentsInsertsNewline() {
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleBlockquote(range: .zero)
+        XCTAssertEqual(textView.text, String(.newline))
+    }
+
+    /// Verifies that toggling a Blockquote, when editing the end of a non empty document, inserts a Newline.
+    ///
+    /// Input:
+    ///     - "Something Here"
+    ///     - Selection of the end of document
+    ///     - Ordered List
+    ///
+    /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/422
+    ///
+    func testTogglingBlockquoteOnNonEmptyDocumentsWhenSelectedRangeIsAtTheEndOfDocumentWillInsertNewline() {
+        let textView = createTextView(withHTML: Constants.sampleText0)
+
+        textView.selectedRange = textView.text.endOfStringNSRange()
+        textView.toggleBlockquote(range: .zero)
+        XCTAssertEqual(textView.text, Constants.sampleText0 + String(.newline))
+
+        textView.selectedRange = textView.text.endOfStringNSRange()
+        textView.deleteBackward()
+        textView.insertText(Constants.sampleText1)
+        textView.insertText(String(.newline))
+        
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.newline))
     }
 }
 


### PR DESCRIPTION
### Details:
In this PR we're nuking the Zero Width Character from the Blockquote Formatter's innerworking.

Thanks in advance sir!
Needs Review: @diegoreymendez 

Closes #422

--

### Scenario A: Missing Blockquote after Backspace
1. Launch the empty editor
2. Toggle the Blockquote format
3. Enter any random text
4. Hit backspace

Verify that the blockquote style is still present.

### Scenario B: Nuking Blockquote after Backspace
1. Launch the empty editor
2. Toggle the Blockquote format
3. Enter any random text
4. Select the end of the document
5. Hit backspace

Verify that the Blockquote gets effectively removed.

### Scenario C: Newline after blockquote
1. Launch the empty editor
2. Toggle the Blockquote format

Verify that a newline is inserted below the blockquote.

### Scenario D: Nuking bottom `\n` and adding newlines
1. Launch the empty editor
2. Toggle the Blockquote format
3. Enter any random text
4. Select the end of the document
5. Hit backspace
6. Hit `\n` and enter any random text

Verify that the new Blockquote line gets it's proper style, even when the bottom `\n` was initially nuked.

### Scenario E: Typing Attributes below Blockquote
1. Launch the empty editor
2. Toggle the Blockquote format
3. Press the arrow down

Verify that the blockquote gets removed from the typing attributes (and that the text indentation looks normal).

### Scenario F: Autoremoval after hitting return on newline
1. Launch the empty editor
2. Toggle the Blockquote format
3. Hit return

Verify that the blockquote gets removed.

