### PR TITLE
Prettifier: Fixing Blocklevel Element Trailing Newline

### DIFF
--- a/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
@@ -178,7 +178,10 @@ private extension Libxml2.Out.HTMLConverter {
             return false
         }
 
-        return !rightSibling.isBlockLevelElement() && node.isBlockLevelElement() && prettyPrint
+        let rightElementNode = rightSibling as? ElementNode
+        let isRightNodeRegularElement = rightElementNode == nil || rightElementNode?.isBlockLevelElement() == false
+
+        return isRightNodeRegularElement && node.isBlockLevelElement() && prettyPrint
     }
 
 

--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -210,7 +210,7 @@ extension Libxml2 {
         ///
         /// - Returns: the right sibling, or `nil` if none exists.
         ///
-        func rightSibling() -> ElementNode? {
+        func rightSibling() -> Node? {
 
             guard let parent = parent else {
                 return nil
@@ -218,11 +218,7 @@ extension Libxml2 {
 
             let index = parent.indexOf(childNode: self)
 
-            guard let sibling = parent.sibling(rightOf: index) else {
-                return nil
-            }
-
-            return sibling as? ElementNode
+            return parent.sibling(rightOf: index)
         }
 
         // MARK: - Paragraph Separation Logic
@@ -231,8 +227,7 @@ extension Libxml2 {
         ///
         func needsClosingParagraphSeparator() -> Bool {
 
-            if let rightSibling = rightSibling(),
-                rightSibling.isBlockLevelElement() {
+            if let rightSibling = rightSibling() as? ElementNode, rightSibling.isBlockLevelElement() {
 
                 return true
             }

--- a/AztecTests/Exporter/OutHTMLConverterTests.swift
+++ b/AztecTests/Exporter/OutHTMLConverterTests.swift
@@ -43,6 +43,23 @@ class OutHTMLConverterTests: XCTestCase {
     }
 
 
+    /// Verifies that Blocklevel Elements get a tailing newline
+    ///
+    func testConverterProperlyAddsNewlineAfterBlocklevelElement() {
+        let sample = "<h1>Header</h1>Tail"
+        let expected = "<h1>Header</h1>\nTail"
+
+        do {
+            let inNode = try InConverter().convert(sample)
+            let outHtml = OutConverter(prettyPrint: true).convert(inNode)
+
+            XCTAssertEqual(outHtml, expected)
+        } catch {
+            XCTFail("Unexpected conversion failure.")
+        }
+    }
+
+
     /// Verifies that unknown tags do not get dropped, and closed, if needed.
     ///
     func testConverterDoesNotDropUnknownTags() {


### PR DESCRIPTION
Fixes #479

### To test:
1. Enter the following HTML: `<h1>Header</h1>Tail`
2. Switch to Rich Mode
3. Switch back to HTML

As a result, you should see the following onscreen:

```
<h1>Header</h1>
Tail
```

Needs Review: @SergioEstevao 
cc @diegoreymendez 

Diego, i'm aware this changes after your incoming branch. Will take care of remapping the helpers, the Unit Test will be super helpful not to miss this!

Thanks gentlemen!
