### PR TITLE
Redrawing Cursor: Encapsulating Workaround

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -799,34 +799,6 @@ open class TextView: UITextView {
     }
 
 
-    /// Force the SDK to Redraw the cursor, asynchronously, if the edited text (inserted / deleted) requires it.
-    /// This method was meant as a workaround for Issue #144.
-    ///
-    func ensureCursorRedraw(afterEditing text: String) {
-        guard text == String(.newline) else {
-            return
-        }
-
-        forceRedrawCursorAfterDelay()
-    }
-
-
-    /// Force the SDK to Redraw the cursor, asynchronously, after a delay. This method was meant as a workaround
-    /// for Issue #144: the Caret might end up redrawn below the Blockquote's custom background.
-    ///
-    func forceRedrawCursorAfterDelay() {
-        let delay = 0.05
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            let pristine = self.selectedRange
-            let updated = NSMakeRange(max(pristine.location - 1, 0), 0)
-            let beforeTypingAttributes = self.typingAttributes
-            self.selectedRange = updated
-            self.selectedRange = pristine
-            self.typingAttributes = beforeTypingAttributes
-        }
-    }
-
-
     // MARK: - Links
 
     /// Adds a link to the designated url on the specified range.
@@ -1092,6 +1064,40 @@ open class TextView: UITextView {
         return attachment
     }
 }
+
+
+// MARK: - Cursor Drawing Workaround
+//
+private extension TextView {
+
+    /// Force the SDK to Redraw the cursor, asynchronously, if the edited text [inserted (OR) deleted] is a newline.
+    /// This method was meant as a workaround for Issue #144.
+    ///
+    func ensureCursorRedraw(afterEditing text: String) {
+        guard text == String(.newline) else {
+            return
+        }
+
+        forceRedrawCursorAfterDelay()
+    }
+
+
+    /// Force the SDK to Redraw the cursor, asynchronously, after a delay. This method was meant as a workaround
+    /// for Issue #144: the Caret might end up redrawn below the Blockquote's custom background.
+    ///
+    func forceRedrawCursorAfterDelay() {
+        let delay = 0.05
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            let pristine = self.selectedRange
+            let updated = NSMakeRange(max(pristine.location - 1, 0), 0)
+            let beforeTypingAttributes = self.typingAttributes
+            self.selectedRange = updated
+            self.selectedRange = pristine
+            self.typingAttributes = beforeTypingAttributes
+        }
+    }
+}
+
 
 // MARK: - ParagraphFormatters: Style Removal Workarounds
 //

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1066,7 +1066,7 @@ open class TextView: UITextView {
 }
 
 
-// MARK: - Cursor Drawing Workaround
+// MARK: - Workarounds: Cursor Drawing
 //
 private extension TextView {
 
@@ -1099,7 +1099,7 @@ private extension TextView {
 }
 
 
-// MARK: - ParagraphFormatters: Style Removal Workarounds
+// MARK: - Workarounds: ParagraphFormatters Removal
 //
 private extension TextView {
 
@@ -1194,7 +1194,7 @@ private extension TextView {
 }
 
 
-// MARK: ParagraphFormatters: Newline Workarounds
+// MARK: Workarounds: ParagraphFormatters + Newline
 //
 private extension TextView {
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -585,11 +585,10 @@ open class TextView: UITextView {
     ///     - range: The NSRange to edit.
     ///
     open func togglePre(range: NSRange) {
-        ensureInsertionOfNewlineWhenEditingEdgeOfTheDocument()
-
         let formatter = PreFormatter(placeholderAttributes: typingAttributes)
-        toggle(formatter: formatter, atRange: range)
 
+        ensureInsertionOfNewline(at: selectedRange.location)
+        toggle(formatter: formatter, atRange: range)
         forceRedrawCursorAfterDelay()
     }
 
@@ -602,11 +601,10 @@ open class TextView: UITextView {
     ///     - range: The NSRange to edit.
     ///
     open func toggleBlockquote(range: NSRange) {
-        ensureInsertionOfNewlineWhenEditingEdgeOfTheDocument()
-
         let formatter = BlockquoteFormatter(placeholderAttributes: typingAttributes)
-        toggle(formatter: formatter, atRange: range)
 
+        ensureInsertionOfNewline(at: selectedRange.location)
+        toggle(formatter: formatter, atRange: range)
         forceRedrawCursorAfterDelay()
     }
 
@@ -615,11 +613,10 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleOrderedList(range: NSRange) {
-        ensureInsertionOfNewlineWhenEditingEdgeOfTheDocument()
-
         let formatter = TextListFormatter(style: .ordered, placeholderAttributes: typingAttributes)
-        toggle(formatter: formatter, atRange: range)
 
+        ensureInsertionOfNewline(at: selectedRange.location)
+        toggle(formatter: formatter, atRange: range)
         forceRedrawCursorAfterDelay()
     }
 
@@ -629,11 +626,10 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleUnorderedList(range: NSRange) {
-        ensureInsertionOfNewlineWhenEditingEdgeOfTheDocument()
-
         let formatter = TextListFormatter(style: .unordered, placeholderAttributes: typingAttributes)
-        toggle(formatter: formatter, atRange: range)
 
+        ensureInsertionOfNewline(at: selectedRange.location)
+        toggle(formatter: formatter, atRange: range)
         forceRedrawCursorAfterDelay()
     }
 
@@ -1196,10 +1192,12 @@ private extension TextView {
 //
 private extension TextView {
 
-    /// Inserts an empty line whenever we're at the end of the document
+    /// Inserts a newline character, below the selected range, whenever we're at the end of the document.
     ///
-    func ensureInsertionOfNewlineWhenEditingEdgeOfTheDocument() {
-        guard selectedRange.location == storage.length else {
+    /// - Parameter location: current location of the cursor.
+    ///
+    func ensureInsertionOfNewline(at location: Int) {
+        guard location == storage.length else {
             return
         }
 
@@ -1211,10 +1209,12 @@ private extension TextView {
     ///
     ///     A.  We're about to insert a new line
     ///     B.  We're at the end of the document
-    ///     C.  There's a List (OR) Blockquote (OR) Pre active
+    ///     C.  There's a Paragraph Formatter Enabled.
     ///
-    /// We're doing this as a workaround, in order to force the LayoutManager render the Bullet (OR)
+    /// Note: We're doing this as a workaround, in order to force the LayoutManager render the Bullet (OR)
     /// Blockquote's background.
+    ///
+    /// - Parameter text: String about to be inserted.
     ///
     func ensureInsertionOfNewline(beforeInserting text: String) {
         guard text == String(.newline) else {


### PR DESCRIPTION
### Details:
In this PR we're simply moving the Cursor Redraw Workaround into it's own TextView extension.
**Zero** code was changed here, just relocated.

In order to verify this, please, make sure the Unit Tests pass.

Ref. #430

Note: This PR **includes** the changes introduced in #436

Needs Review: @diegoreymendez 
Thanks!!
