### PR TITLE
Adjust text container inset so scrollbar appears at edge of view

### DIFF
--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -259,8 +259,8 @@ class EditorDemoController: UIViewController {
             ])
 
         NSLayoutConstraint.activate([
-            richTextView.leftAnchor.constraint(equalTo: view.leftAnchor, constant: Constants.margin),
-            richTextView.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -Constants.margin),
+            richTextView.leftAnchor.constraint(equalTo: view.leftAnchor),
+            richTextView.rightAnchor.constraint(equalTo: view.rightAnchor),
             richTextView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0),
             richTextView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -Constants.margin)
             ])
@@ -281,6 +281,8 @@ class EditorDemoController: UIViewController {
         textView.keyboardDismissMode = .interactive
         textView.textColor = UIColor.darkText
         textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.textContainerInset.left = Constants.margin
+        textView.textContainerInset.right = Constants.margin
     }
 
     private func registerAttachmentImageProviders() {


### PR DESCRIPTION
### Details:
This PR ports this awesome [WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/7281) submitted by our beloved @frosty.

From now on, the scrollbar won't appear floating at the middle of nowhere.

### To test:
1. Launch the Editor
2. Verify that the scrollbar is on the righter-most edge

Needs Review: @diegoreymendez 
Thanks sir!
