### PR TITLE
Feature/165 433 video in html

### DIFF
--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -539,6 +539,33 @@ extension Libxml2 {
             rootNode.replaceCharacters(in: range, with: descriptor)
         }
 
+        // MARK: - Videos
+
+        /// Replaces the specified range with a given image.
+        ///
+        /// - Parameters:
+        ///   - range: the range to insert the image
+        ///   - videoURL: the URL for the video src attribute
+        ///   - posterURL: the URL for ther video poster attribute
+        ///
+        func replace(_ range: NSRange, withVideoURL videoURL: URL, posterURL: URL?) {
+            performAsyncUndoable { [weak self] in
+                self?.replaceSynchronously(range, withVideoURL: videoURL, posterURL: posterURL)
+            }
+        }
+
+        private func replaceSynchronously(_ range: NSRange, withVideoURL videoURL: URL, posterURL: URL?) {
+            let videoURLString = videoURL.absoluteString
+
+            var attributes = [Libxml2.StringAttribute(name:"src", value: videoURLString)]
+            if let posterURLString = posterURL?.absoluteString {
+                attributes.append(Libxml2.StringAttribute(name:"poster", value: posterURLString))
+            }
+            let descriptor = ElementNodeDescriptor(elementType: .video, attributes: attributes)
+
+            rootNode.replaceCharacters(in: range, with: descriptor)
+        }
+
         /// Replaces the specified range with a Horizontal Ruler Style.
         ///
         /// - Parameters:

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -269,7 +269,7 @@ extension Libxml2 {
             }
         }
 
-        /// Disables an image from the specified range.
+        /// Removes an image from the specified range.
         ///
         /// - Parameters:
         ///     - range: the range to remove the style from.
@@ -277,6 +277,17 @@ extension Libxml2 {
         func removeImage(spanning range: NSRange) {
             performAsyncUndoable { [weak self] in
                 self?.removeImageSynchronously(spanning: range)
+            }
+        }
+
+        /// Removes an video from the specified range.
+        ///
+        /// - Parameters:
+        ///     - range: the range to remove the style from.
+        ///
+        func removeVideo(spanning range: NSRange) {
+            performAsyncUndoable { [weak self] in
+                self?.removeVideoSynchronously(spanning: range)
             }
         }
 
@@ -356,6 +367,10 @@ extension Libxml2 {
 
         private func removeImageSynchronously(spanning range: NSRange) {
             domEditor.unwrap(range: range, fromElementsNamed: StandardElementType.img.equivalentNames)
+        }
+
+        private func removeVideoSynchronously(spanning range: NSRange) {
+            domEditor.unwrap(range: range, fromElementsNamed: StandardElementType.video.equivalentNames)
         }
         
         private func removeItalicSynchronously(spanning range: NSRange) {

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -296,7 +296,9 @@ open class MediaAttachment: NSTextAttachment
         let padding = textContainer?.lineFragmentPadding ?? 0
         let width = lineFrag.width - padding * 2
 
-        return CGRect(origin: CGPoint.zero, size: CGSize(width: width, height: onScreenHeight(width)))
+        let size = CGSize(width: width, height: onScreenHeight(width))
+        
+        return CGRect(origin: CGPoint.zero, size: size)
     }
 
     func updateImage(inTextContainer textContainer: NSTextContainer? = nil) {

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -505,17 +505,17 @@ open class TextStorage: NSTextStorage {
         let originalUrl = original?.srcURL
         let newUrl = new?.srcURL
 
-        let addImageUrl = originalUrl == nil && newUrl != nil
-        let removeImageUrl = originalUrl != nil && newUrl == nil
+        let addVideoUrl = originalUrl == nil && newUrl != nil
+        let removeVideoUrl = originalUrl != nil && newUrl == nil
 
-        if addImageUrl {
+        if addVideoUrl {
             guard let urlToAdd = newUrl else {
                 assertionFailure("This should not be possible.  Review your logic.")
                 return
             }
 
             dom.replace(range, withVideoURL: urlToAdd, posterURL: new?.posterURL)
-        } else if removeImageUrl {
+        } else if removeVideoUrl {
             dom.removeVideo(spanning: range)
         }
     }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -514,7 +514,7 @@ open class TextStorage: NSTextStorage {
                 return
             }
 
-            dom.replace(range, with: urlToAdd)
+            dom.replace(range, withVideoURL: urlToAdd, posterURL: new?.posterURL)
         } else if removeImageUrl {
             dom.removeVideo(spanning: range)
         }
@@ -771,6 +771,28 @@ open class TextStorage: NSTextStorage {
         let attachment = ImageAttachment(identifier: identifier)
         attachment.delegate = self
         attachment.url = url
+        attachment.image = placeHolderImage
+
+        // Inject the Attachment and Layout
+        let insertionRange = NSMakeRange(position, 0)
+        let attachmentString = NSAttributedString(attachment: attachment)
+        replaceCharacters(in: insertionRange, with: attachmentString)
+
+        return attachment
+    }
+
+    /// Insert Video Element at the specified range using url as source
+    ///
+    /// - parameter sourceURL: the source URL of the video
+    /// - parameter posterURL: an URL pointing to a frame/thumbnail of the video
+    /// - parameter position: the position to insert the image
+    /// - parameter placeHolderImage: an image to display while the image from sourceURL is being prepared
+    ///
+    /// - returns: the attachment object that was created and inserted on the text
+    ///
+    func insertVideo(sourceURL: URL, posterURL: URL?, atPosition position:Int, placeHolderImage: UIImage, identifier: String = UUID().uuidString) -> VideoAttachment {
+        let attachment = VideoAttachment(identifier: identifier, srcURL: sourceURL, posterURL: posterURL)
+        attachment.delegate = self
         attachment.image = placeHolderImage
 
         // Inject the Attachment and Layout

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1088,11 +1088,21 @@ open class TextView: UITextView {
     /// Inserts a Video attachment at the specified index
     ///
     /// - Parameters:
-    ///     - index: The character index at which to insert the image.
-    ///     - params: TBD
+    ///   - location: the location in the text to insert the video
+    ///   - sourceURL: the video source URL
+    ///   - posterURL: the video poster image URL
+    ///   - placeHolderImage: an image to use has an placeholder while the video poster is being loaded
+    ///   - identifier: an unique indentifier for the video
     ///
-    open func insertVideo(_ index: Int, params: [String: AnyObject]) {
-        print("video")
+    /// - Returns: the video attachment object that was inserted.
+    ///
+    open func insertVideo(atLocation location: Int, sourceURL: URL, posterURL: URL?, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> VideoAttachment {
+        let attachment = storage.insertVideo(sourceURL: sourceURL, posterURL: posterURL, atPosition: location, placeHolderImage: placeHolderImage ?? defaultMissingImage, identifier: identifier)
+        let length = NSAttributedString.lengthOfTextAttachment
+        textStorage.addAttributes(typingAttributes, range: NSMakeRange(location, length))
+        selectedRange = NSMakeRange(location+length, 0)
+        delegate?.textViewDidChange?(self)
+        return attachment
     }
 
     /// Returns the associated TextAttachment, at a given point, if any.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -990,11 +990,11 @@ open class TextView: UITextView {
         return attachment
     }
 
-    /// Returns the associated TextAttachment, at a given point, if any.
+    /// Returns the associated NSTextAttachment, at a given point, if any.
     ///
     /// - Parameter point: The point on screen to check for attachments.
     ///
-    /// - Returns: The associated TextAttachment.
+    /// - Returns: The associated NSTextAttachment.
     ///
     open func attachmentAtPoint(_ point: CGPoint) -> NSTextAttachment? {
         let index = layoutManager.characterIndex(for: point, in: textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
@@ -1002,7 +1002,18 @@ open class TextView: UITextView {
             return nil
         }
 
-        return textStorage.attribute(NSAttachmentAttributeName, at: index, effectiveRange: nil) as? NSTextAttachment
+        guard let attachment = textStorage.attribute(NSAttachmentAttributeName, at: index, effectiveRange: nil) as? NSTextAttachment else {
+            return nil
+        }
+
+        let glyphIndex = layoutManager.glyphIndexForCharacter(at: index)
+        let bounds = layoutManager.boundingRect(forGlyphRange: NSRange(location: glyphIndex, length: 1), in: textContainer)
+
+        if bounds.contains(point) {
+            return attachment
+        }
+
+        return nil
     }
 
     /// Move the selected range to the nearest character of the point specified in the textView

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -22,11 +22,11 @@ open class VideoAttachment: MediaAttachment
     ///
     open var posterURL: URL? {
         get {
-            return self.srcURL
+            return self.url
         }
 
         set {
-            self.srcURL = newValue
+            self.url = newValue
         }
     }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -789,14 +789,15 @@ extension EditorDemoController: TextViewMediaDelegate {
         }
 
         if let videoAttachment = attachment as? VideoAttachment {
+            if let imageAttachment = currentSelectedAttachment {
+                deselected(textAttachment: imageAttachment, atPosition: position)
+            }
             selected(videoAttachment: videoAttachment, atPosition: position)
         }
     }
 
     func textView(_ textView: TextView, deselectedAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
-        if let imgAttachment = attachment as? ImageAttachment {
-            deselected(textAttachment: imgAttachment, atPosition: position)
-        }
+        deselected(textAttachment: attachment, atPosition: position)
     }
 
     func selected(textAttachment attachment: ImageAttachment, atPosition position: CGPoint) {
@@ -817,9 +818,12 @@ extension EditorDemoController: TextViewMediaDelegate {
         }
     }
 
-    func deselected(textAttachment attachment: ImageAttachment, atPosition position: CGPoint) {
-        attachment.clearAllOverlays()
-        richTextView.refreshLayoutFor(attachment: attachment)
+    func deselected(textAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
+        currentSelectedAttachment = nil
+        if let mediaAttachment = attachment as? MediaAttachment {
+            mediaAttachment.clearAllOverlays()
+            richTextView.refreshLayoutFor(attachment: mediaAttachment)
+        }
     }
 
     func selected(videoAttachment attachment: VideoAttachment, atPosition position: CGPoint) {


### PR DESCRIPTION
Fixes #165 and #433 

This PR adds support for video insertion trough the formatting toolbar and implements HTML/DOM changes when videos are added/removed.

To test:
 - Open the demo app with the preloaded content
 - Tap on the image and video and see if they work correctly
 - Delete image and video from the content and see if  the HTML is updated correctly.
 - Tap on the media toolbar item
 - Add video and image, and check if they are inserted correctly
 - Switch to HTML mode and check if the HTML is correct.
