### PR TITLE
Technical Debt: Zero Width Spacing Workarounds-Cleanup

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -292,7 +292,6 @@ open class TextView: UITextView {
         ///
         ensureInsertionOfNewline(beforeInserting: text)
 
-        // Note:
         // Whenever the entered text causes the Paragraph Attributes to be removed, we should prevent the actual
         // text insertion to happen. Thus, we won't call super.insertText.
         // But because we don't call the super we need to refresh the attributes ourselfs, and callback to the delegate.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1190,7 +1190,7 @@ private extension TextView {
     ///     B. Below there's an empty line.
     ///     C. The user pressed Arrow Down
     ///
-    ///     Why: We only want to extend the `Paragraph Attribute` if a Newline is explicitly entered.
+    ///     Why: We only want to carry over the `Paragraph Attribute` if a Newline is explicitly pressed.
     ///
     /// Scenario B:
     ///
@@ -1203,7 +1203,7 @@ private extension TextView {
     ///
     /// - Parameters:
     ///     - text: String that is about to be inserted.
-    ///     - location: Insertion point
+    ///     - location: Selected Range's Location
     ///
     /// - Returns: true if we should remove the paragraph attributes. false otherwise!
     ///


### PR DESCRIPTION
### Details:
In this PR we're addressing (part of the) "Nuking Zero Width Space" workarounds that had to be implemented, in order to force the LayoutManager to render empty lines, in which there's no actual text.

Please: Verify that the unit tests still pass, and re-verify the Blockquote Test cases (pasting them below for convenience!).

Thanks in advance!!

Needs Review: @diegoreymendez 
You, sir, are a genius.

Ref. #430

--

### Scenario A: Missing Blockquote after Backspace
1. Launch the empty editor
2. Toggle the Blockquote format
3. Enter any random text
4. Hit backspace

Verify that the blockquote style is still present.

### Scenario B: Nuking Blockquote after Backspace
1. Launch the empty editor
2. Toggle the Blockquote format
3. Select the end of the document
4. Hit backspace

Verify that the Blockquote gets effectively removed.

### Scenario C: Newline after blockquote
1. Launch the empty editor
2. Toggle the Blockquote format

Verify that a newline is inserted below the blockquote.

### Scenario D: Nuking bottom `\n` and adding newlines
1. Launch the empty editor
2. Toggle the Blockquote format
3. Enter any random text
4. Select the end of the document
5. Hit backspace
6. Hit `\n` and enter any random text

Verify that the new Blockquote line gets it's proper style, even when the bottom `\n` was initially nuked.

### Scenario E: Typing Attributes below Blockquote
1. Launch the empty editor
2. Toggle the Blockquote format
3. Press the arrow down

Verify that the blockquote gets removed from the typing attributes (and that the text indentation looks normal).

### Scenario F: Autoremoval after hitting return on newline
1. Launch the empty editor
2. Toggle the Blockquote format
3. Hit return

Verify that the blockquote gets removed.
