### PR TITLE
Refactor TextAttachment to be MediaAttachment.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		599F254E1D8BC9A1002871D6 /* FormatBarDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F252B1D8BC9A1002871D6 /* FormatBarDelegate.swift */; };
 		599F254F1D8BC9A1002871D6 /* FormatBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F252C1D8BC9A1002871D6 /* FormatBarItem.swift */; };
 		599F25501D8BC9A1002871D6 /* FormattingIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F252D1D8BC9A1002871D6 /* FormattingIdentifier.swift */; };
-		599F25521D8BC9A1002871D6 /* TextAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25301D8BC9A1002871D6 /* TextAttachment.swift */; };
+		599F25521D8BC9A1002871D6 /* MediaAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25301D8BC9A1002871D6 /* MediaAttachment.swift */; };
 		599F25531D8BC9A1002871D6 /* TextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25311D8BC9A1002871D6 /* TextStorage.swift */; };
 		599F25541D8BC9A1002871D6 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25321D8BC9A1002871D6 /* TextView.swift */; };
 		599F255C1D8BCDB4002871D6 /* Gridicons.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 599F255B1D8BCDB4002871D6 /* Gridicons.framework */; };
@@ -102,6 +102,7 @@
 		F1FFB2A11E6058930015ACB8 /* DOMStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FFB2A01E6058930015ACB8 /* DOMStringTests.swift */; };
 		FF13CD4D1E5C8067000FF10E /* HeaderFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF13CD4C1E5C8067000FF10E /* HeaderFormatter.swift */; };
 		FF152D8E1E68552A00FF596C /* StringRangeConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF152D8D1E68552A00FF596C /* StringRangeConversionTests.swift */; };
+		FF4E26601EA8DF1E005E8E42 /* ImageAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4E265F1EA8DF1E005E8E42 /* ImageAttachment.swift */; };
 		FF7A1C511E5651EA00C4C7C8 /* LineAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7A1C501E5651EA00C4C7C8 /* LineAttachment.swift */; };
 		FF7C89A81E3A2B7C000472A8 /* Blockquote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7C89A71E3A2B7C000472A8 /* Blockquote.swift */; };
 		FF7C89AC1E3A47F1000472A8 /* StandardAttributeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7C89AB1E3A47F1000472A8 /* StandardAttributeFormatter.swift */; };
@@ -167,7 +168,7 @@
 		599F252B1D8BC9A1002871D6 /* FormatBarDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormatBarDelegate.swift; sourceTree = "<group>"; };
 		599F252C1D8BC9A1002871D6 /* FormatBarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormatBarItem.swift; sourceTree = "<group>"; };
 		599F252D1D8BC9A1002871D6 /* FormattingIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattingIdentifier.swift; sourceTree = "<group>"; };
-		599F25301D8BC9A1002871D6 /* TextAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextAttachment.swift; sourceTree = "<group>"; };
+		599F25301D8BC9A1002871D6 /* MediaAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaAttachment.swift; sourceTree = "<group>"; };
 		599F25311D8BC9A1002871D6 /* TextStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextStorage.swift; sourceTree = "<group>"; };
 		599F25321D8BC9A1002871D6 /* TextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
 		599F25571D8BCA01002871D6 /* libxml2-umbrella.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "libxml2-umbrella.h"; sourceTree = "<group>"; };
@@ -241,6 +242,7 @@
 		F1FFB2A01E6058930015ACB8 /* DOMStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DOMStringTests.swift; sourceTree = "<group>"; };
 		FF13CD4C1E5C8067000FF10E /* HeaderFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderFormatter.swift; sourceTree = "<group>"; };
 		FF152D8D1E68552A00FF596C /* StringRangeConversionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringRangeConversionTests.swift; sourceTree = "<group>"; };
+		FF4E265F1EA8DF1E005E8E42 /* ImageAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageAttachment.swift; sourceTree = "<group>"; };
 		FF5B98E21DC29D0C00571CA4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		FF5B98E41DC355B400571CA4 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
 		FF7A1C481E51EFB600C4C7C8 /* WordPress-Aztec-iOS.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "WordPress-Aztec-iOS.podspec"; sourceTree = "<group>"; };
@@ -471,7 +473,8 @@
 				B572AC271E817CFE008948C2 /* CommentAttachment.swift */,
 				B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */,
 				FF7A1C501E5651EA00C4C7C8 /* LineAttachment.swift */,
-				599F25301D8BC9A1002871D6 /* TextAttachment.swift */,
+				599F25301D8BC9A1002871D6 /* MediaAttachment.swift */,
+				FF4E265F1EA8DF1E005E8E42 /* ImageAttachment.swift */,
 				FFFEC7DA1EA7698900F4210F /* VideoAttachment.swift */,
 				B5BC4FF51DA2D76600614582 /* TextList.swift */,
 				599F25311D8BC9A1002871D6 /* TextStorage.swift */,
@@ -784,6 +787,7 @@
 				599F253B1D8BC9A1002871D6 /* InNodesConverter.swift in Sources */,
 				B5B86D3C1DA41A550083DB3F /* TextListFormatter.swift in Sources */,
 				FF8F85841E84162900C12BB4 /* PreFormatter.swift in Sources */,
+				FF4E26601EA8DF1E005E8E42 /* ImageAttachment.swift in Sources */,
 				599F254F1D8BC9A1002871D6 /* FormatBarItem.swift in Sources */,
 				B577DC651E7B18E90012A1F8 /* NodeDescriptor.swift in Sources */,
 				599F254E1D8BC9A1002871D6 /* FormatBarDelegate.swift in Sources */,
@@ -795,7 +799,7 @@
 				F1288BB01DD0B1EF00E67ABC /* HTMLToAttributedString.swift in Sources */,
 				E11B77641DBA6ADC0024E455 /* AttributeFormatter.swift in Sources */,
 				599F25351D8BC9A1002871D6 /* CLinkedListToArrayConverter.swift in Sources */,
-				599F25521D8BC9A1002871D6 /* TextAttachment.swift in Sources */,
+				599F25521D8BC9A1002871D6 /* MediaAttachment.swift in Sources */,
 				F1FA0E831E6EF514009D98EE /* ElementNode.swift in Sources */,
 				FFD0FEB71DAE59A700430586 /* NSLayoutManager+Attachments.swift in Sources */,
 				599F25541D8BC9A1002871D6 /* TextView.swift in Sources */,

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -227,15 +227,15 @@ class HMTLNodeToNSAttributedString: SafeConverter {
                 url = nil
             }
 
-            let attachment = TextAttachment(identifier: UUID().uuidString, url: url)
+            let attachment = ImageAttachment(identifier: UUID().uuidString, url: url)
 
             if let elementClass = node.valueForStringAttribute(named: "class") {
                 let classAttributes = elementClass.components(separatedBy: " ")
                 for classAttribute in classAttributes {
-                    if let alignment = TextAttachment.Alignment.fromHTML(string: classAttribute) {
+                    if let alignment = ImageAttachment.Alignment.fromHTML(string: classAttribute) {
                         attachment.alignment = alignment
                     }
-                    if let size = TextAttachment.Size.fromHTML(string: classAttribute) {
+                    if let size = ImageAttachment.Size.fromHTML(string: classAttribute) {
                         attachment.size = size
                     }
                 }

--- a/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
@@ -57,7 +57,7 @@ class LinkFormatter: StandardAttributeFormatter {
 
 class ImageFormatter: StandardAttributeFormatter {
     init() {
-        super.init(attributeKey: NSAttachmentAttributeName, attributeValue: TextAttachment(identifier: NSUUID().uuidString))
+        super.init(attributeKey: NSAttachmentAttributeName, attributeValue: ImageAttachment(identifier: NSUUID().uuidString))
     }
 }
 

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -592,7 +592,7 @@ extension Libxml2 {
         
         // MARK: - Candidates for removal
         
-        func updateImage(spanning ranges: [NSRange], url: URL, size: TextAttachment.Size, alignment: TextAttachment.Alignment) {
+        func updateImage(spanning ranges: [NSRange], url: URL, size: ImageAttachment.Size, alignment: ImageAttachment.Alignment) {
             performAsyncUndoable { [weak self] in
                 self?.updateImageSynchronously(spanning: ranges, url: url, size: size, alignment: alignment)
             }
@@ -600,7 +600,7 @@ extension Libxml2 {
         
         // MARK: - Candidates for removal: Synchronously
         
-        private func updateImageSynchronously(spanning ranges: [NSRange], url: URL, size: TextAttachment.Size, alignment: TextAttachment.Alignment) {
+        private func updateImageSynchronously(spanning ranges: [NSRange], url: URL, size: ImageAttachment.Size, alignment: ImageAttachment.Alignment) {
             
             for range in ranges {
                 let element = self.rootNode.lowestElementNodeWrapping(range)
@@ -610,7 +610,7 @@ extension Libxml2 {
                     if let currentAttributes = element.valueForStringAttribute(named: "class") {
                         components = currentAttributes.components(separatedBy: CharacterSet.whitespaces)
                         components = components.filter({ (value) -> Bool in
-                            return TextAttachment.Alignment.fromHTML(string: value.lowercased()) == nil && TextAttachment.Size.fromHTML(string: value.lowercased()) == nil
+                            return ImageAttachment.Alignment.fromHTML(string: value.lowercased()) == nil && ImageAttachment.Size.fromHTML(string: value.lowercased()) == nil
                         })
 
                     }

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -1,0 +1,194 @@
+import Foundation
+import UIKit
+
+/// Custom text attachment.
+///
+open class ImageAttachment: MediaAttachment
+{
+    /// Attachment Alignment
+    ///
+    open var alignment: Alignment = .center {
+        willSet {
+            if newValue != alignment {
+                glyphImage = nil
+            }
+        }
+    }
+
+    /// Attachment Size
+    ///
+    open var size: Size = .full {
+        willSet {
+            if newValue != size {
+                glyphImage = nil
+            }
+        }
+    }
+
+    /// Creates a new attachment
+    ///
+    /// - Parameters:
+    ///   - identifier: An unique identifier for the attachment
+    ///   - url: the url that represents the image
+    ///
+    required public init(identifier: String, url: URL? = nil) {
+        super.init(identifier: identifier, url: url)
+    }
+
+    /// Required Initializer
+    ///
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+
+        if aDecoder.containsValue(forKey: EncodeKeys.alignment.rawValue) {
+            let alignmentRaw = aDecoder.decodeInteger(forKey: EncodeKeys.alignment.rawValue)
+            if let alignment = Alignment(rawValue:alignmentRaw) {
+                self.alignment = alignment
+            }
+        }
+        if aDecoder.containsValue(forKey: EncodeKeys.size.rawValue) {
+            let sizeRaw = aDecoder.decodeInteger(forKey: EncodeKeys.size.rawValue)
+            if let size = Size(rawValue:sizeRaw) {
+                self.size = size
+            }
+        }
+    }
+
+    override open func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+        aCoder.encode(alignment.rawValue, forKey: EncodeKeys.alignment.rawValue)
+        aCoder.encode(size.rawValue, forKey: EncodeKeys.size.rawValue)
+    }
+
+    fileprivate enum EncodeKeys: String {
+        case alignment
+        case size
+    }
+    // MARK: - Origin calculation
+
+    override func xPosition(forContainerWidth containerWidth: CGFloat) -> CGFloat {
+        let imageWidth = onScreenWidth(containerWidth)
+
+        switch (alignment) {
+        case .center:
+            return CGFloat(floor((containerWidth - imageWidth) / 2))
+        case .right:
+            return CGFloat(floor(containerWidth - imageWidth))
+        default:
+            return 0
+        }
+    }
+
+    override func onScreenHeight(_ containerWidth: CGFloat) -> CGFloat {
+        if let image = image {
+            let targetWidth = onScreenWidth(containerWidth)
+            let scale = targetWidth / image.size.width
+
+            return floor(image.size.height * scale) + (imageMargin * 2)
+        } else {
+            return 0
+        }
+    }
+
+    override func onScreenWidth(_ containerWidth: CGFloat) -> CGFloat {
+        if let image = image {
+            switch (size) {	
+            case .full:
+                return floor(min(image.size.width, containerWidth))
+            default:
+                return floor(min(min(image.size.width,size.width), containerWidth))
+            }
+        } else {
+            return 0
+        }
+    }
+}
+
+
+
+/// Nested Types
+///
+extension ImageAttachment
+{
+    /// Alignment
+    ///
+    public enum Alignment: Int {
+        case none
+        case left
+        case center
+        case right
+
+        func htmlString() -> String {
+            switch self {
+                case .center:
+                    return "aligncenter"
+                case .left:
+                    return "alignleft"
+                case .right:
+                    return "alignright"
+                case .none:
+                    return "alignnone"
+            }
+        }
+
+        static let mappedValues:[String:Alignment] = [
+            Alignment.none.htmlString():.none,
+            Alignment.left.htmlString():.left,
+            Alignment.center.htmlString():.center,
+            Alignment.right.htmlString():.right
+        ]
+
+        static func fromHTML(string value:String) -> Alignment? {
+            return mappedValues[value]
+        }
+    }
+
+    /// Size Onscreen!
+    ///
+    public enum Size: Int {
+        case thumbnail
+        case medium
+        case large
+        case full
+
+        func htmlString() -> String {
+            switch self {
+            case .thumbnail:
+                return "size-thumbnail"
+            case .medium:
+                return "size-medium"
+            case .large:
+                return "size-large"
+            case .full:
+                return "size-full"
+            }
+        }
+
+        static let mappedValues:[String:Size] = [
+            Size.thumbnail.htmlString():.thumbnail,
+            Size.medium.htmlString():.medium,
+            Size.large.htmlString():.large,
+            Size.full.htmlString():.full
+        ]
+
+        static func fromHTML(string value:String) -> Size? {
+            return mappedValues[value]
+        }
+
+        var width: CGFloat {
+            switch self {
+            case .thumbnail: return Settings.thumbnail
+            case .medium: return Settings.medium
+            case .large: return Settings.large
+            case .full: return Settings.maximum
+            }
+        }
+
+        fileprivate struct Settings {
+            static let thumbnail = CGFloat(135)
+            static let medium = CGFloat(270)
+            static let large = CGFloat(360)
+            static let maximum = CGFloat.greatestFiniteMagnitude
+        }
+    }
+}

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1031,7 +1031,7 @@ open class TextView: UITextView {
     ///
     /// - Returns: the attachment object that can be used for further calls
     ///
-    open func insertImage(sourceURL url: URL, atPosition position: Int, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> TextAttachment {
+    open func insertImage(sourceURL url: URL, atPosition position: Int, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> ImageAttachment {
         let attachment = storage.insertImage(sourceURL: url, atPosition: position, placeHolderImage: placeHolderImage ?? defaultMissingImage, identifier: identifier)
         let length = NSAttributedString.lengthOfTextAttachment
         textStorage.addAttributes(typingAttributes, range: NSMakeRange(position, length))
@@ -1041,11 +1041,11 @@ open class TextView: UITextView {
     }
 
 
-    /// Returns the TextAttachment instance with the matching identifier
+    /// Returns the MediaAttachment instance with the matching identifier
     ///
     /// - Parameter id: Identifier of the text attachment to be retrieved
     ///
-    open func attachment(withId id: String) -> TextAttachment? {
+    open func attachment(withId id: String) -> MediaAttachment? {
         return storage.attachment(withId: id)
     }
 
@@ -1061,7 +1061,7 @@ open class TextView: UITextView {
     /// Removes all of the text attachments contained within the storage
     ///
     open func removeTextAttachments() {
-        storage.removeTextAttachments()
+        storage.removeMediaAttachments()
         delegate?.textViewDidChange?(self)
     }
 
@@ -1119,7 +1119,7 @@ open class TextView: UITextView {
     open func isPointInsideAttachmentMargin(point: CGPoint) -> Bool {
         let index = layoutManager.characterIndex(for: point, in: textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
 
-        if let attachment = attachmentAtPoint(point) as? TextAttachment {
+        if let attachment = attachmentAtPoint(point) as? MediaAttachment {
             let glyphRange = layoutManager.glyphRange(forCharacterRange: NSRange(location: index, length: 1), actualCharacterRange: nil)
             let rect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
             if point.y >= rect.origin.y && point.y <= (rect.origin.y + (2*attachment.imageMargin)) {
@@ -1213,9 +1213,9 @@ open class TextView: UITextView {
     /// - parameter size:       the size value
     /// - parameter url:        the attachment url
     ///
-    open func update(attachment: TextAttachment,
-                     alignment: TextAttachment.Alignment,
-                     size: TextAttachment.Size,
+    open func update(attachment: ImageAttachment,
+                     alignment: ImageAttachment.Alignment,
+                     size: ImageAttachment.Size,
                      url: URL) {
         storage.update(attachment: attachment, alignment: alignment, size: size, url: url)
         layoutManager.invalidateLayoutForAttachment(attachment)
@@ -1227,7 +1227,7 @@ open class TextView: UITextView {
     /// - Parameters:
     ///   - attachment: the attachment to update
     ///
-    open func refreshLayoutFor(attachment: TextAttachment) {
+    open func refreshLayoutFor(attachment: MediaAttachment) {
         layoutManager.invalidateLayoutForAttachment(attachment)
     }
 
@@ -1319,7 +1319,7 @@ extension TextView: TextStorageAttachmentsDelegate {
 @objc class AttachmentGestureRecognizerDelegate: NSObject, UIGestureRecognizerDelegate
 {
     let textView: TextView
-    fileprivate var currentSelectedAttachment: TextAttachment?
+    fileprivate var currentSelectedAttachment: ImageAttachment?
 
     public init(textView: TextView) {
         self.textView = textView
@@ -1366,7 +1366,7 @@ extension TextView: TextStorageAttachmentsDelegate {
             return
         }
 
-        currentSelectedAttachment = attachment as? TextAttachment
+        currentSelectedAttachment = attachment as? ImageAttachment
         textView.mediaDelegate?.textView(textView, selectedAttachment: attachment, atPosition: locationInTextView)
     }
 }

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -12,122 +12,32 @@ protocol VideoAttachmentDelegate: class {
 
 /// Custom text attachment.
 ///
-open class VideoAttachment: NSTextAttachment
+open class VideoAttachment: MediaAttachment
 {
-    public struct Appearance {
-        public var overlayColor = UIColor(white: 0.6, alpha: 0.6)
-
-        /// The height of the progress bar for progress indicators
-        public var progressHeight = CGFloat(2.0)
-
-        /// The color to use when drawing the backkground of the progress indicators
-        ///
-        public var progressBackgroundColor = UIColor.cyan
-
-        /// The color to use when drawing progress indicators
-        ///
-        public var progressColor = UIColor.blue
-
-        /// The margin apply to the images being displayed. This is to avoid that two images in a row get glued together.
-        ///
-        public var margin = CGFloat(10.0)
-    }
-
-
-    /// This property allows the global customization of appearance properties of the TextAttachment
-    ///
-    open static var appearance: Appearance = Appearance()
-
-    /// Identifier used to match this attachment with a custom UIView subclass
-    ///
-    fileprivate(set) open var identifier: String
-    
     /// Attachment video URL
     ///
     open var srcURL: URL?
 
-
     /// Video poster image to show, while the video is not played.
     ///
-    open var posterURL: URL?
+    open var posterURL: URL? {
+        get {
+            return self.srcURL
+        }
 
-    fileprivate var lastRequestedURL: URL?
-
-    /// A progress value that indicates the progress of an attachment. It can be set between values 0 and 1
-    ///
-    open var progress: Double? = nil {
-        willSet {
-            assert(newValue == nil || (newValue! >= 0 && newValue! <= 1), "Progress must be value between 0 and 1 or nil")
-            if newValue != progress {
-                glyphImage = nil
-            }
+        set {
+            self.srcURL = newValue
         }
     }
-
-    /// The color to use when drawing the background overlay for messages, icons, and progress
-    ///
-    open var overlayColor: UIColor = TextAttachment.appearance.overlayColor
-
-    /// The height of the progress bar for progress indicators
-    open var progressHeight: CGFloat = TextAttachment.appearance.progressHeight
-
-    /// The color to use when drawing the backkground of the progress indicators
-    ///
-    open var progressBackgroundColor: UIColor = TextAttachment.appearance.progressBackgroundColor
-
-    /// The color to use when drawing progress indicators
-    ///
-    open var progressColor: UIColor = TextAttachment.appearance.progressColor
-
-    /// The margin apply to the images being displayed. This is to avoid that two images in a row get glued together.
-    ///
-    open var margin: CGFloat = VideoAttachment.appearance.margin
-
-    /// A message to display overlaid on top of the image
-    ///
-    open var message: NSAttributedString? {
-        willSet {
-            if newValue != message {
-                glyphImage = nil
-            }
-        }
-    }
-
-    /// An image to display overlaid on top of the image has an action icon.
-    ///
-    open var overlayImage: UIImage? {
-        willSet {
-            if newValue != overlayImage {
-                glyphImage = nil
-            }
-        }
-    }
-
-
-    /// Clears all overlay information that is applied to the attachment
-    ///
-    open func clearAllOverlays() {
-        progress = nil
-        message = nil
-        overlayImage = nil
-    }
-
-    fileprivate var glyphImage: UIImage?
-
-    weak var delegate: VideoAttachmentDelegate?
-    
-    var isFetchingImage: Bool = false
 
     /// Creates a new attachment
     ///
     /// - parameter identifier: An unique identifier for the attachment
     ///
     required public init(identifier: String, srcURL: URL? = nil, posterURL: URL? = nil) {
-        self.identifier = identifier
         self.srcURL = srcURL
-        self.posterURL = posterURL
         
-        super.init(data: nil, ofType: nil)
+        super.init(identifier: identifier, url: posterURL)
 
         self.overlayImage = Gridicon.iconOfType(.video)
     }
@@ -135,228 +45,52 @@ open class VideoAttachment: NSTextAttachment
     /// Required Initializer
     ///
     required public init?(coder aDecoder: NSCoder) {
-        identifier = ""
         super.init(coder: aDecoder)
 
-        if let decodedIndentifier = aDecoder.decodeObject(forKey: EncodeKeys.identifier.rawValue) as? String {
-            identifier = decodedIndentifier
-        }
         if aDecoder.containsValue(forKey: EncodeKeys.srcURL.rawValue) {
             srcURL = aDecoder.decodeObject(forKey: EncodeKeys.srcURL.rawValue) as? URL
         }
-
-        if aDecoder.containsValue(forKey: EncodeKeys.posterURL.rawValue) {
-            posterURL = aDecoder.decodeObject(forKey: EncodeKeys.posterURL.rawValue) as? URL
-        }
     }
-
-    override init(data contentData: Data?, ofType uti: String?) {
-        identifier = ""
-        srcURL = nil
-        posterURL = nil
-        super.init(data: contentData, ofType: uti)
-    }
-
-    fileprivate func setupDefaultAppearance() {
-        progressHeight = VideoAttachment.appearance.progressHeight
-        progressBackgroundColor = VideoAttachment.appearance.progressBackgroundColor
-        progressColor = VideoAttachment.appearance.progressColor
-        overlayColor = VideoAttachment.appearance.overlayColor
+    
+    required public init(identifier: String, url: URL?) {
+        self.srcURL = nil
+        super.init(identifier: identifier, url: url)
     }
 
     override open func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
-        aCoder.encode(identifier, forKey: EncodeKeys.identifier.rawValue)
         if let url = self.srcURL {
             aCoder.encode(url, forKey: EncodeKeys.srcURL.rawValue)
-        }
-        if let url = self.posterURL {
-            aCoder.encode(url, forKey: EncodeKeys.posterURL.rawValue)
         }
     }
 
     fileprivate enum EncodeKeys: String {
-        case identifier
         case srcURL
-        case posterURL
     }
     // MARK: - Origin calculation
 
-    fileprivate func xPosition(forContainerWidth containerWidth: CGFloat) -> CGFloat {
+    override func xPosition(forContainerWidth containerWidth: CGFloat) -> CGFloat {
         let imageWidth = onScreenWidth(containerWidth)
 
         return CGFloat(floor((containerWidth - imageWidth) / 2))
     }
 
-    fileprivate func onScreenHeight(_ containerWidth: CGFloat) -> CGFloat {
+    override func onScreenHeight(_ containerWidth: CGFloat) -> CGFloat {
         if let image = image {
             let targetWidth = onScreenWidth(containerWidth)
             let scale = targetWidth / image.size.width
 
-            return floor(image.size.height * scale) + (margin * 2)
+            return floor(image.size.height * scale) + (imageMargin * 2)
         } else {
             return 0
         }
     }
 
-    fileprivate func onScreenWidth(_ containerWidth: CGFloat) -> CGFloat {
+    override func onScreenWidth(_ containerWidth: CGFloat) -> CGFloat {
         if let image = image {
             return floor(min(image.size.width, containerWidth))
         } else {
             return 0
         }
-    }
-
-    // MARK: - NSTextAttachmentContainer
-
-    override open func image(forBounds imageBounds: CGRect, textContainer: NSTextContainer?, characterIndex charIndex: Int) -> UIImage? {
-        
-        updateImage(inTextContainer: textContainer)
-
-        guard let image = image else {
-            return nil
-        }
-
-        if let cachedImage = glyphImage, imageBounds.size.equalTo(cachedImage.size) {
-            return cachedImage
-        }
-
-        glyphImage = glyph(basedOnImage:image, forBounds: imageBounds)
-
-        return glyphImage
-    }
-
-    fileprivate func glyph(basedOnImage image:UIImage, forBounds bounds: CGRect) -> UIImage? {
-
-        let containerWidth = bounds.size.width
-        let origin = CGPoint(x: xPosition(forContainerWidth: bounds.size.width), y: margin)
-        let size = CGSize(width: onScreenWidth(containerWidth), height: onScreenHeight(containerWidth) - margin)
-
-        UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0)
-
-        image.draw(in: CGRect(origin: origin, size: size))
-
-        drawOverlay(at:origin, size: size)
-        drawProgress(at:origin, size: size)
-
-
-        var imagePadding: CGFloat = 0
-        if let overlayImage = overlayImage {
-            UIColor.white.set()
-            let center = CGPoint(x: round(origin.x + (size.width / 2.0)), y: round(origin.y + (size.height / 2.0)))
-            let radius = round(overlayImage.size.width * 2.0/3.0)
-            let path = UIBezierPath(arcCenter: center, radius: radius, startAngle: 0, endAngle: CGFloat.pi * 2, clockwise: true)
-            path.stroke()
-            overlayImage.draw(at: CGPoint(x: round(center.x - (overlayImage.size.width / 2.0)), y: round(center.y - (overlayImage.size.height / 2.0))))
-            imagePadding += radius * 2;
-        }
-
-        if let message = message {
-            let textRect = message.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
-            var y =  origin.y + ((size.height - textRect.height) / 2.0)
-            if imagePadding != 0 {
-                y = origin.y + ((size.height + imagePadding) / 2.0)
-            }
-            let textPosition = CGPoint(x: origin.x, y: y)
-            message.draw(in: CGRect(origin: textPosition , size: CGSize(width:size.width, height:textRect.size.height)))
-        }
-
-        let result = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return result;
-    }
-
-    fileprivate func drawOverlay(at origin: CGPoint, size:CGSize) {
-        guard message != nil || progress != nil || overlayImage != nil else {
-            return
-        }
-        let box = UIBezierPath()
-        box.move(to: CGPoint(x:origin.x, y:origin.y))
-        box.addLine(to: CGPoint(x: origin.x + size.width, y: origin.y))
-        box.addLine(to: CGPoint(x: origin.x + size.width, y: origin.y + size.height))
-        box.addLine(to: CGPoint(x: origin.x, y: origin.y + size.height))
-        box.addLine(to: CGPoint(x: origin.x, y: origin.y))
-        box.lineWidth = 2.0
-        overlayColor.setFill()
-        box.fill()
-    }
-
-    fileprivate func drawProgress(at origin: CGPoint, size:CGSize) {
-        guard let progress = progress else {
-            return
-        }
-        let lineY = origin.y + (progressHeight / 2.0)
-
-        let backgroundPath = UIBezierPath()
-        backgroundPath.lineWidth = progressHeight
-        progressBackgroundColor.setStroke()
-        backgroundPath.move(to: CGPoint(x:origin.x, y: lineY))
-        backgroundPath.addLine(to: CGPoint(x: origin.x + size.width, y: lineY ))
-        backgroundPath.stroke()
-
-        let path = UIBezierPath()
-        path.lineWidth = progressHeight
-        progressColor.setStroke()
-        path.move(to: CGPoint(x:origin.x, y: lineY))
-        path.addLine(to: CGPoint(x: origin.x + (size.width * CGFloat(max(0,min(progress,1)))), y: lineY ))
-        path.stroke()
-    }
-
-    /// Returns the "Onscreen Character Size" of the attachment range. When we're in Alignment.None,
-    /// the attachment will be 'Inline', and thus, we'll return the actual Associated View Size.
-    /// Otherwise, we'll always take the whole container's width.
-    ///
-    override open func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
-        
-        updateImage(inTextContainer: textContainer)
-        
-        if image == nil {
-            return CGRect.zero
-        }
-
-        let padding = textContainer?.lineFragmentPadding ?? 0
-        let width = lineFrag.width - padding * 2
-
-        return CGRect(origin: CGPoint.zero, size: CGSize(width: width, height: onScreenHeight(width)))
-    }
-
-    func updateImage(inTextContainer textContainer: NSTextContainer? = nil) {
-
-        guard let delegate = delegate else {
-            assertionFailure("This class doesn't really support not having an updater set.")
-            return
-        }
-        
-        guard let url = posterURL, !isFetchingImage && url != lastRequestedURL else {
-            return
-        }
-        
-        isFetchingImage = true
-        
-        let image = delegate.videoAttachment(self, imageForURL: url, onSuccess: { [weak self] image in
-                guard let strongSelf = self else {
-                    return
-                }
-                strongSelf.lastRequestedURL = url
-                strongSelf.isFetchingImage = false
-                strongSelf.image = image
-                strongSelf.invalidateLayout(inTextContainer: textContainer)
-            }, onFailure: { [weak self] _ in
-                
-                guard let strongSelf = self else {
-                    return
-                }
-                
-                strongSelf.isFetchingImage = false
-                strongSelf.invalidateLayout(inTextContainer: textContainer)
-            })
-
-        if self.image == nil {
-            self.image = image
-        }
-    }
-    
-    fileprivate func invalidateLayout(inTextContainer textContainer: NSTextContainer?) {
-        textContainer?.layoutManager?.invalidateLayoutForAttachment(self)
     }
 }

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -310,7 +310,7 @@ class TextStorageTests: XCTestCase
         }
 
         // Nuke
-        storage.removeTextAttachments()
+        storage.removeMediaAttachments()
 
         // Verify the attachments are there
         for identifier in identifiers {

--- a/Example/Example/AttachmentDetailsViewController.swift
+++ b/Example/Example/AttachmentDetailsViewController.swift
@@ -8,8 +8,8 @@ class AttachmentDetailsViewController: UITableViewController
     @IBOutlet var sizeSegmentedControl: UISegmentedControl!
     @IBOutlet var sourceURLTextField: UITextField!
 
-    var attachment: TextAttachment?
-    var onUpdate: ((TextAttachment.Alignment, TextAttachment.Size, URL) -> Void)?
+    var attachment: ImageAttachment?
+    var onUpdate: ((ImageAttachment.Alignment, ImageAttachment.Size, URL) -> Void)?
 
 
     override func viewDidLoad() {
@@ -82,8 +82,8 @@ private extension AttachmentDetailsViewController
 {
     /// Aliases
     ///
-    typealias AttachmentAlignment = TextAttachment.Alignment
-    typealias AttachmentSize = TextAttachment.Size
+    typealias AttachmentAlignment = ImageAttachment.Alignment
+    typealias AttachmentSize = ImageAttachment.Size
 
 
     /// Maps an TextAttachment.Alignment into a Integer based Enum, to aid in the mapping between

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -102,7 +102,7 @@ class EditorDemoController: UIViewController {
         }
     }    
 
-    fileprivate var currentSelectedAttachment: TextAttachment?
+    fileprivate var currentSelectedAttachment: ImageAttachment?
 
     fileprivate var formatBarAnimatedPeek = false
 
@@ -142,10 +142,10 @@ class EditorDemoController: UIViewController {
 
         richTextView.setHTML(html)
 
-        TextAttachment.appearance.progressColor = UIColor.blue
-        TextAttachment.appearance.progressBackgroundColor = UIColor.lightGray
-        TextAttachment.appearance.progressHeight = 2.0
-        TextAttachment.appearance.overlayColor = UIColor(white: 0.5, alpha: 0.5)
+        MediaAttachment.appearance.progressColor = UIColor.blue
+        MediaAttachment.appearance.progressBackgroundColor = UIColor.lightGray
+        MediaAttachment.appearance.progressHeight = 2.0
+        MediaAttachment.appearance.overlayColor = UIColor(white: 0.5, alpha: 0.5)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -784,7 +784,7 @@ extension EditorDemoController: TextViewMediaDelegate {
     }
 
     func textView(_ textView: TextView, selectedAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
-        if let imgAttachment = attachment as? TextAttachment {
+        if let imgAttachment = attachment as? ImageAttachment {
             selected(textAttachment: imgAttachment, atPosition: position)
         }
 
@@ -794,12 +794,12 @@ extension EditorDemoController: TextViewMediaDelegate {
     }
 
     func textView(_ textView: TextView, deselectedAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
-        if let imgAttachment = attachment as? TextAttachment {
+        if let imgAttachment = attachment as? ImageAttachment {
             deselected(textAttachment: imgAttachment, atPosition: position)
         }
     }
 
-    func selected(textAttachment attachment: TextAttachment, atPosition position: CGPoint) {
+    func selected(textAttachment attachment: ImageAttachment, atPosition position: CGPoint) {
         if (currentSelectedAttachment == attachment) {
             displayActions(forAttachment: attachment, position: position)
         } else {
@@ -817,7 +817,7 @@ extension EditorDemoController: TextViewMediaDelegate {
         }
     }
 
-    func deselected(textAttachment attachment: TextAttachment, atPosition position: CGPoint) {
+    func deselected(textAttachment attachment: ImageAttachment, atPosition position: CGPoint) {
         attachment.clearAllOverlays()
         richTextView.refreshLayoutFor(attachment: attachment)
     }
@@ -934,7 +934,7 @@ private extension EditorDemoController
         return attributes
     }
 
-    func displayActions(forAttachment attachment: TextAttachment, position: CGPoint) {
+    func displayActions(forAttachment attachment: ImageAttachment, position: CGPoint) {
         let mediaID = attachment.identifier
         let title: String = NSLocalizedString("Media Options", comment: "Title for action sheet with media options.")
         let message: String? = nil
@@ -972,7 +972,7 @@ private extension EditorDemoController
         present(alertController, animated:true, completion: nil)
     }
 
-    func displayDetailsForAttachment(_ attachment: TextAttachment, position:CGPoint) {
+    func displayDetailsForAttachment(_ attachment: ImageAttachment, position:CGPoint) {
         let detailsViewController = AttachmentDetailsViewController.controller()
         detailsViewController.attachment = attachment
         detailsViewController.onUpdate = { [weak self] (alignment, size, url) in


### PR DESCRIPTION
Refs #165 

This PR refactor TextAttachment to be MediaAttachment. It then creates a ImageAttachment to replace the uses of the previous TextAttachment and it also implements VideoAttachment as a subclass of MediaAttachment.

This change allow sharing of a lot of layout and delegate code between the Image and Video implementations and make simples in the future do changes to both systems.

How to test:
 * Run the Demo app
 * Check that the image and video of the demo show up correctly
 * Test the interactions with the image ( add image, remove image, tap for details)
 * Test the interactions with videos ( tap to play, remove)
