### PR TITLE
Fixes some issues with lists.

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -50,6 +50,16 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     fileprivate func convert(_ node: Node, inheritingAttributes attributes: [String:Any]) -> NSAttributedString {
 
+        let string = convertContents(of: node, inheritingAttributes: attributes)
+
+        guard node.needsClosingParagraphSeparator() else {
+            return string
+        }
+
+        return appendParagraphSeparator(to: string, inheritingAttributes: attributes)
+    }
+
+    private func convertContents(of node: Node, inheritingAttributes attributes: [String:Any]) -> NSAttributedString {
         switch node {
         case let textNode as TextNode:
             return convertTextNode(textNode, inheritingAttributes: attributes)
@@ -75,13 +85,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
             return NSAttributedString()
         }
 
-        let content = NSMutableAttributedString(string: node.text(), attributes: inheritedAttributes)
-
-        if node.needsClosingParagraphSeparator() {
-            content.append(NSAttributedString(.paragraphSeparator, attributes: inheritedAttributes))
-        }
-
-        return content
+        return NSAttributedString(string: node.text(), attributes: inheritedAttributes)
     }
 
     /// Converts a `CommentNode` to `NSAttributedString`.
@@ -120,6 +124,18 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
         return NSAttributedString(attachment: attachment, attributes: attributes)
     }
+
+    // MARK: - Paragraph Separator
+
+    private func appendParagraphSeparator(to string: NSAttributedString, inheritingAttributes inheritedAttributes: [String: Any]) -> NSAttributedString {
+
+        let stringWithSeparator = NSMutableAttributedString(attributedString: string)
+
+        stringWithSeparator.append(NSAttributedString(.paragraphSeparator, attributes: inheritedAttributes))
+
+        return NSAttributedString(attributedString: stringWithSeparator)
+    }
+
 
     // MARK: - Node Styling
 

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -77,7 +77,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
         let content = NSMutableAttributedString(string: node.text(), attributes: inheritedAttributes)
 
-        if node.isLastInBlockLevelElement() {
+        if node.needsClosingParagraphSeparator() {
             content.append(NSAttributedString(.paragraphSeparator, attributes: inheritedAttributes))
         }
 

--- a/Aztec/Classes/Extensions/NSMutableAttributedString+ReplaceOcurrences.swift
+++ b/Aztec/Classes/Extensions/NSMutableAttributedString+ReplaceOcurrences.swift
@@ -19,4 +19,29 @@ extension NSMutableAttributedString {
             replaceCharacters(in: nsRange, with: replacementString)
         }
     }
+
+    /// Replaces all ocurrences of `stringToFind` with `replacementString` in the receiver.
+    ///
+    /// - Parameters:
+    ///     - stringToFind: the string to replace.
+    ///     - replacementString: the string to replace all matching occurrences with.
+    ///
+    /// - Returns: the provided range after replacing the occurrences.
+    ///
+    func replaceOcurrences(of stringToFind: String, with replacementString: String, within range: NSRange) {
+
+        assert(!replacementString.contains(stringToFind),
+               "Allowing the replacement string to contain the original string would result in a ininite loop.")
+
+        let swiftUTF16Range = string.utf16.range(from: range)
+        let swiftRange = string.range(from: swiftUTF16Range)
+
+        while let matchRange = string.range(of: stringToFind, options: [], range: swiftRange, locale: nil) {
+            let matchNSRange = string.utf16NSRange(from: matchRange)
+
+            replaceCharacters(in: matchNSRange, with: replacementString)
+        }
+
+
+    }
 }

--- a/Aztec/Classes/Formatters/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/AttributeFormatter.swift
@@ -157,7 +157,7 @@ extension AttributeFormatter {
     @discardableResult
     func toggle(in text: NSMutableAttributedString, at range: NSRange) -> NSRange {
         //We decide if we need to apply or not the attribute based on the value on the initial position of the range
-        let shouldApply =  shouldApplyAttributes(to: text, at: range)
+        let shouldApply = shouldApplyAttributes(to: text, at: range)
 
         if shouldApply {
             return applyAttributes(to: text, at: range)
@@ -213,6 +213,52 @@ extension ParagraphAttributeFormatter {
 
     func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange {
         return text.paragraphRange(for: range)
+    }
+
+    /// Applies the Formatter's Attributes into a given string, at the specified range.
+    ///
+    /// - Returns: the full range where the attributes where applied
+    ///
+    @discardableResult
+    func applyAttributes(to text: NSMutableAttributedString, at range: NSRange) -> NSRange {
+        let rangeToApply = applicationRange(for: range, in: text)
+
+        text.replaceOcurrences(of: String(.newline), with: String(.paragraphSeparator), within: rangeToApply)
+
+        text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, _) in
+            let currentAttributes = text.attributes(at: range.location, effectiveRange: nil)
+            let attributes = apply(to: currentAttributes)
+            text.addAttributes(attributes, range: range)
+        }
+
+        return rangeToApply
+    }
+
+    /// Removes the Formatter's Attributes from a given string, at the specified range.
+    ///
+    /// - Returns: the full range where the attributes where removed
+    ///
+    @discardableResult
+    func removeAttributes(from text: NSMutableAttributedString, at range: NSRange) -> NSRange {
+        let rangeToApply = applicationRange(for: range, in: text)
+
+        text.replaceOcurrences(of: String(.paragraphSeparator), with: String(.newline), within: rangeToApply)
+
+        text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, stop) in
+            let currentAttributes = text.attributes(at: range.location, effectiveRange: nil)
+            let attributes = remove(from: currentAttributes)
+
+            let currentKeys = Set(currentAttributes.keys)
+            let newKeys = Set(attributes.keys)
+            let removedKeys = currentKeys.subtracting(newKeys)
+            for key in removedKeys {
+                text.removeAttribute(key, range: range)
+            }
+
+            text.addAttributes(attributes, range: range)
+        }
+
+        return rangeToApply
     }
 
     func worksInEmptyRange() -> Bool {

--- a/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
@@ -35,9 +35,17 @@ extension Libxml2.Out {
             let xmlNodePtr = Libxml2.Out.NodeConverter().convert(rawNode)
 
             xmlDocSetRootElement(xmlDocPtr, xmlNodePtr)
-            htmlNodeDumpFormatOutput(outputBuffer, xmlDocPtr, xmlNodePtr, nil, 0)
+            htmlNodeDumpFormatOutput(outputBuffer, xmlDocPtr, xmlNodePtr, "UTF-8", 0)
 
-            let htmlDumpString = String(cString: xmlBufContent(outputBuffer.pointee.buffer))
+            let buffer = xmlBufContent(outputBuffer.pointee.buffer)!
+
+            let finalBuffer = buffer.withMemoryRebound(to: CChar.self, capacity: 10) { ptr -> UnsafePointer<CChar> in
+                return UnsafePointer<CChar>(ptr)
+            }
+
+            let htmlDumpString = String(utf8String: finalBuffer)!
+
+            //let htmlDumpString = String(cString: xmlBufContent(outputBuffer.pointee.buffer))
 
             let finalString = htmlDumpString.replacingOccurrences(of: "<\(RootNode.name)>", with: "").replacingOccurrences(of: "</\(RootNode.name)>", with: "")
 

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -73,6 +73,16 @@ extension Libxml2 {
             return text().characters.count
         }
 
+        /// Checks if the specified node requires a closing paragraph separator.
+        ///
+        override func needsClosingParagraphSeparator() -> Bool {
+            guard children.count == 0 else {
+                return false
+            }
+
+            return super.needsClosingParagraphSeparator()
+        }
+
         // MARK: - Node Queries
 
         func valueForStringAttribute(named attributeName: String) -> String? {

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -176,6 +176,13 @@ extension Libxml2 {
             return type.equivalentNames.contains(name.lowercased())
         }
 
+        /// Retrieves the last child matching a specific filtering closure.
+        ///
+        /// - Parameters:
+        ///     - filter: the filtering closure.
+        ///
+        /// - Returns: the requested node, or `nil` if there are no nodes matching the request.
+        ///
         func lastChild(matching filter: (Node) -> Bool) -> Node? {
             return children.filter(filter).last
         }

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -1101,7 +1101,10 @@ extension Libxml2 {
 
                     guard element.standardName != .br else {
                         remove(element)
-                        splitLocations.append(offset)
+
+                        if offset > 0 && offset < length() {
+                            splitLocations.append(offset)
+                        }
 
                         continue
                     }

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -176,6 +176,10 @@ extension Libxml2 {
             return type.equivalentNames.contains(name.lowercased())
         }
 
+        func lastChild(matching filter: (Node) -> Bool) -> Node? {
+            return children.filter(filter).last
+        }
+
         // MARK: - DOM Queries
         
         /// Returns the index of the specified child node.  This method should only be called when

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -76,7 +76,7 @@ extension Libxml2 {
         /// Checks if the specified node requires a closing paragraph separator.
         ///
         override func needsClosingParagraphSeparator() -> Bool {
-            guard children.count == 0 else {
+            guard children.count == 0 && standardName != .br else {
                 return false
             }
 

--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -177,6 +177,11 @@ extension Libxml2 {
             return self === lastMatchingChildInParent
         }
 
+        /// Checks if the receiver is the last node in the tree.
+        ///
+        /// - Note: The verification excludes all child nodes, since this method only cares about
+        ///     siblings and parents in the tree.
+        ///
         func isLastInTree() -> Bool {
 
             guard let parent = parent else {
@@ -186,6 +191,11 @@ extension Libxml2 {
             return isLastInParent() && parent.isLastInTree()
         }
 
+        /// Checks if the receiver is the last node in a block-level ancestor.
+        ///
+        /// - Note: The verification excludes all child nodes, since this method only cares about
+        ///     siblings and parents in the tree.
+        ///
         func isLastInBlockLevelAncestor() -> Bool {
 
             guard let parent = parent else {
@@ -196,6 +206,10 @@ extension Libxml2 {
                 (parent.isBlockLevelElement() || parent.isLastInBlockLevelAncestor())
         }
 
+        /// Retrieves the right sibling for a node.
+        ///
+        /// - Returns: the right sibling, or `nil` if none exists.
+        ///
         func rightSibling() -> ElementNode? {
 
             guard let parent = parent else {

--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -153,26 +153,74 @@ extension Libxml2 {
             return element.isBlockLevelElement() && element.children.last == self
         }
 
-        func isLastInBlockLevelElement() -> Bool {
+        func isLastInParent() -> Bool {
+
+            guard let parent = parent else {
+                return true
+            }
+
+            // We are filtering empty text nodes from being considered the last node in our
+            // parent node.
+            //
+            let lastMatchingChildInParent = parent.lastChild(matching: { node -> Bool in
+                guard let textNode = node as? TextNode,
+                    textNode.length() == 0 else {
+                        return true
+                }
+
+                return false
+            })
+
+            return self === lastMatchingChildInParent
+        }
+
+        func isLastInTree() -> Bool {
+
+            guard let parent = parent else {
+                return true
+            }
+
+            return isLastInParent() && parent.isLastInTree()
+        }
+
+        func isLastInBlockLevelAncestor() -> Bool {
+
             guard let parent = parent else {
                 return false
             }
 
-            guard !isLastIn(blockLevelElement: parent) else {
-                return true
+            return isLastInParent() &&
+                (parent.isBlockLevelElement() || parent.isLastInBlockLevelAncestor())
+        }
+
+        func rightSibling() -> ElementNode? {
+
+            guard let parent = parent else {
+                return nil
             }
 
             let index = parent.indexOf(childNode: self)
 
-            if let sibling = parent.sibling(rightOf: index) {
-                if let siblingElement = sibling as? ElementNode {
-                    return siblingElement.isBlockLevelElement()
-                } else {
-                    return false
-                }
-            } else {
-                return parent.isLastInBlockLevelElement()
+            guard let sibling = parent.sibling(rightOf: index) else {
+                return nil
             }
+
+            return sibling as? ElementNode
+        }
+
+        // MARK: - Paragraph Separation Logic
+
+        /// Checks if the specified node requires a closing paragraph separator.
+        ///
+        func needsClosingParagraphSeparator() -> Bool {
+
+            if let rightSibling = rightSibling(),
+                rightSibling.isBlockLevelElement() {
+
+                return true
+            }
+
+            return !isLastInTree() && isLastInBlockLevelAncestor()
         }
 
         // MARK: - DOM Modification

--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -153,6 +153,9 @@ extension Libxml2 {
             return element.isBlockLevelElement() && element.children.last == self
         }
 
+        /// Checks if the receiver is the last node in its parent.
+        /// Empty text nodes are filtered to avoid false positives.
+        ///
         func isLastInParent() -> Bool {
 
             guard let parent = parent else {

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -28,6 +28,18 @@ extension Libxml2 {
         override func length() -> Int {
             return contents.characters.count
         }
+
+        // MARK: - Node
+
+        /// Checks if the specified node requires a closing paragraph separator.
+        ///
+        override func needsClosingParagraphSeparator() -> Bool {
+            guard length() > 0 else {
+                return false
+            }
+
+            return super.needsClosingParagraphSeparator()
+        }
         
         // MARK: - Editing: Atomic Operations
         

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -231,6 +231,26 @@ extension Libxml2 {
                 strongSelf.domUndoManager.endUndoGrouping()
             }
         }
+
+        /// We have some special setup we need to take care of before registering undo operations.
+        /// This method takes care of hooking up an undo operation in the client-provided undo
+        /// manager with an undo operation in the DOM undo manager.
+        ///
+        /// Parameters:
+        ///     - task: the task to execute that contains undo operations.
+        ///
+        private func performSyncUndoable(task: @escaping () -> ()) {
+            domQueue.sync { [weak self] in
+
+                guard let strongSelf = self else {
+                    return
+                }
+
+                strongSelf.domUndoManager.beginUndoGrouping()
+                task()
+                strongSelf.domUndoManager.endUndoGrouping()
+            }
+        }
         
         /// Make our private undo manager start observing the parent undo manager.  This means
         /// our private undo manager will basically be connected to the parent one to know when
@@ -366,10 +386,15 @@ extension Libxml2 {
         /// - Parameters:
         ///     - range: the range to remove the style from.
         ///
-        func removeOrderedList(spanning range: NSRange) {
-            performAsyncUndoable { [weak self] in
-                self?.removeOrderedListSynchronously(spanning: range)
+        func removeOrderedList(spanning range: NSRange) -> NSRange {
+
+            var finalRange = range
+
+            performSyncUndoable { [unowned self] in
+                finalRange = self.removeOrderedListSynchronously(spanning: range)
             }
+
+            return finalRange
         }
 
         /// Disables unordered list from the specified range.
@@ -377,10 +402,15 @@ extension Libxml2 {
         /// - Parameters:
         ///     - range: the range to remove the style from.
         ///
-        func removeUnorderedList(spanning range: NSRange) {
-            performAsyncUndoable { [weak self] in
-                self?.removeUnorderedListSynchronously(spanning: range)
+        func removeUnorderedList(spanning range: NSRange) -> NSRange {
+
+            var finalRange = range
+
+            performSyncUndoable { [unowned self] in
+                finalRange = self.removeUnorderedListSynchronously(spanning: range)
             }
+
+            return finalRange
         }
 
         /// Disables blockquote from the specified range.
@@ -459,14 +489,14 @@ extension Libxml2 {
             domEditor.unwrap(range: range, fromElementsNamed: StandardElementType.u.equivalentNames)
         }
 
-        private func removeOrderedListSynchronously(spanning range: NSRange) {
-            domEditor.unwrap(range: range, fromElementsNamed: StandardElementType.li.equivalentNames)
-            domEditor.unwrap(range: range, fromElementsNamed: StandardElementType.ol.equivalentNames)
+        private func removeOrderedListSynchronously(spanning range: NSRange) -> NSRange {
+            let intermediateRange = domEditor.unwrap(range: range, fromElementsNamed: StandardElementType.ol.equivalentNames)
+            return domEditor.unwrap(range: intermediateRange, fromElementsNamed: StandardElementType.li.equivalentNames)
         }
 
-        private func removeUnorderedListSynchronously(spanning range: NSRange) {
-            domEditor.unwrap(range: range, fromElementsNamed: StandardElementType.li.equivalentNames)
-            domEditor.unwrap(range: range, fromElementsNamed: StandardElementType.ul.equivalentNames)
+        private func removeUnorderedListSynchronously(spanning range: NSRange) -> NSRange {
+            let intermediateRange = domEditor.unwrap(range: range, fromElementsNamed: StandardElementType.ul.equivalentNames)
+            return domEditor.unwrap(range: intermediateRange, fromElementsNamed: StandardElementType.li.equivalentNames)
         }
 
         private func removeHeaderSynchronously(headerLevel: Int, spanning range: NSRange) {

--- a/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
+++ b/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
@@ -13,28 +13,31 @@ extension Libxml2 {
         let matchingNames: [String]
         let canMergeLeft: Bool
         let canMergeRight: Bool
+        let endsWithVisualNewline: Bool
 
         // MARK: - CustomReflectable
-        
+
         public override var customMirror: Mirror {
             get {
                 return Mirror(self, children: ["name": name, "attributes": attributes, "matchingNames": matchingNames])
             }
         }
-        
-        init(name: String, childDescriptor: ElementNodeDescriptor? = nil, attributes: [Attribute] = [], matchingNames: [String] = [], canMergeLeft: Bool = true, canMergeRight: Bool = true) {
+
+        init(name: String, childDescriptor: ElementNodeDescriptor? = nil, attributes: [Attribute] = [], matchingNames: [String] = [], canMergeLeft: Bool = true, canMergeRight: Bool = true, endsWithVisualNewline: Bool = false) {
             self.attributes = attributes
             self.canMergeLeft = canMergeLeft
             self.canMergeRight = canMergeRight
             self.childDescriptor = childDescriptor
             self.matchingNames = matchingNames
+            self.endsWithVisualNewline = endsWithVisualNewline
+
             super.init(name: name)
         }
 
-        convenience init(elementType: StandardElementType, childDescriptor: ElementNodeDescriptor? = nil, attributes: [Attribute] = [], canMergeLeft: Bool = true, canMergeRight: Bool = true) {
-            self.init(name: elementType.rawValue, childDescriptor: childDescriptor, attributes: attributes, matchingNames: elementType.equivalentNames, canMergeLeft: canMergeLeft, canMergeRight: canMergeRight)
+        convenience init(elementType: StandardElementType, childDescriptor: ElementNodeDescriptor? = nil, attributes: [Attribute] = [], canMergeLeft: Bool = true, canMergeRight: Bool = true, endsWithVisualNewline: Bool = false) {
+            self.init(name: elementType.rawValue, childDescriptor: childDescriptor, attributes: attributes, matchingNames: elementType.equivalentNames, canMergeLeft: canMergeLeft, canMergeRight: canMergeRight, endsWithVisualNewline: endsWithVisualNewline)
         }
-        
+
         // MARK: - Introspection
         
         func isBlockLevel() -> Bool {

--- a/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
+++ b/Aztec/Classes/Libxml2/Descriptors/ElementNodeDescriptor.swift
@@ -13,7 +13,6 @@ extension Libxml2 {
         let matchingNames: [String]
         let canMergeLeft: Bool
         let canMergeRight: Bool
-        let endsWithVisualNewline: Bool
 
         // MARK: - CustomReflectable
 
@@ -23,19 +22,18 @@ extension Libxml2 {
             }
         }
 
-        init(name: String, childDescriptor: ElementNodeDescriptor? = nil, attributes: [Attribute] = [], matchingNames: [String] = [], canMergeLeft: Bool = true, canMergeRight: Bool = true, endsWithVisualNewline: Bool = false) {
+        init(name: String, childDescriptor: ElementNodeDescriptor? = nil, attributes: [Attribute] = [], matchingNames: [String] = [], canMergeLeft: Bool = true, canMergeRight: Bool = true) {
             self.attributes = attributes
             self.canMergeLeft = canMergeLeft
             self.canMergeRight = canMergeRight
             self.childDescriptor = childDescriptor
             self.matchingNames = matchingNames
-            self.endsWithVisualNewline = endsWithVisualNewline
 
             super.init(name: name)
         }
 
         convenience init(elementType: StandardElementType, childDescriptor: ElementNodeDescriptor? = nil, attributes: [Attribute] = [], canMergeLeft: Bool = true, canMergeRight: Bool = true, endsWithVisualNewline: Bool = false) {
-            self.init(name: elementType.rawValue, childDescriptor: childDescriptor, attributes: attributes, matchingNames: elementType.equivalentNames, canMergeLeft: canMergeLeft, canMergeRight: canMergeRight, endsWithVisualNewline: endsWithVisualNewline)
+            self.init(name: elementType.rawValue, childDescriptor: childDescriptor, attributes: attributes, matchingNames: elementType.equivalentNames, canMergeLeft: canMergeLeft, canMergeRight: canMergeRight)
         }
 
         // MARK: - Introspection

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -753,16 +753,18 @@ open class TextStorage: NSTextStorage {
         let addOrdered = new == .ordered
         let addUnordered = new == .unordered
 
+        var rangeForAddingStyle = range
+
         if removeOrdered {
-            dom.removeOrderedList(spanning: range)
+            rangeForAddingStyle = dom.removeOrderedList(spanning: range)
         } else if removeUnordered {
-            dom.removeUnorderedList(spanning: range)
+            rangeForAddingStyle = dom.removeUnorderedList(spanning: range)
         }
 
         if addOrdered {
-            dom.applyOrderedList(spanning: range, canMergeLeft: canMergeLeft, canMergeRight: canMergeRight)
+            dom.applyOrderedList(spanning: rangeForAddingStyle, canMergeLeft: canMergeLeft, canMergeRight: canMergeRight)
         } else if addUnordered {
-            dom.applyUnorderedList(spanning: range, canMergeLeft: canMergeLeft, canMergeRight: canMergeRight)
+            dom.applyUnorderedList(spanning: rangeForAddingStyle, canMergeLeft: canMergeLeft, canMergeRight: canMergeRight)
         }
     }
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -163,25 +163,23 @@ open class TextStorage: NSTextStorage {
 
         attributedString.enumerateAttribute(NSParagraphStyleAttributeName, in: fullRange, options: []) { (value, subRange, stop) in
 
-            guard let paragraphStyle = value as? ParagraphStyle else {
+            guard value is ParagraphStyle else {
                 return
             }
 
-            if paragraphStyle.textList != nil {
-                var newlineRange = finalString.mutableString.range(of: String(.newline))
+            var newlineRange = finalString.mutableString.range(of: String(.newline))
 
-                while newlineRange.location != NSNotFound {
+            while newlineRange.location != NSNotFound {
 
-                    let originalAttributes = finalString.attributes(at: newlineRange.location, effectiveRange: nil)
+                let originalAttributes = finalString.attributes(at: newlineRange.location, effectiveRange: nil)
 
-                    finalString.replaceCharacters(in: newlineRange, with: NSAttributedString(.paragraphSeparator, attributes: originalAttributes))
+                finalString.replaceCharacters(in: newlineRange, with: NSAttributedString(.paragraphSeparator, attributes: originalAttributes))
 
-                    let nextLocation = newlineRange.location + newlineRange.length
-                    let nextLength = subRange.length - nextLocation
-                    let nextRange = NSRange(location: nextLocation, length: nextLength)
+                let nextLocation = newlineRange.location + newlineRange.length
+                let nextLength = subRange.length - nextLocation
+                let nextRange = NSRange(location: nextLocation, length: nextLength)
 
-                    newlineRange = finalString.mutableString.range(of: String(.newline), options: [], range: nextRange)
-                }
+                newlineRange = finalString.mutableString.range(of: String(.newline), options: [], range: nextRange)
             }
         }
 
@@ -254,8 +252,18 @@ open class TextStorage: NSTextStorage {
 
     // MARK: - Overriden Methods
 
+    /// Retrieves the attributes for the requested character location.
+    ///
+    /// - Important: please note that this method returns the style at the character location, and
+    ///     NOT at the caret location.  For N characters we always have N+1 character locations.
+    ///
     override open func attributes(at location: Int, effectiveRange range: NSRangePointer?) -> [String : Any] {
-        return textStore.length == 0 ? [:] : textStore.attributes(at: location, effectiveRange: range)
+
+        guard textStore.length > 0 else {
+            return [:]
+        }
+
+        return textStore.attributes(at: location, effectiveRange: range)
     }
  
     override open func replaceCharacters(in range: NSRange, with str: String) {
@@ -269,7 +277,7 @@ open class TextStorage: NSTextStorage {
         detectAttachmentRemoved(in: range)
         textStore.replaceCharacters(in: range, with: str)
 
-        edited(.editedCharacters, range: range, changeInLength: string.characters.count - range.length)
+        edited(.editedCharacters, range: range, changeInLength: str.characters.count - range.length)
         
         endEditing()
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -571,7 +571,7 @@ open class TextView: UITextView {
     ///     - range: The NSRange to edit.
     ///
     open func togglePre(range: NSRange) {
-        ensureInsertionOfEndOfLineForEmptyParagraphAtEndOfFile()
+        ensureInsertionOfEndOfLineForEmptyParagraphAtEndOfFile(forApplicationRange: range)
 
         let formatter = PreFormatter(placeholderAttributes: typingAttributes)
         toggle(formatter: formatter, atRange: range)
@@ -588,7 +588,7 @@ open class TextView: UITextView {
     ///     - range: The NSRange to edit.
     ///
     open func toggleBlockquote(range: NSRange) {
-        ensureInsertionOfEndOfLineForEmptyParagraphAtEndOfFile()
+        ensureInsertionOfEndOfLineForEmptyParagraphAtEndOfFile(forApplicationRange: range)
 
         let formatter = BlockquoteFormatter(placeholderAttributes: typingAttributes)
         toggle(formatter: formatter, atRange: range)
@@ -601,7 +601,7 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleOrderedList(range: NSRange) {
-        ensureInsertionOfEndOfLineForEmptyParagraphAtEndOfFile()
+        ensureInsertionOfEndOfLineForEmptyParagraphAtEndOfFile(forApplicationRange: range)
 
         let formatter = TextListFormatter(style: .ordered, placeholderAttributes: typingAttributes)
         toggle(formatter: formatter, atRange: range)
@@ -615,7 +615,7 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleUnorderedList(range: NSRange) {
-        ensureInsertionOfEndOfLineForEmptyParagraphAtEndOfFile()
+        ensureInsertionOfEndOfLineForEmptyParagraphAtEndOfFile(forApplicationRange: range)
 
         let formatter = TextListFormatter(style: .unordered, placeholderAttributes: typingAttributes)
         toggle(formatter: formatter, atRange: range)
@@ -700,15 +700,18 @@ open class TextView: UITextView {
     }
 
 
-    /// Inserts an end-of-line character whenever we're at end-of-file, in an
+    /// Inserts an end-of-line character whenever the provided range is at end-of-file, in an
     /// empty paragraph. This is useful when attempting to apply a paragraph-level style at EOF,
     /// since it won't be possible without the paragraph having any characters.
     ///
     /// Call this method before applying the formatter.
     ///
-    private func ensureInsertionOfEndOfLineForEmptyParagraphAtEndOfFile() {
+    /// - Parameters:
+    ///     - range: the range where the formatter will be applied.
+    ///
+    private func ensureInsertionOfEndOfLineForEmptyParagraphAtEndOfFile(forApplicationRange range: NSRange) {
 
-        guard let selectedRangeForSwift = textStorage.string.nsRange(fromUTF16NSRange: selectedRange) else {
+        guard let selectedRangeForSwift = textStorage.string.nsRange(fromUTF16NSRange: range) else {
             assertionFailure("This should never happen.  Review the logic!")
             return
         }

--- a/AztecTests/Formatters/BlockquoteFormatterTests.swift
+++ b/AztecTests/Formatters/BlockquoteFormatterTests.swift
@@ -69,8 +69,12 @@ class BlockquoteFormatterTests: XCTestCase {
 
         let formatter = BlockquoteFormatter()
         let original = textView.storage.copy() as! NSAttributedString
-        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
-        formatter.toggle(in: storage, at: NSUnionRange(paragraphs[0], paragraphs[1]))
+
+        let toggleRange = NSUnionRange(paragraphs[0], paragraphs[1])
+
+        formatter.toggle(in: storage, at: toggleRange)
+        formatter.toggle(in: storage, at: toggleRange)
+
         XCTAssertTrue(original.isEqual(to: textView.storage))
     }
 

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -164,7 +164,7 @@ class TextStorageTests: XCTestCase
         XCTAssertEqual(html, "<img src=\"https://wordpress.com\" class=\"alignleft size-medium\">")
     }
 
-    func testBlockquoteToggle() {
+    func testBlockquoteToggle1() {
         let mockDelegate = MockAttachmentsDelegate()
         let storage = TextStorage()
         storage.attachmentsDelegate = mockDelegate
@@ -176,11 +176,28 @@ class TextStorageTests: XCTestCase
 
         XCTAssertEqual(html, "<blockquote>Apply a blockquote</blockquote>")
 
-        storage.toggle(formatter:blockquoteFormatter, at: storage.rangeOfEntireString)
+        storage.toggle(formatter: blockquoteFormatter, at: storage.rangeOfEntireString)
 
         html = storage.getHTML()
 
         XCTAssertEqual(html, "Apply a blockquote")
+    }
+
+    func testBlockquoteToggle2() {
+        let mockDelegate = MockAttachmentsDelegate()
+        let storage = TextStorage()
+        storage.attachmentsDelegate = mockDelegate
+        storage.append(NSAttributedString(string: "Hello 🌎!\nApply a blockquote!"))
+        let blockquoteFormatter = BlockquoteFormatter()
+
+        let range = NSRange(location: 9, length: 19)
+        let utf16Range = storage.string.utf16NSRange(from: range)
+
+        storage.toggle(formatter: blockquoteFormatter, at: utf16Range)
+
+        let html = storage.getHTML()
+
+        XCTAssertEqual(html, "Hello &#x1F30E;!<br><blockquote>Apply a blockquote!</blockquote>")
     }
 
     func testLinkInsert() {
@@ -222,6 +239,36 @@ class TextStorageTests: XCTestCase
         html = storage.getHTML()
 
         XCTAssertEqual(html, "Apply a header")
+    }
+
+    /// Tests toggling blockquote three times.
+    ///
+    func testToggleBlockquoteThrice() {
+        let storage = TextStorage()
+        let mockDelegate = MockAttachmentsDelegate()
+        storage.attachmentsDelegate = mockDelegate
+
+        storage.append(NSAttributedString(string: "Apply a blockquote"))
+
+        let formatter = BlockquoteFormatter()
+
+        storage.toggle(formatter: formatter, at: storage.rangeOfEntireString)
+
+        var html = storage.getHTML()
+
+        XCTAssertEqual(html, "<blockquote>Apply a blockquote</blockquote>")
+
+        storage.toggle(formatter: formatter, at: storage.rangeOfEntireString)
+
+        html = storage.getHTML()
+
+        XCTAssertEqual(html, "Apply a blockquote<br>")
+
+        storage.toggle(formatter: formatter, at: storage.rangeOfEntireString)
+
+        html = storage.getHTML()
+
+        XCTAssertEqual(html, "<blockquote>Apply a blockquote</blockquote>")
     }
 
     /// This test ensures that when applying a header style on top of another style the replacement occurs correctly.

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -241,36 +241,6 @@ class TextStorageTests: XCTestCase
         XCTAssertEqual(html, "Apply a header")
     }
 
-    /// Tests toggling blockquote three times.
-    ///
-    func testToggleBlockquoteThrice() {
-        let storage = TextStorage()
-        let mockDelegate = MockAttachmentsDelegate()
-        storage.attachmentsDelegate = mockDelegate
-
-        storage.append(NSAttributedString(string: "Apply a blockquote"))
-
-        let formatter = BlockquoteFormatter()
-
-        storage.toggle(formatter: formatter, at: storage.rangeOfEntireString)
-
-        var html = storage.getHTML()
-
-        XCTAssertEqual(html, "<blockquote>Apply a blockquote</blockquote>")
-
-        storage.toggle(formatter: formatter, at: storage.rangeOfEntireString)
-
-        html = storage.getHTML()
-
-        XCTAssertEqual(html, "Apply a blockquote<br>")
-
-        storage.toggle(formatter: formatter, at: storage.rangeOfEntireString)
-
-        html = storage.getHTML()
-
-        XCTAssertEqual(html, "<blockquote>Apply a blockquote</blockquote>")
-    }
-
     /// This test ensures that when applying a header style on top of another style the replacement occurs correctly.
     ///
     func testSwitchHeaderStyleToggle() {

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -602,14 +602,14 @@ class TextViewTests: XCTestCase {
     /// Tests that deleting a newline works at the end of text with paragraph with header before works.
     ///
     /// Input:
-    ///     - Initial HTML: "<h1>Header</h1>\n"
+    ///     - Initial HTML: "<h1>Header</h1><br>"
     ///     - Deletion range: (loc: 5, len 1)
     ///
     /// Output:
     ///     - Final HTML: "<h1>Header</h1>"
     ///
     func testDeleteNewlineAtEndOfText() {
-        let html = "<h1>Header</h1>\n"
+        let html = "<h1>Header</h1><br>"
         let textView = createTextView(withHTML: html)
 
         let range = NSRange(location: textView.text.characters.count, length:0)

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -717,7 +717,7 @@ class TextViewTests: XCTestCase {
         textView.insertText("2")
         textView.deleteBackward()
 
-        XCTAssertEqual(textView.getHTML(), "<h1>Header<br></h1>1")
+        XCTAssertEqual(textView.getHTML(), "<h1>Header</h1>1")
     }
 
     // MARK: - Unicode tests
@@ -1142,7 +1142,7 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
         textView.insertText(String(.newline))
 
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.paragraphSeparator))
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.paragraphSeparator) + String(.paragraphSeparator))
     }
 
 
@@ -1328,7 +1328,7 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
         textView.insertText(String(.newline))
         
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.paragraphSeparator))
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.paragraphSeparator) + String(.paragraphSeparator))
     }
 }
 

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -403,15 +403,23 @@ class TextViewTests: XCTestCase {
         textView.insertText("\n")
     }
 
+    /// Tests that a visual newline is not added at EoF
+    ///
+    func testNewlineNotAddedAtEof() {
+        let textView = createTextView(withHTML: "<p>Testing <b>bold</b> newlines</p>")
+
+        XCTAssertEqual(textView.text, "Testing bold newlines")
+    }
+
     /// Tests that the visual newline is shown at the correct position.
     ///
     /// Added to avoid regressions to the bug reported here:
     /// https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/387
     ///
     func testNewlineRenderedAtTheCorrectPosition() {
-        let textView = createTextView(withHTML: "<p>Testing <b>bold</b> newlines</p>")
+        let textView = createTextView(withHTML: "<p>Testing <b>bold</b> newlines</p>Hey!")
 
-        XCTAssertEqual(textView.text, "Testing bold newlines\(String(.paragraphSeparator))")
+        XCTAssertEqual(textView.text, "Testing bold newlines\(String(.paragraphSeparator))Hey!")
     }
 
 
@@ -429,6 +437,8 @@ class TextViewTests: XCTestCase {
     func testDeleteNewline() {
 
         let textView = createTextView(withHTML: "<p>Hello</p><p>World!</p>")
+
+        print(textView.storage.getHTML())
 
         let rangeStart = textView.position(from: textView.beginningOfDocument, offset: 5)!
         let rangeEnd = textView.position(from: rangeStart, offset: 1)!


### PR DESCRIPTION
### Description:

This PR fixes #456.

Lists were losing some of their formatting when combined with multi-line selection and newlines in general.

This PR solves those issues.

### Testing:

**Test 1:**

1. Launch the empty editor.
2. Add an ordered list with 3 lines of text or more.
3. Select part of the list.
4. Convert to unordered list.
5. Switch to HTML and back.  Make sure everything is OK.

**Additional testing:**

Play with lists and try to break them in visual mode.