### PR TITLE
Fix media unavailable issues

### DIFF
--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -329,12 +329,12 @@ open class MediaAttachment: NSTextAttachment
                 }
                 
                 strongSelf.isFetchingImage = false
+                strongSelf.lastRequestedURL = nil
+                strongSelf.image = nil
                 strongSelf.invalidateLayout(inTextContainer: textContainer)
             })
 
-        if self.image == nil {
-            self.image = image
-        }
+        self.image = image
     }
     
     fileprivate func invalidateLayout(inTextContainer textContainer: NSTextContainer?) {

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -7,6 +7,8 @@ protocol MediaAttachmentDelegate: class {
         imageForURL url: URL,
         onSuccess success: @escaping (UIImage) -> (),
         onFailure failure: @escaping () -> ()) -> UIImage
+
+    func mediaAttachmentPlaceholderImageFor(attachment: MediaAttachment) -> UIImage
 }
 
 /// Custom text attachment.
@@ -309,6 +311,9 @@ open class MediaAttachment: NSTextAttachment
         }
         
         guard let url = url, !isFetchingImage && url != lastRequestedURL else {
+            if self.url == nil {
+                self.image = delegate.mediaAttachmentPlaceholderImageFor(attachment: self)                
+            }
             return
         }
         

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -1061,6 +1061,12 @@ open class TextStorage: NSTextStorage {
 //
 extension TextStorage: MediaAttachmentDelegate {
 
+    func mediaAttachmentPlaceholderImageFor(attachment: MediaAttachment) -> UIImage {
+        assert(attachmentsDelegate != nil)
+        return attachmentsDelegate.storage(self, missingImageFor: attachment)
+    }
+
+
     func mediaAttachment(
         _ mediaAttachment: MediaAttachment,
         imageForURL url: URL,

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -12,6 +12,7 @@ public protocol TextViewAttachmentDelegate: class {
     ///
     /// - Parameters:
     ///     - textView: the `TextView` the call has been made from.
+    ///     - attachment: the attachment that is requesting the image
     ///     - imageURL: the url to download the image from.
     ///     - success: when the image is obtained, this closure should be executed.
     ///     - failure: if the image cannot be obtained, this closure should be executed.
@@ -36,6 +37,14 @@ public protocol TextViewAttachmentDelegate: class {
     ///
     func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL
 
+    /// Called when an attachment doesn't have an available source URL to provide an image representation.
+    ///
+    /// - Parameters:
+    ///   - textView: the textview that is requesting the image
+    ///   - attachment: the attachment that does not an have image source
+    /// - Returns: an UIImage to represent the attachment graphically
+    func textView(_ textView: TextView,
+                  placeholderForAttachment attachment: NSTextAttachment) -> UIImage
 
     /// Called after a attachment is removed from the storage.
     ///
@@ -1333,7 +1342,10 @@ extension TextView: TextStorageAttachmentsDelegate {
     }
 
     func storage(_ storage: TextStorage, missingImageFor attachment: NSTextAttachment) -> UIImage {
-        return defaultMissingImage
+        guard let textAttachmentDelegate = textAttachmentDelegate else {
+            fatalError("This class requires a text attachment delegate to be set.")
+        }
+        return textAttachmentDelegate.textView(self, placeholderForAttachment: attachment)
     }
     
     func storage(_ storage: TextStorage, urlFor imageAttachment: ImageAttachment) -> URL {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -20,6 +20,7 @@ public protocol TextViewAttachmentDelegate: class {
     ///         of the images.
     ///
     func textView(_ textView: TextView,
+                  attachment: NSTextAttachment,
                   imageAt url: URL,
                   onSuccess success: @escaping (UIImage) -> Void,
                   onFailure failure: @escaping (Void) -> Void) -> UIImage
@@ -1328,7 +1329,7 @@ extension TextView: TextStorageAttachmentsDelegate {
             fatalError("This class requires a text attachment delegate to be set.")
         }
         
-        return textAttachmentDelegate.textView(self, imageAt: url, onSuccess: success, onFailure: failure)
+        return textAttachmentDelegate.textView(self, attachment: attachment, imageAt: url, onSuccess: success, onFailure: failure)
     }
 
     func storage(_ storage: TextStorage, missingImageFor attachment: NSTextAttachment) -> UIImage {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -832,7 +832,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
 
 extension EditorDemoController: TextViewAttachmentDelegate {
 
-    func textView(_ textView: TextView, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) -> UIImage {
+    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) -> UIImage {
 
         let task = URLSession.shared.dataTask(with: url, completionHandler: { (data, urlResponse, error) in
             DispatchQueue.main.async(execute: {
@@ -849,7 +849,18 @@ extension EditorDemoController: TextViewAttachmentDelegate {
         }) 
         task.resume()
 
-        return Gridicon.iconOfType(.image)
+        let placeholderImage: UIImage
+        switch attachment {
+        case _ as ImageAttachment:
+            placeholderImage = Gridicon.iconOfType(.image, withSize: CGSize(width:32, height:32))
+        case _ as VideoAttachment:
+            placeholderImage = Gridicon.iconOfType(.video, withSize: CGSize(width:32, height:32))
+        default:
+            placeholderImage = Gridicon.iconOfType(.attachment, withSize: CGSize(width:32, height:32))
+
+        }
+
+        return placeholderImage
     }
     
     func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -849,6 +849,14 @@ extension EditorDemoController: TextViewAttachmentDelegate {
         }) 
         task.resume()
 
+        return placeholderImage(forAttachment: attachment)
+    }
+
+    func textView(_ textView: TextView, placeholderForAttachment attachment: NSTextAttachment) -> UIImage {
+        return placeholderImage(forAttachment: attachment)
+    }
+
+    func placeholderImage(forAttachment attachment: NSTextAttachment) -> UIImage {
         let placeholderImage: UIImage
         switch attachment {
         case _ as ImageAttachment:
@@ -862,7 +870,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
 
         return placeholderImage
     }
-    
+
     func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL {
         
         // TODO: start fake upload process

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -849,22 +849,23 @@ extension EditorDemoController: TextViewAttachmentDelegate {
         }) 
         task.resume()
 
-        return placeholderImage(forAttachment: attachment)
+        return placeholderImage(for: attachment)
     }
 
     func textView(_ textView: TextView, placeholderForAttachment attachment: NSTextAttachment) -> UIImage {
-        return placeholderImage(forAttachment: attachment)
+        return placeholderImage(for: attachment)
     }
 
-    func placeholderImage(forAttachment attachment: NSTextAttachment) -> UIImage {
+    func placeholderImage(for attachment: NSTextAttachment) -> UIImage {
+        let imageSize = CGSize(width:32, height:32)
         let placeholderImage: UIImage
         switch attachment {
         case _ as ImageAttachment:
-            placeholderImage = Gridicon.iconOfType(.image, withSize: CGSize(width:32, height:32))
+            placeholderImage = Gridicon.iconOfType(.image, withSize: imageSize)
         case _ as VideoAttachment:
-            placeholderImage = Gridicon.iconOfType(.video, withSize: CGSize(width:32, height:32))
+            placeholderImage = Gridicon.iconOfType(.video, withSize: imageSize)
         default:
-            placeholderImage = Gridicon.iconOfType(.attachment, withSize: CGSize(width:32, height:32))
+            placeholderImage = Gridicon.iconOfType(.attachment, withSize: imageSize)
 
         }
 


### PR DESCRIPTION
Fixes #434 

This PR address two issues:
 1. The #434 issue when changing a image src to a non available/incorrect source the image is not updated.
 1. When the image or video don't have a src or poster attribute

Both issues are sorted by using a placeholder image to represent them when no media image is available
 
To test:

Scenario 1:
 - Start the demo app
 - Open the demo with content
 - Scroll to the image on the demo
 - Tap on it
 - Change the source of the image to an invalid image
 - Make sure the placeholder image shows in place
 - Repeat the process but with a valid image
 - Check that the image shows up.

Scenario 2:
 - Start the demo app
 - Open the demo with content
 - Switch to HTML mode
 - Remove src from the image tag and poster from the video shortcode
 - Switch to visual mode
 - Check if the image and video show as a placeholder.



