### PR TITLE
Fixes a crashing bug related to unknown HTML.

### DIFF
--- a/Aztec/Classes/Extensions/Character+Name.swift
+++ b/Aztec/Classes/Extensions/Character+Name.swift
@@ -1,10 +1,12 @@
 import Foundation
+import UIKit
 
 extension Character {
-    
+
     enum Name: Character {
         case lineSeparator = "\u{2028}"
         case newline = "\n"
+        case objectReplacement = "\u{FFFC}"
         case paragraphSeparator = "\u{2029}"
         case space = " "
         case zeroWidthSpace = "\u{200B}"

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -66,10 +66,6 @@ extension Libxml2 {
         /// Node length.  Calculated by adding the length of all child nodes.
         ///
         override func length() -> Int {
-            guard isSupportedByEditor() else {
-                return defaultLengthForUnsupportedElements
-            }
-
             return text().characters.count
         }
 
@@ -817,7 +813,11 @@ extension Libxml2 {
         }
         
         override func text() -> String {
-            
+
+            guard isSupportedByEditor() else {
+                return String(.objectReplacement)
+            }
+
             if let nodeType = standardName,
                 let implicitRepresentation = nodeType.implicitRepresentation() {
                 

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -66,9 +66,9 @@ extension Libxml2 {
         private lazy var domEditor: DOMEditor = {
             return DOMEditor(with: self.rootNode)
         }()
-        
+
         // MARK: - Init & deinit
-        
+
         deinit {
             stopObservingParentUndoManager()
         }
@@ -89,7 +89,7 @@ extension Libxml2 {
 
             return result
         }
-        
+
         // MARK: - Settings & Getting HTML
         
         /// Gets the HTML representation of the DOM.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -284,6 +284,14 @@ open class TextView: UITextView {
     // MARK: - Intercept keyboard operations
 
     open override func insertText(_ text: String) {
+        
+        // For some reason the text view is allowing the attachment style to be set in
+        // typingAttributes.  That's simply not acceptable.
+        //
+        // This was causing the following issue:
+        // https://github.com/wordpress-mobile/AztecEditor-iOS/issues/462
+        //
+        typingAttributes[NSAttachmentAttributeName] = nil
 
         guard !ensureRemovalOfParagraphAttributesWhenPressingEnterInAnEmptyParagraph(input: text) else {
             return


### PR DESCRIPTION
### Description:

Fixes a crash that was triggered by editing after an unknown tag, at EoF.

Fixes 465 - I can't REF the issue (there seem to be GitHub Issues)

### Testing:

**Test 1:**

Run the unit tests and make sure none was broken.

**Test 2:**

1. Launch the empty editor
2. Switch to HTML mode, and type: `<asd>`
3. Switch to Visual mode, move the care to the End-of-file position.
4. Type anything.

Make sure the app doesn't crash.