### PR TITLE
Removes the attachment attribute style from typingAttributes.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -287,6 +287,9 @@ open class TextView: UITextView {
         // For some reason the text view is allowing the attachment style to be set in
         // typingAttributes.  That's simply not acceptable.
         //
+        // This was causing the following issue:
+        // https://github.com/wordpress-mobile/AztecEditor-iOS/issues/462
+        //
         typingAttributes[NSAttachmentAttributeName] = nil
 
         guard !ensureRemovalOfParagraphAttributesWhenPressingEnterInAnEmptyParagraph(input: text) else {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -280,10 +280,14 @@ open class TextView: UITextView {
         pasteboard.items[0][NSAttributedString.pastesboardUTI] = data
     }
 
-
     // MARK: - Intercept keyboard operations
 
     open override func insertText(_ text: String) {
+
+        // For some reason the text view is allowing the attachment style to be set in
+        // typingAttributes.  That's simply not acceptable.
+        //
+        typingAttributes[NSAttachmentAttributeName] = nil
 
         guard !ensureRemovalOfParagraphAttributesWhenPressingEnterInAnEmptyParagraph(input: text) else {
             return


### PR DESCRIPTION
Fixes #462 

To test:

Run the unit tests.
Do some random editing in the editor, involving attachments.
