### PR TITLE
Blockquote: Fixing unwanted 1px white separator

### DIFF
--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -53,7 +53,7 @@ private extension LayoutManager {
 
             enumerateLineFragments(forGlyphRange: blockquoteGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
                 let lineRect = rect.offsetBy(dx: origin.x, dy: origin.y)
-                self.drawBlockquote(in: lineRect, with: context)
+                self.drawBlockquote(in: lineRect.integral, with: context)
             }
         }
 


### PR DESCRIPTION
### Details:
We were getting a 1px separator between blockquote lines, due to drawing positions not being integer(s).

Needs Review: @SergioEstevao 
Thanks in advance Sergio!

Fixes #442

### To test:
1. Toggle Blockquote
2. Enter several lines of text

Verify that there are no white lines showing up between the Blockquote's Lines.
