### PR TITLE
PreFormatter: Nukes Zero Width Spacing character

### DIFF
--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -64,8 +64,6 @@ protocol AttributeFormatter {
     func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange
 
     func worksInEmptyRange() -> Bool
-
-    func needsEmptyLinePlaceholder() -> Bool
 }
 
 
@@ -120,15 +118,9 @@ extension AttributeFormatter {
     ///
     @discardableResult
     func applyAttributes(to text: NSMutableAttributedString, at range: NSRange) -> NSRange {
-        var rangeToApply = applicationRange(for: range, in: text)
+        let rangeToApply = applicationRange(for: range, in: text)
 
-        if needsEmptyLinePlaceholder() && worksInEmptyRange() && ( rangeToApply.length == 0 || text.length == 0)   {
-            let placeholder = placeholderForEmptyLine(using: placeholderAttributes)
-            text.insert(placeholder, at: rangeToApply.location)
-            rangeToApply = NSMakeRange(rangeToApply.location, placeholder.length)
-        }
-
-        text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, stop) in
+        text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, _) in
             let currentAttributes = text.attributes(at: range.location, effectiveRange: nil)
             let attributes = apply(to: currentAttributes)
             text.addAttributes(attributes, range: range)
@@ -180,12 +172,6 @@ extension AttributeFormatter {
 //
 private extension AttributeFormatter {
 
-    /// The string to be used when adding attributes to an empty line.
-    ///
-    func placeholderForEmptyLine(using attributes: [String: Any]?) -> NSAttributedString {
-        return VisualOnlyElementFactory().zeroWidthSpace(inheritingAttributes: attributes)
-    }
-
     /// Helper that indicates whether if we should format the specified range, or not. 
     /// -   Note: For convenience reasons, whenever the Text is empty, this helper will return *true*.
     ///
@@ -215,10 +201,6 @@ extension CharacterAttributeFormatter {
     func worksInEmptyRange() -> Bool {
         return false
     }
-
-    func needsEmptyLinePlaceholder() -> Bool {
-        return false
-    }
 }
 
 
@@ -234,10 +216,6 @@ extension ParagraphAttributeFormatter {
     }
 
     func worksInEmptyRange() -> Bool {
-        return true
-    }
-
-    func needsEmptyLinePlaceholder() -> Bool {
         return true
     }
 }

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -66,9 +66,5 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
         let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle
         return style?.blockquote != nil
     }
-
-    func needsEmptyLinePlaceholder() -> Bool {
-        return false
-    }
 }
 

--- a/Aztec/Classes/Formatters/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/HeaderFormatter.swift
@@ -97,9 +97,5 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         }
         return false
     }
-
-    func needsEmptyLinePlaceholder() -> Bool {
-        return false
-    }
 }
 

--- a/Aztec/Classes/Formatters/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/HeaderFormatter.swift
@@ -1,8 +1,13 @@
 import Foundation
 import UIKit
 
+
+// MARK: - Header Formatter
+//
 open class HeaderFormatter: ParagraphAttributeFormatter {
 
+    /// Available Heading Types
+    ///
     public enum HeaderType: Int {
         case none = 0
         case h1 = 1
@@ -37,14 +42,24 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         }
     }
 
+    /// Heading Level of this formatter
+    ///
     let headerLevel: HeaderType
 
+    /// Attributes to be added by default
+    ///
     let placeholderAttributes: [String : Any]?
 
+
+    /// Designated Initializer
+    ///
     init(headerLevel: HeaderType = .h1, placeholderAttributes: [String : Any]? = nil) {
         self.headerLevel = headerLevel
         self.placeholderAttributes = placeholderAttributes
     }
+
+
+    // MARK: - Overwriten Methods
 
     func apply(to attributes: [String : Any]) -> [String: Any] {
         var resultingAttributes = attributes

--- a/Aztec/Classes/Formatters/PreFormatter.swift
+++ b/Aztec/Classes/Formatters/PreFormatter.swift
@@ -1,15 +1,29 @@
 import Foundation
 import UIKit
 
+
+// MARK: - Pre Formatter
+//
 open class PreFormatter: ParagraphAttributeFormatter {
 
+    /// Font to be used
+    ///
     let monospaceFont: UIFont
+
+    /// Attributes to be added by default
+    ///
     let placeholderAttributes: [String : Any]?
 
+
+    /// Designated Initializer
+    ///
     init(monospaceFont: UIFont = UIFont(descriptor:UIFontDescriptor(name: "Courier", size: 12), size:12), placeholderAttributes: [String : Any]? = nil) {
         self.monospaceFont = monospaceFont
         self.placeholderAttributes = placeholderAttributes
     }
+
+
+    // MARK: - Overwriten Methods
 
     func apply(to attributes: [String : Any]) -> [String: Any] {
         var resultingAttributes = attributes
@@ -35,10 +49,7 @@ open class PreFormatter: ParagraphAttributeFormatter {
     }
 
     func present(in attributes: [String : Any]) -> Bool {
-        if let font = attributes[NSFontAttributeName] as? UIFont {
-            return font == monospaceFont
-        }
-        return false
+        let font = attributes[NSFontAttributeName] as? UIFont
+        return font == monospaceFont
     }
 }
-

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -71,10 +71,6 @@ class TextListFormatter: ParagraphAttributeFormatter {
         return list.style == listStyle
     }
 
-    func needsEmptyLinePlaceholder() -> Bool {
-        return false
-    }
-
     static func listsOfAnyKindPresent(in attributes: [String: Any]) -> Bool {
         let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle
         return style?.textList != nil

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -766,7 +766,7 @@ open class TextView: UITextView {
             TextListFormatter(style: .ordered),
             TextListFormatter(style: .unordered),
             BlockquoteFormatter(),
-            PreFormatter()
+            PreFormatter(placeholderAttributes: self.defaultAttributes)
         ]
 
         let atEdgeOfDocument = range.location >= storage.length
@@ -816,7 +816,7 @@ open class TextView: UITextView {
 
         let formatters: [AttributeFormatter] = [
             BlockquoteFormatter(),
-            PreFormatter(),
+            PreFormatter(placeholderAttributes: self.defaultAttributes),
             TextListFormatter(style: .ordered),
             TextListFormatter(style: .unordered)
         ]
@@ -860,7 +860,7 @@ open class TextView: UITextView {
 
         let formatters: [AttributeFormatter] = [
             BlockquoteFormatter(),
-            PreFormatter(),
+            PreFormatter(placeholderAttributes: self.defaultAttributes),
             TextListFormatter(style: .ordered),
             TextListFormatter(style: .unordered)
         ]

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -576,6 +576,23 @@ open class TextView: UITextView {
         toggle(formatter: formatter, atRange: range)
     }
 
+    /// Adds or removes a Pre style from the specified range.
+    /// Pre are applied to an entire paragrah regardless of the range.
+    /// If the range spans multiple paragraphs, the style is applied to all
+    /// affected paragraphs.
+    ///
+    /// - Parameters:
+    ///     - range: The NSRange to edit.
+    ///
+    open func togglePre(range: NSRange) {
+        ensureInsertionOfNewlineWhenEditingEdgeOfTheDocument()
+
+        let formatter = PreFormatter(placeholderAttributes: typingAttributes)
+        toggle(formatter: formatter, atRange: range)
+
+        forceRedrawCursorAfterDelay()
+    }
+
     /// Adds or removes a blockquote style from the specified range.
     /// Blockquotes are applied to an entire paragrah regardless of the range.
     /// If the range spans multiple paragraphs, the style is applied to all


### PR DESCRIPTION
### Details:
This is the (last) PR in the series "Let's stop using the Zero Width Spacing" character. We're replicating the exact same mechanisms (+ battle of unit tests) we've already got for Lists and Blockquotes.

Needs Review: @diegoreymendez 
Thaaanks!!!

Closes #420
Closes #414

### Testing:
Verifying this PR is gonna be a bit tricky, since we don't really have (yet) a way to toggle `Pre` blocks. Parsing from HTML is supported, but visual edition hasn't been shipped yet.

In this PR i've added a `togglePre` method, analog to `toggleList` and `toggleBlockquote`. In order to verify this PR, please:

- Make sure the unit tests pass
- Whenever the test scenario indicates "Toggle Pre", please:
 A. Switch to HTML
 B. Insert `<pre>Payload</pre>`
 C. Switch back!

Apologies about this inconvenience. We don't really have a `Pre` gridicon we could wire, right now, for this PR. Formal support coming in later, in another PR!

--

### Scenario A: Missing Pre after Backspace
1. Launch the empty editor
2. Toggle the Pre format
3. Enter any random text
4. Hit backspace

Verify that the pre style is still present.

### Scenario B: Nuking Pre after Backspace
1. Launch the empty editor
2. Insert `Pre` Tag
3. Enter any random text
4. Select the end of the document
5. Hit backspace

Verify that the Pre gets effectively removed.

### Scenario C: Newline after Pre
1. Launch the empty editor
2. Insert `Pre` Tag

Verify that a newline is inserted below the pre.

### Scenario D: Nuking bottom `\n` and adding newlines
1. Launch the empty editor
2. Toggle the Pre format
3. Enter any random text
4. Select the end of the document
5. Hit backspace
6. Hit `\n` and enter any random text

Verify that the new Pre line gets it's proper style, even when the bottom `\n` was initially nuked.

### Scenario E: Typing Attributes below Pre
1. Launch the empty editor
2. Insert `Pre` Tag
3. Press the arrow down

Verify that the Pre gets removed from the typing attributes (and that the text indentation looks normal).

### Scenario F: Autoremoval after hitting return on newline
1. Launch the empty editor
2. Insert `Pre` Tag
3. Hit return

Verify that the blockquote gets removed.


