### PR TITLE
Adds a pre-processor for shortcodes

### DIFF
--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - String NSRange and Location convertion Extensions
 //
-extension String
+public extension String
 {
     /// Converts a UTF16 NSRange into a Swift String NSRange for this string.
     ///

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		E63EF92B1D36A60B00B5BA4B /* EditorDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63EF92A1D36A60B00B5BA4B /* EditorDemoController.swift */; };
 		FF6691C21E76CF9200C6A703 /* OptionsTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */; };
 		FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */; };
+		FFD06EA41EC3C5350072AD85 /* WordPressShortcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD06EA31EC3C5350072AD85 /* WordPressShortcode.swift */; };
+		FFD06EA71EC474500072AD85 /* ShortCodeParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD06EA61EC474500072AD85 /* ShortCodeParserTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -115,6 +117,8 @@
 		E63EF92A1D36A60B00B5BA4B /* EditorDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorDemoController.swift; sourceTree = "<group>"; };
 		FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionsTableView.swift; sourceTree = "<group>"; };
 		FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AttachmentDetailsViewController.storyboard; sourceTree = "<group>"; };
+		FFD06EA31EC3C5350072AD85 /* WordPressShortcode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressShortcode.swift; sourceTree = "<group>"; };
+		FFD06EA61EC474500072AD85 /* ShortCodeParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortCodeParserTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -214,6 +218,7 @@
 				59280F271D47CAF40083FB59 /* SampleContent */,
 				607FACD31AFB9204008FA782 /* Supporting Files */,
 				FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */,
+				FFD06EA31EC3C5350072AD85 /* WordPressShortcode.swift */,
 			);
 			name = "Example for WordPress-Aztec-iOS";
 			path = Example;
@@ -231,6 +236,7 @@
 			isa = PBXGroup;
 			children = (
 				607FACE91AFB9204008FA782 /* Supporting Files */,
+				FFD06EA61EC474500072AD85 /* ShortCodeParserTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -340,7 +346,7 @@
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0830;
 						ProvisioningStyle = Manual;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
@@ -430,6 +436,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				599F25701D8BCF57002871D6 /* AppDelegate.swift in Sources */,
+				FFD06EA41EC3C5350072AD85 /* WordPressShortcode.swift in Sources */,
 				59D2873B1D8C599B00B99C80 /* AttachmentDetailsViewController.swift in Sources */,
 				FF6691C21E76CF9200C6A703 /* OptionsTableView.swift in Sources */,
 				B570B1CC1E82D343008CF41E /* CommentAttachmentRenderer.swift in Sources */,
@@ -444,6 +451,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FFD06EA71EC474500072AD85 /* ShortCodeParserTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -634,6 +642,8 @@
 		607FACF31AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -643,19 +653,24 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wordpress.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AztecExample.app/AztecExample";
 			};
 			name = Debug;
 		};
 		607FACF41AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wordpress.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AztecExample.app/AztecExample";
 			};
 			name = Release;
 		};
@@ -793,12 +808,15 @@
 		F111A10F1DA7E77500294FD3 /* Profiling */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wordpress.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AztecExample.app/AztecExample";
 			};
 			name = Profiling;
 		};
@@ -876,6 +894,8 @@
 		F1882B681D9E0F55000B48D6 /* Release-Alpha */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -885,7 +905,9 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wordpress.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AztecExample.app/AztecExample";
 			};
 			name = "Release-Alpha";
 		};

--- a/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
+++ b/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:../Aztec.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "607FACE41AFB9204008FA782"
+               BuildableName = "AztecExample-Tests.xctest"
+               BlueprintName = "AztecExample-Tests"
+               ReferencedContainer = "container:AztecExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -100,7 +100,7 @@ class EditorDemoController: UIViewController {
                 htmlTextView.text = richTextView.getHTML()
                 htmlTextView.becomeFirstResponder()
             case .richText:
-                richTextView.setHTML(htmlTextView.text)
+                setHTML(htmlTextView.text)                
                 richTextView.becomeFirstResponder()
             }
 
@@ -114,6 +114,16 @@ class EditorDemoController: UIViewController {
     fileprivate var formatBarAnimatedPeek = false
 
     var loadSampleHTML = false
+
+    fileprivate var shortcodeProcessors = [ShortcodeProcessor]()
+
+    func setHTML(_ html: String) {
+        var processedHTML = html
+        for shortcodeProcessor in shortcodeProcessors {
+            processedHTML = shortcodeProcessor.process(text: processedHTML)
+        }
+        richTextView.setHTML(processedHTML)
+    }
 
 
     // MARK: - Lifecycle Methods
@@ -138,6 +148,7 @@ class EditorDemoController: UIViewController {
         view.addSubview(separatorView)
         configureConstraints()
         registerAttachmentImageProviders()
+        registerShortcodeProcessors()
 
         let html: String
 
@@ -147,7 +158,7 @@ class EditorDemoController: UIViewController {
             html = ""
         }
 
-        richTextView.setHTML(html)
+        setHTML(html)
 
         MediaAttachment.appearance.progressColor = UIColor.blue
         MediaAttachment.appearance.progressBackgroundColor = UIColor.lightGray
@@ -270,6 +281,25 @@ class EditorDemoController: UIViewController {
         for provider in providers {
             richTextView.registerAttachmentImageProvider(provider)
         }
+    }
+
+    private func registerShortcodeProcessors() {
+        let videoPressProcessor = ShortcodeProcessor(tag:"wpvideo", replacer: { (shortcode) in
+            var html = "<video "
+            if let src = shortcode.attributes.unamedAttributes.first {
+                html += "source=\"videopress://\(src)\" "
+            }
+            if let width = shortcode.attributes.namedAttributes["w"] {
+                html += "width=\(width) "
+            }
+            if let height = shortcode.attributes.namedAttributes["h"] {
+                html += "height=\(height) "
+            }
+            html += "\\>"
+            return html
+        })
+        
+        shortcodeProcessors.append(videoPressProcessor)
     }
 
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -287,7 +287,7 @@ class EditorDemoController: UIViewController {
         let videoPressProcessor = ShortcodeProcessor(tag:"wpvideo", replacer: { (shortcode) in
             var html = "<video "
             if let src = shortcode.attributes.unamedAttributes.first {
-                html += "source=\"videopress://\(src)\" "
+                html += "src=\"videopress://\(src)\" "
             }
             if let width = shortcode.attributes.namedAttributes["w"] {
                 html += "width=\(width) "
@@ -298,8 +298,21 @@ class EditorDemoController: UIViewController {
             html += "\\>"
             return html
         })
+
+        let wordPressVideoProcessor = ShortcodeProcessor(tag:"video", replacer: { (shortcode) in
+            var html = "<video "
+            if let src = shortcode.attributes.namedAttributes["src"] {
+                html += "src=\"\(src)\" "
+            }
+            if let poster = shortcode.attributes.namedAttributes["poster"] {
+                html += "poster=\"\(poster)\" "
+            }
+            html += "\\>"
+            return html
+        })
         
         shortcodeProcessors.append(videoPressProcessor)
+        shortcodeProcessors.append(wordPressVideoProcessor)
     }
 
 

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -93,6 +93,7 @@ Video:<br/><br/>
 
 <video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://i2.wp.com/videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg?ssl=1" alt="Video about bunnies" />
 <br/>
+[wpvideo XYRAZVF]
 </p>
 
 <p>

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -93,7 +93,8 @@ Video:<br/><br/>
 
 <video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://i2.wp.com/videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg?ssl=1" alt="Video about bunnies" />
 <br/>
-[wpvideo XYRAZVF]
+Video with Shortcode:<br/><br/>
+[video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://i2.wp.com/videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg?ssl=1" /]
 </p>
 
 <p>

--- a/Example/Example/WordPressShortcode.swift
+++ b/Example/Example/WordPressShortcode.swift
@@ -1,0 +1,230 @@
+import Foundation
+
+
+/// Struct to represent a WordPress shortcode
+/// More details here: https://codex.wordpress.org/Shortcode and here: https://en.support.wordpress.com/shortcodes/
+///
+public struct Shortcode {
+    public enum TagType {
+        case selfClosing
+        case closed
+        case single
+    }
+
+    public let tag: String
+    public let attributes: ShortcodeAttributes
+    public let type: TagType
+    public let content: String?
+}
+
+/// Struct to represent the attributes of a shortcode
+///
+public struct ShortcodeAttributes {
+
+
+    /// Attributes that have a form key=value or key="value" or key='value'
+    let namedAttributes: [String: String]
+
+    /// Attributes that have a form value "value"
+    let unamedAttributes: [String]
+}
+
+
+/// A class that processes a string and replace the desiganted shortcode for the replacement provided strings
+///
+open class ShortcodeProcessor {
+
+    public typealias ReplaceMethod = (Shortcode) -> String
+
+    let tag: String
+
+    let replacer: ReplaceMethod
+
+    /// Regular expression to detect attributes
+    /// Capture groups:
+    ///
+    /// 1. An extra `[` to allow for escaping shortcodes with double `[[]]`
+    /// 2. The shortcode name
+    /// 3. The shortcode argument list
+    /// 4. The self closing `/`
+    /// 5. The content of a shortcode when it wraps some content.
+    /// 6. The closing tag.
+    /// 7. An extra `]` to allow for escaping shortcodes with double `[[]]`
+    ///
+    lazy var regex: NSRegularExpression = {
+        let pattern = "\\[(\\[?)(\(self.tag))(?![\\w-])([^\\]\\/]*(?:\\/(?!\\])[^\\]\\/]*)*?)(?:(\\/)\\]|\\](?:([^\\[]*(?:\\[(?!\\/\\2\\])[^\\[]*)*)(\\[\\/\\2\\]))?)(\\]?)"
+        let regex = try! NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+        return regex
+    }()
+
+    enum CaptureGroups: Int {
+        case all = 0
+        case extraOpen
+        case name
+        case arguments
+        case selfClosingElement
+        case content
+        case closingTag
+        case extraClose
+    }
+
+    public init(tag: String, replacer: @escaping ReplaceMethod) {
+        self.tag = tag
+        self.replacer = replacer
+    }
+
+    public func process(text: String) -> String {
+        return replace(in: text, with: replacer)
+    }
+
+    /// Replace in text all the matches of the Processor with the string provided by the replacer
+    ///
+    /// - Parameters:
+    ///   - text: the text to process
+    ///   - replacer: the callback function that is invoked each time a shortcode is found to obtain the replacement
+    /// - Returns: the new text after the processing is applied
+    ///
+    func replace(in text: String, with replacer: ReplaceMethod) -> String {
+        let matches = regex.matches(in: text, options: [], range: text.nsRange(from: text.startIndex..<text.endIndex))
+        var replacements = [(NSRange, String)]()
+        for match in matches {
+            guard match.numberOfRanges == 8 else {
+                continue
+            }
+            var attributes = ShortcodeAttributes(namedAttributes: [:], unamedAttributes: [])
+            if let attributesText = match.captureGroup(in:CaptureGroups.arguments.rawValue, text: text) {
+                attributes = ShortcodeAttributesParser.makeAttributes(in: attributesText)
+            }
+
+            var type: Shortcode.TagType = .single
+            if match.captureGroup(in:CaptureGroups.selfClosingElement.rawValue, text: text) != nil {
+                type = .selfClosing
+            } else if match.captureGroup(in:CaptureGroups.closingTag.rawValue, text: text) != nil {
+                type = .closed
+            }
+
+            let content: String? = match.captureGroup(in:CaptureGroups.content.rawValue, text: text)
+
+            let shortcode = Shortcode(tag: tag, attributes: attributes, type: type, content: content)
+
+            let replacement = replacer(shortcode)
+            replacements.append((match.range, replacement))
+        }
+        let resultText = replace(matches: replacements, in: text)
+        return resultText
+    }
+
+    /// Replaces in text all the matches found in the range with the provided string
+    ///
+    /// - Parameters:
+    ///   - matches: an array with tupples that designated the range of the match and the replacement string to apply
+    ///   - text: the original text to where the replacement will be done
+    /// - Returns: the new string with the replacements done
+    ///
+    func replace(matches: [(NSRange, String)], in text: String) -> String {
+        let mutableString = NSMutableString(string: text)
+        var offset = 0
+        for (range, replacement) in matches {
+            let lengthBefore = mutableString.length
+            let offsetRange = NSRange(location: range.location + offset, length: range.length)
+            mutableString.replaceCharacters(in: offsetRange, with: replacement)
+            let lengthAfter = mutableString.length
+            offset += (lengthAfter - lengthBefore)
+        }
+        return mutableString as String
+    }
+}
+
+
+/// A struct that parses attributes inside a shortcode and return the corresponding attributes object
+///
+public struct ShortcodeAttributesParser {
+
+    enum CaptureGroups: Int {
+        case all = 0
+        case nameInDoubleQuotes
+        case valueInDoubleQuotes
+        case nameInSingleQuotes
+        case valueInSingleQuotes
+        case nameUnquoted
+        case valueUnquoted
+        case justValueQuoted
+        case justValueUnquoted
+    }
+
+    /// Regular expression to detect attributes
+    /// This regular expression is reused from `shortcode_parse_atts()`
+    /// in `wp-includes/shortcodes.php`.
+    ///
+    /// Capture groups:
+    ///
+    /// 1. An attribute name, that corresponds to...
+    /// 2. a value in double quotes.
+    /// 3. An attribute name, that corresponds to...
+    /// 4. a value in single quotes.
+    /// 5. An attribute name, that corresponds to...
+    /// 6. an unquoted value.
+    /// 7. A numeric attribute in double quotes.
+    /// 8. An unquoted numeric attribute.
+    ///
+    static var attributesRegex: NSRegularExpression = {
+        let attributesPattern: String = "(\\w+)\\s*=\\s*\"([^\"]*)\"(?:\\s|$)|(\\w+)\\s*=\\s*'([^']*)'(?:\\s|$)|(\\w+)\\s*=\\s*([^\\s'\"]+)(?:\\s|$)|\"([^\"]*)\"(?:\\s|$)|(\\S+)(?:\\s|$)"
+        return try! NSRegularExpression(pattern: attributesPattern, options: .caseInsensitive)
+    }()
+
+    /// Parses the attributes from a string to the object
+    ///
+    /// - Parameter text: the text to where to find the attributes
+    /// - Returns: the ShortcodeAttributes parsed from the text
+    ///
+    static func makeAttributes(in text:String) -> ShortcodeAttributes {
+        var namedAttributes = [String: String]()
+        var unamedAttributes = [String]()
+
+        let attributesMatches = ShortcodeAttributesParser.attributesRegex.matches(in: text, options: [], range: text.nsRange(from: text.startIndex..<text.endIndex))
+        for attributeMatch in attributesMatches {
+            if let key = attributeMatch.captureGroup(in: CaptureGroups.nameInDoubleQuotes.rawValue, text: text),
+                let value = attributeMatch.captureGroup(in: CaptureGroups.valueInDoubleQuotes.rawValue, text: text) {
+                namedAttributes[key] = value
+            } else if let key = attributeMatch.captureGroup(in: CaptureGroups.nameInSingleQuotes.rawValue, text: text),
+                let value = attributeMatch.captureGroup(in: CaptureGroups.valueInSingleQuotes.rawValue, text: text) {
+                namedAttributes[key] = value
+            } else if let key = attributeMatch.captureGroup(in: CaptureGroups.nameUnquoted.rawValue, text: text),
+                let value = attributeMatch.captureGroup(in: CaptureGroups.valueUnquoted.rawValue, text: text) {
+                namedAttributes[key] = value
+            } else if let value = attributeMatch.captureGroup(in: CaptureGroups.justValueQuoted.rawValue, text: text) {
+                unamedAttributes.append(value)
+            } else if let value = attributeMatch.captureGroup(in: CaptureGroups.justValueUnquoted.rawValue, text: text) {
+                unamedAttributes.append(value)
+            }
+        }
+        return ShortcodeAttributes(namedAttributes: namedAttributes, unamedAttributes: unamedAttributes)
+    }
+
+}
+
+extension NSTextCheckingResult {
+
+    /// Returns the match for the corresponding capture group position in a text
+    ///
+    /// - Parameters:
+    ///   - position: the capture group position
+    ///   - text: the string where the match was detected
+    /// - Returns: the string with the captured group text
+    ///
+    func captureGroup(in position: Int, text: String) -> String? {
+        guard position < numberOfRanges else {
+            return nil
+        }
+
+        let nsrange = rangeAt(position)
+
+        guard nsrange.location != NSNotFound else {
+            return nil
+        }
+
+        let range = text.range(from: nsrange)
+        let captureGroup = text.substring(with: range)
+        return captureGroup
+    }
+}

--- a/Example/Tests/ShortCodeParserTests.swift
+++ b/Example/Tests/ShortCodeParserTests.swift
@@ -15,7 +15,7 @@ class ShortCodeParserTests: XCTestCase {
         let shortCodeParser = ShortcodeProcessor(tag:"wpvideo", replacer:{ (shortcode) in
             var html = "<video "
             if let src = shortcode.attributes.unamedAttributes.first {
-                html += "source=\"videopress://\(src)\" "
+                html += "src=\"videopress://\(src)\" "
             }
             if let width = shortcode.attributes.namedAttributes["w"] {
                 html += "width=\(width) "
@@ -28,7 +28,7 @@ class ShortCodeParserTests: XCTestCase {
         })
         let sampleText = "[wpvideo OcobLTqC w=640 h=400 autoplay=true html5only=true] Some Text [wpvideo OcobLTqC w=640 h=400 autoplay=true html5only=true]"
         let parsedText = shortCodeParser.process(text: sampleText)
-        XCTAssertEqual(parsedText, "<video source=\"videopress://OcobLTqC\" width=640 height=400 \\> Some Text <video source=\"videopress://OcobLTqC\" width=640 height=400 \\>")
+        XCTAssertEqual(parsedText, "<video src=\"videopress://OcobLTqC\" width=640 height=400 \\> Some Text <video src=\"videopress://OcobLTqC\" width=640 height=400 \\>")
     }
 
     func testParserOfWordPressVideoCode() {

--- a/Example/Tests/ShortCodeParserTests.swift
+++ b/Example/Tests/ShortCodeParserTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import AztecExample
+
+class ShortCodeParserTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testParserOfVideoPressCode() {
+        let shortCodeParser = ShortcodeProcessor(tag:"wpvideo", replacer:{ (shortcode) in
+            var html = "<video "
+            if let src = shortcode.attributes.unamedAttributes.first {
+                html += "source=\"videopress://\(src)\" "
+            }
+            if let width = shortcode.attributes.namedAttributes["w"] {
+                html += "width=\(width) "
+            }
+            if let height = shortcode.attributes.namedAttributes["h"] {
+                html += "height=\(height) "
+            }
+            html += "\\>"
+            return html
+        })
+        let sampleText = "[wpvideo OcobLTqC w=640 h=400 autoplay=true html5only=true] Some Text [wpvideo OcobLTqC w=640 h=400 autoplay=true html5only=true]"
+        let parsedText = shortCodeParser.process(text: sampleText)
+        XCTAssertEqual(parsedText, "<video source=\"videopress://OcobLTqC\" width=640 height=400 \\> Some Text <video source=\"videopress://OcobLTqC\" width=640 height=400 \\>")
+    }
+
+    func testParserOfWordPressVideoCode() {
+        let shortCodeParser = ShortcodeProcessor(tag:"video", replacer: { (shortcode) in
+            var html = "<video "
+            if let src = shortcode.attributes.namedAttributes["src"] {
+                html += "src=\"\(src)\" "
+            }
+            html += "\\>"
+            return html
+        })
+        let sampleText = "[video src=\"video-source.mp4\"]"
+        let parsedText = shortCodeParser.process(text: sampleText)
+        XCTAssertEqual(parsedText, "<video src=\"video-source.mp4\" \\>")
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}


### PR DESCRIPTION
Refs #115

This PR is part I of tackling the parsing of shortcodes. 
At the moment it only tackles the parsing and pre-processing of shortcode and the transformation to html. It not tackles the issue of going back from the html to shortcode, that will probably be easier to implement after we have our DOM serializer.

On the example code you can see example of processing of the `[wpvideo]` and `[video]` shortcodes, but the infrastructure is one in a way that any WordPress shortcode can be now implemented.

I have plans to make this architecture more generic and support any kind of pre-processing not limited to shortcodes. So for example we can match URL from youtube,vimeo or and replace it with the corresponding video player code.

But it was already big PR and with enough functionality that it can be first step.

To test:
 - Start the demo app
 - Scroll to the end and check if the `[video]` was translated correctly to a `<video>` element.
 - Check if the unit tests are running correctly.
