### PR TITLE
FormatBar: Buttons should acquire full height

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -35,6 +35,7 @@ open class FormatBar: UIView {
         didSet {
             configure(items: scrollableItems)
             scrollableStackView.addArrangedSubviews(scrollableItems)
+            configureConstraints(for: scrollableItems, in: scrollableStackView)
         }
     }
 
@@ -48,6 +49,7 @@ open class FormatBar: UIView {
         didSet {
             configure(items: fixedItems)
             fixedStackView.addArrangedSubviews(fixedItems)
+            configureConstraints(for: fixedItems, in: fixedStackView)
         }
     }
 
@@ -318,6 +320,20 @@ private extension FormatBar {
     }
 
 
+    /// Sets up the Constraints for a given FormatBarItem, within the specified Container
+    ///
+    func configureConstraints(for items: [FormatBarItem], in container: UIView) {
+        let constraints = items.flatMap { item in
+            return [
+                item.widthAnchor.constraint(equalToConstant: Constants.stackButtonWidth),
+                item.heightAnchor.constraint(equalTo: container.heightAnchor)
+            ]
+        }
+
+        NSLayoutConstraint.activate(constraints)
+    }
+
+
     /// Refreshes the Stack View(s) Spacing, according to the Horizontal Size Class
     ///
     func refreshStackViewsSpacing() {
@@ -387,8 +403,9 @@ private extension FormatBar {
         static let fixedSeparatorMidPointPaddingX = CGFloat(5)
         static let fixedStackViewInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 10)
         static let scrollableStackViewInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
-        static let stackViewCompactSpacing = CGFloat(7)
-        static let stackViewRegularSpacing = CGFloat(20)
+        static let stackViewCompactSpacing = CGFloat(0)
+        static let stackViewRegularSpacing = CGFloat(15)
+        static let stackButtonWidth = CGFloat(30)
         static let topBorderHeightInPixels = CGFloat(1)
     }
 }


### PR DESCRIPTION
### Details:
In this PR we're enforcing the FormatBarItem Buttons to acquire the **full height** of their container views. Prior to this PR, the Buttons were getting a ~ 20x20 size, which made it quite hard to press.

Needs Review: @diegoreymendez 


### To test:
- Verify how the Format Bar looks like on: [SE, iPhone Plus, iPad]
- Toggle Vertical / Horizontal Orientations
- Run a smoke test over the format bar actions.

--

### Screenshots:

I've tinted the actual button's colors to red, and took few screenshot (prior to this patch, and how it looks afterwards), so that it's easier to spot the 'pressable' areas.

**P.s.:** do not worry, the final version won't look red-dish!


#### iPhone SE (Unpatched)
![se h](https://cloud.githubusercontent.com/assets/1195260/26645211/b7f99f86-460d-11e7-9eb2-b303d939253a.png)
![se v](https://cloud.githubusercontent.com/assets/1195260/26645212/b837444e-460d-11e7-9aa2-807c35d4b41f.png)

--

#### iPhone Plus (Unpatched)
![plus h](https://cloud.githubusercontent.com/assets/1195260/26645224/be8caf6e-460d-11e7-852b-ea8964ef5879.png)
![plus v](https://cloud.githubusercontent.com/assets/1195260/26645225/bec2efb6-460d-11e7-862e-1eed795f4373.png)

--

#### iPad (Unpatched)
![ipad h](https://cloud.githubusercontent.com/assets/1195260/26645232/c4adc1f8-460d-11e7-9d27-e0fed8797b6b.png)
![ipad v](https://cloud.githubusercontent.com/assets/1195260/26645233/c4b738fa-460d-11e7-8f92-b98e641df767.png)

--

#### iPhone SE (Patched)
![se h fixed](https://cloud.githubusercontent.com/assets/1195260/26645254/d3576af6-460d-11e7-9e8a-220f2467bef3.png)
![se v fixed](https://cloud.githubusercontent.com/assets/1195260/26645255/d35a1d96-460d-11e7-9e96-12fa7c1c31a0.png)

--

#### iPhone Plus (Patched)
![plus h fixed](https://cloud.githubusercontent.com/assets/1195260/26645263/d81cfc40-460d-11e7-81d3-968c24bcee1f.png)
![plus v fixed](https://cloud.githubusercontent.com/assets/1195260/26645264/d81f40cc-460d-11e7-99ff-6ce4df98194f.png)

-

#### iPad (Patched)
![ipad h fixed](https://cloud.githubusercontent.com/assets/1195260/26645272/dcccacae-460d-11e7-8d42-b5b21e285876.png)
![ipad v fixed](https://cloud.githubusercontent.com/assets/1195260/26645271/dccab07a-460d-11e7-9f30-c30eb56046c0.png)
