### PR TITLE
Renaming TextViewMediaDelegate > TextViewAttachmentDelegate

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -20,11 +20,11 @@ protocol TextStorageAttachmentsDelegate {
     func storage(
         _ storage: TextStorage,
         attachment: NSTextAttachment,
-        imageForURL url: URL,
+        imageFor url: URL,
         onSuccess success: @escaping (UIImage) -> (),
         onFailure failure: @escaping () -> ()) -> UIImage
     
-    func storage(_ storage: TextStorage, missingImageForAttachment: NSTextAttachment) -> UIImage
+    func storage(_ storage: TextStorage, missingImageFor attachment: NSTextAttachment) -> UIImage
     
     /// Called when an image is about to be added to the storage as an attachment, so that the
     /// delegate can specify an URL where that image is available.
@@ -43,7 +43,7 @@ protocol TextStorageAttachmentsDelegate {
     ///   - textView: The textView where the attachment was removed.
     ///   - attachmentID: The attachment identifier of the media removed.
     ///
-    func storage(_ storage: TextStorage, deletedAttachmentWithID attachmentID: String)
+    func storage(_ storage: TextStorage, deletedAttachmentWith attachmentID: String)
 
     /// Provides the Bounds required to represent a given attachment, within a specified line fragment.
     ///
@@ -246,7 +246,7 @@ open class TextStorage: NSTextStorage {
 
     fileprivate func detectAttachmentRemoved(in range:NSRange) {
         textStore.enumerateAttachmentsOfType(MediaAttachment.self, range: range) { (attachment, range, stop) in
-            self.attachmentsDelegate.storage(self, deletedAttachmentWithID: attachment.identifier)
+            self.attachmentsDelegate.storage(self, deletedAttachmentWith: attachment.identifier)
         }
     }
 
@@ -1055,7 +1055,7 @@ extension TextStorage: MediaAttachmentDelegate {
         onFailure failure: @escaping () -> ()) -> UIImage
     {
         assert(attachmentsDelegate != nil)
-        return attachmentsDelegate.storage(self, attachment: mediaAttachment, imageForURL: url, onSuccess: success, onFailure: failure)
+        return attachmentsDelegate.storage(self, attachment: mediaAttachment, imageFor: url, onSuccess: success, onFailure: failure)
     }
 }
 
@@ -1068,7 +1068,7 @@ extension TextStorage: VideoAttachmentDelegate {
         onFailure failure: @escaping () -> ()) -> UIImage
     {
         assert(attachmentsDelegate != nil)
-        return attachmentsDelegate.storage(self, attachment: videoAttachment, imageForURL: url, onSuccess: success, onFailure: failure)
+        return attachmentsDelegate.storage(self, attachment: videoAttachment, imageFor: url, onSuccess: success, onFailure: failure)
     }
     
 }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -31,11 +31,11 @@ protocol TextStorageAttachmentsDelegate {
     ///
     /// - Parameters:
     ///     - storage: The storage that is requesting the image.
-    ///     - image: The image that was added to the storage.
+    ///     - imageAttachment: The image that was added to the storage.
     ///
     /// - Returns: the requested `NSURL` where the image is stored.
     ///
-    func storage(_ storage: TextStorage, urlForAttachment attachment: NSTextAttachment) -> URL
+    func storage(_ storage: TextStorage, urlFor imageAttachment: ImageAttachment) -> URL
 
     /// Called when a attachment is removed from the storage.
     ///
@@ -235,7 +235,7 @@ open class TextStorage: NSTextStorage {
                 let replacementAttachment = ImageAttachment(identifier: NSUUID.init().uuidString)
                 replacementAttachment.delegate = self
                 replacementAttachment.image = image
-                replacementAttachment.url = attachmentsDelegate.storage(self, urlForAttachment: replacementAttachment)
+                replacementAttachment.url = attachmentsDelegate.storage(self, urlFor: replacementAttachment)
 
                 finalString.addAttribute(NSAttachmentAttributeName, value: replacementAttachment, range: range)
             }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -41,9 +41,10 @@ public protocol TextViewAttachmentDelegate: class {
     /// - Parameters:
     ///   - textView: The textView where the attachment was removed.
     ///   - attachmentID: The attachment identifier of the media removed.
+    ///
     func textView(_ textView: TextView, deletedAttachmentWith attachmentID: String)
 
-    /// Called when an attachment is selected with a single tap.
+    /// Called after an attachment is selected with a single tap.
     ///
     /// - Parameters:
     ///   - textView: the textview where the attachment is.
@@ -52,7 +53,7 @@ public protocol TextViewAttachmentDelegate: class {
     ///
     func textView(_ textView: TextView, selected attachment: NSTextAttachment, atPosition position: CGPoint)
 
-    /// Called when an attachment is deselected with a single tap.
+    /// Called after an attachment is deselected with a single tap.
     ///
     /// - Parameters:
     ///   - textView: the textview where the attachment is.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -6,7 +6,7 @@ import Gridicons
 
 // MARK: - TextViewMediaDelegate
 //
-public protocol TextViewMediaDelegate: class {
+public protocol TextViewAttachmentDelegate: class {
 
     /// This method requests from the delegate the image at the specified URL.
     ///
@@ -128,7 +128,7 @@ open class TextView: UITextView {
     /// The media delegate takes care of providing remote media when requested by the `TextView`.
     /// If this is not set, all remove images will be left blank.
     ///
-    open weak var mediaDelegate: TextViewMediaDelegate?
+    open weak var mediaDelegate: TextViewAttachmentDelegate?
 
     /// Maintains a reference to the user provided Text Attachment Image Providers
     ///

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -36,7 +36,7 @@ public protocol TextViewAttachmentDelegate: class {
     func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL
 
 
-    /// Called when a attachment is removed from the storage.
+    /// Called after a attachment is removed from the storage.
     ///
     /// - Parameters:
     ///   - textView: The textView where the attachment was removed.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -50,7 +50,7 @@ public protocol TextViewAttachmentDelegate: class {
     ///   - attachment: the attachment that was selected.
     ///   - position: touch position relative to the textview.
     ///
-    func textView(_ textView: TextView, selectedAttachment attachment: NSTextAttachment, atPosition position: CGPoint)
+    func textView(_ textView: TextView, selected attachment: NSTextAttachment, atPosition position: CGPoint)
 
     /// Called when an attachment is deselected with a single tap.
     ///
@@ -59,7 +59,7 @@ public protocol TextViewAttachmentDelegate: class {
     ///   - attachment: the attachment that was deselected.
     ///   - position: touch position relative to the textView
     ///
-    func textView(_ textView: TextView, deselectedAttachment attachment: NSTextAttachment, atPosition position: CGPoint)
+    func textView(_ textView: TextView, deselected attachment: NSTextAttachment, atPosition position: CGPoint)
 }
 
 
@@ -1378,7 +1378,7 @@ extension TextView: TextStorageAttachmentsDelegate {
         guard textView.attachmentAtPoint(locationInTextView) != nil else {
             // if we have a current selected attachment let's notify of deselection
             if let selectedAttachment = currentSelectedAttachment {
-                textView.textAttachmentDelegate?.textView(textView, deselectedAttachment: selectedAttachment, atPosition: locationInTextView)
+                textView.textAttachmentDelegate?.textView(textView, deselected: selectedAttachment, atPosition: locationInTextView)
             }
             currentSelectedAttachment = nil
             return false
@@ -1402,14 +1402,14 @@ extension TextView: TextStorageAttachmentsDelegate {
 
         if textView.isPointInsideAttachmentMargin(point: locationInTextView) {
             if let selectedAttachment = currentSelectedAttachment {
-                textView.textAttachmentDelegate?.textView(textView, deselectedAttachment: selectedAttachment, atPosition: locationInTextView)
+                textView.textAttachmentDelegate?.textView(textView, deselected: selectedAttachment, atPosition: locationInTextView)
             }
             currentSelectedAttachment = nil
             return
         }
 
         currentSelectedAttachment = attachment as? ImageAttachment
-        textView.textAttachmentDelegate?.textView(textView, selectedAttachment: attachment, atPosition: locationInTextView)
+        textView.textAttachmentDelegate?.textView(textView, selected: attachment, atPosition: locationInTextView)
     }
 }
 

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -102,19 +102,19 @@ class TextStorageTests: XCTestCase
 
         var deletedAttachmendIDCalledWithString: String?
 
-        func storage(_ storage: TextStorage, deletedAttachmentWithID attachmentID: String) {
+        func storage(_ storage: TextStorage, deletedAttachmentWith attachmentID: String) {
             deletedAttachmendIDCalledWithString = attachmentID
         }
 
-        func storage(_ storage: TextStorage, urlForAttachment attachment: NSTextAttachment) -> URL {
+        func storage(_ storage: TextStorage, urlFor imageAttachment: ImageAttachment) -> URL {
             return URL(string:"test://")!
         }
 
-        func storage(_ storage: TextStorage, missingImageForAttachment: NSTextAttachment) -> UIImage {
+        func storage(_ storage: TextStorage, missingImageFor attachment: NSTextAttachment) -> UIImage {
             return UIImage()
         }
 
-        func storage(_ storage: TextStorage, attachment: NSTextAttachment, imageForURL url: URL, onSuccess success: @escaping (UIImage) -> (), onFailure failure: @escaping () -> ()) -> UIImage {
+        func storage(_ storage: TextStorage, attachment: NSTextAttachment, imageFor url: URL, onSuccess success: @escaping (UIImage) -> (), onFailure failure: @escaping () -> ()) -> UIImage {
             return UIImage()
         }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -21,7 +21,7 @@ class EditorDemoController: UIViewController {
 
         textView.delegate = self
         textView.formattingDelegate = self
-        textView.mediaDelegate = self
+        textView.textAttachmentDelegate = self
         textView.accessibilityIdentifier = "richContentView"
 
         return textView
@@ -806,7 +806,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
 
 extension EditorDemoController: TextViewAttachmentDelegate {
 
-    func textView(_ textView: TextView, imageAtUrl url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) -> UIImage {
+    func textView(_ textView: TextView, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) -> UIImage {
 
         let task = URLSession.shared.dataTask(with: url, completionHandler: { (data, urlResponse, error) in
             DispatchQueue.main.async(execute: {
@@ -826,17 +826,17 @@ extension EditorDemoController: TextViewAttachmentDelegate {
         return Gridicon.iconOfType(.image)
     }
     
-    func textView(_ textView: TextView, urlForAttachment attachment: NSTextAttachment) -> URL {
+    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL {
         
         // TODO: start fake upload process
-        if let image = attachment.image {
+        if let image = imageAttachment.image {
             return saveToDisk(image: image)
         } else {
             return URL(string: "placeholder://")!
         }
     }
 
-    func textView(_ textView: TextView, deletedAttachmentWithID attachmentID: String) {
+    func textView(_ textView: TextView, deletedAttachmentWith attachmentID: String) {
         print("Attachment \(attachmentID) removed.\n")
     }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -804,7 +804,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
 }
 
 
-extension EditorDemoController: TextViewMediaDelegate {
+extension EditorDemoController: TextViewAttachmentDelegate {
 
     func textView(_ textView: TextView, imageAtUrl url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) -> UIImage {
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -840,7 +840,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
         print("Attachment \(attachmentID) removed.\n")
     }
 
-    func textView(_ textView: TextView, selectedAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
+    func textView(_ textView: TextView, selected attachment: NSTextAttachment, atPosition position: CGPoint) {
         if let imgAttachment = attachment as? ImageAttachment {
             selected(textAttachment: imgAttachment, atPosition: position)
         }
@@ -853,7 +853,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
         }
     }
 
-    func textView(_ textView: TextView, deselectedAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
+    func textView(_ textView: TextView, deselected attachment: NSTextAttachment, atPosition position: CGPoint) {
         deselected(textAttachment: attachment, atPosition: position)
     }
 


### PR DESCRIPTION
### Details:
- Renamed `TextViewMediaDelegate` > `TextViewAttachmentDelegate`
- Renamed textView's `mediaDelegate` > `textAttachmentDelegate`
- Updated `TextViewAttachmentDelegate` method signatures to be Swift 3 compliant
- Updated few `TextStorageAttachmentsDelegate` methods

### To test:
1. Verify that the unit tests run correctly
2. Run a smoke test over the sample app

Needs Review: @diegoreymendez 
cc @SergioEstevao 

Thanks in advance!
