### PR TITLE
Add basic usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ pod "WordPress-Aztec-iOS"
 
 ## Usage
 
-### Swift
-
 After installing Aztec, import the module and use the `Aztec.TextView` view:
 
 ```swift
@@ -41,15 +39,7 @@ import Aztec
 let textView = Aztec.TextView(defaultFont: Constants.defaultContentFont, defaultMissingImage: Constants.defaultMissingImage)
 ```
 
-### Obj-C
-
-After installing Aztec, import the Swift-compatibility header and use the `TextView` view:
-
-```objc
-#import "Aztec/Aztec-Swift.h"
-
-TextView *view = [[TextView alloc] initWithDefaultFont:font defaultMissingImage:defaultImage];
-```
+Note: Obj-C is not officially supported.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,30 @@ it, simply add the following line to your Podfile:
 pod "WordPress-Aztec-iOS"
 ```
 
+## Usage
+
+### Swift
+
+After installing Aztec, import the module and use the `Aztec.TextView` view:
+
+```swift
+import Aztec
+
+// ...
+
+let textView = Aztec.TextView(defaultFont: Constants.defaultContentFont, defaultMissingImage: Constants.defaultMissingImage)
+```
+
+### Obj-C
+
+After installing Aztec, import the Swift-compatibility header and use the `TextView` view:
+
+```objc
+#import "Aztec/Aztec-Swift.h"
+
+TextView *view = [[TextView alloc] initWithDefaultFont:font defaultMissingImage:defaultImage];
+```
+
 ## License
 
 WordPress-Aztec-iOS is available under the GPLv2 license. See the [LICENSE file](./LICENSE) for more info.


### PR DESCRIPTION
Since Aztec is written in Swift, it's a bit different using it in Obj-C land than a traditional Obj-C view. In particular, you have to load in the compatibility headers, which are actually quite a pain to find in the official documentation.

To improve this experience a bit, it'd be nice to add basic usage documentation to the readme. That's what this PR does. :)

Potentially, adding an example Obj-C project (or even just one view) might be useful as well?