### PR TITLE
Support updates on video elements

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		FF7C89B01E3BC52F000472A8 /* NSAttributedString+FontTraits.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7C89AF1E3BC52F000472A8 /* NSAttributedString+FontTraits.swift */; };
 		FF7DCB471E80837D00AB77CB /* UIColor+Parsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7DCB461E80837D00AB77CB /* UIColor+Parsers.swift */; };
 		FF7DCB4B1E815F9400AB77CB /* UIColorHexParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7DCB4A1E815F9400AB77CB /* UIColorHexParserTests.swift */; };
+		FF8669EC1EE7677F00F071A6 /* TextViewStubAttachmentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8669EB1EE7677F00F071A6 /* TextViewStubAttachmentDelegate.swift */; };
 		FF8F85841E84162900C12BB4 /* PreFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8F85831E84162900C12BB4 /* PreFormatter.swift */; };
 		FFA61E891DF18F3D00B71BF6 /* ParagraphStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */; };
 		FFA61EC21DF6C1C900B71BF6 /* NSAttributedString+Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */; };
@@ -281,6 +282,7 @@
 		FF7C89AF1E3BC52F000472A8 /* NSAttributedString+FontTraits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+FontTraits.swift"; sourceTree = "<group>"; };
 		FF7DCB461E80837D00AB77CB /* UIColor+Parsers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Parsers.swift"; sourceTree = "<group>"; };
 		FF7DCB4A1E815F9400AB77CB /* UIColorHexParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIColorHexParserTests.swift; path = Extensions/UIColorHexParserTests.swift; sourceTree = "<group>"; };
+		FF8669EB1EE7677F00F071A6 /* TextViewStubAttachmentDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextViewStubAttachmentDelegate.swift; sourceTree = "<group>"; };
 		FF8F85831E84162900C12BB4 /* PreFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreFormatter.swift; sourceTree = "<group>"; };
 		FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParagraphStyle.swift; sourceTree = "<group>"; };
 		FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Archive.swift"; sourceTree = "<group>"; };
@@ -621,6 +623,7 @@
 			children = (
 				599F25931D8BDCFC002871D6 /* TextViewTests.swift */,
 				599F25921D8BDCFC002871D6 /* TextStorageTests.swift */,
+				FF8669EB1EE7677F00F071A6 /* TextViewStubAttachmentDelegate.swift */,
 			);
 			name = TextKit;
 			sourceTree = "<group>";
@@ -929,6 +932,7 @@
 				FF20D6471EDC3B3900294B78 /* HTMLProcessorTests.swift in Sources */,
 				594C9D731D8BE6C300D74542 /* InAttributeConverterTests.swift in Sources */,
 				F11904A51D9D857500BFF9A1 /* TextNodeTests.swift in Sources */,
+				FF8669EC1EE7677F00F071A6 /* TextViewStubAttachmentDelegate.swift in Sources */,
 				FF152D8E1E68552A00FF596C /* StringRangeConversionTests.swift in Sources */,
 				F1FFB2A11E6058930015ACB8 /* DOMStringTests.swift in Sources */,
 				59FEA07A1D8BDFA700D138DF /* InHTMLConverterTests.swift in Sources */,

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -266,7 +266,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
                 posterURL = URL(string: urlString)
             }
 
-            let attachment = VideoAttachment(identifier: UUID().uuidString, srcURL: srcURL, posterURL: posterURL)
+            let attachment = VideoAttachment(identifier: UUID().uuidString, srcURL: srcURL, posterURL: posterURL, namedAttributes: node.namedAttributes, unnamedAttributes: node.unnamedAttributes)
 
             attributeValue = attachment
         }

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -256,17 +256,21 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         }
 
         if node.isNodeType(.video) {
+
+            var namedAttributes = node.namedAttributes
             var srcURL: URL?
-            if let urlString = node.valueForStringAttribute(named: "src") {
+            if let urlString = namedAttributes["src"] {
                 srcURL = URL(string: urlString)
+                namedAttributes.removeValue(forKey: "src")
             }
 
             var posterURL: URL?
-            if let urlString = node.valueForStringAttribute(named: "poster") {
+            if let urlString = namedAttributes["poster"] {
                 posterURL = URL(string: urlString)
+                namedAttributes.removeValue(forKey: "poster")
             }
 
-            let attachment = VideoAttachment(identifier: UUID().uuidString, srcURL: srcURL, posterURL: posterURL, namedAttributes: node.namedAttributes, unnamedAttributes: node.unnamedAttributes)
+            let attachment = VideoAttachment(identifier: UUID().uuidString, srcURL: srcURL, posterURL: posterURL, namedAttributes: namedAttributes, unnamedAttributes: node.unnamedAttributes)
 
             attributeValue = attachment
         }

--- a/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/StandardAttributeFormatter.swift
@@ -63,7 +63,7 @@ class ImageFormatter: StandardAttributeFormatter {
 
 class VideoFormatter: StandardAttributeFormatter {
     init() {
-        super.init(attributeKey: NSAttachmentAttributeName, attributeValue: VideoAttachment(identifier: NSUUID().uuidString))
+        super.init(attributeKey: NSAttachmentAttributeName, attributeValue: VideoAttachment(identifier: NSUUID().uuidString, namedAttributes: [String:String](), unnamedAttributes: []))
     }
 }
 

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -92,6 +92,26 @@ extension Libxml2 {
             return nil
         }
 
+        var namedAttributes: [String: String] {
+            var attributesResult = [String:String]()
+            for attribute in attributes {
+                if let attribute = attribute as? StringAttribute {
+                    attributesResult[attribute.name] = attribute.value
+                }
+            }
+            return attributesResult
+        }
+
+        var unnamedAttributes: [String] {
+            var attributesResult = [String]()
+            for attribute in attributes {
+                if !(attribute is StringAttribute) {
+                    attributesResult.append(attribute.name)
+                }
+            }
+            return attributesResult
+        }
+
         /// Updates or adds an attribute with the specificed name with the corresponding value
         ///
         /// - parameter attributeName: the name of the attribute

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -695,18 +695,24 @@ extension Libxml2 {
         ///   - videoURL: the URL for the video src attribute
         ///   - posterURL: the URL for ther video poster attribute
         ///
-        func replace(_ range: NSRange, withVideoURL videoURL: URL, posterURL: URL?) {
+        func replace(_ range: NSRange, withVideoURL videoURL: URL, posterURL: URL?, namedAttributes: [String:String], unnamedAttributes: [String]) {
             performAsyncUndoable { [weak self] in
-                self?.replaceSynchronously(range, withVideoURL: videoURL, posterURL: posterURL)
+                self?.replaceSynchronously(range, withVideoURL: videoURL, posterURL: posterURL, namedAttributes: namedAttributes, unnamedAttributes: unnamedAttributes)
             }
         }
 
-        private func replaceSynchronously(_ range: NSRange, withVideoURL videoURL: URL, posterURL: URL?) {
+        private func replaceSynchronously(_ range: NSRange, withVideoURL videoURL: URL, posterURL: URL?, namedAttributes: [String:String], unnamedAttributes: [String]) {
             let videoURLString = videoURL.absoluteString
 
-            var attributes = [Libxml2.StringAttribute(name:"src", value: videoURLString)]
+            var attributes: [Libxml2.Attribute] = [Libxml2.StringAttribute(name:"src", value: videoURLString)]
             if let posterURLString = posterURL?.absoluteString {
                 attributes.append(Libxml2.StringAttribute(name:"poster", value: posterURLString))
+            }
+            for (key, value) in namedAttributes {
+                attributes.append(Libxml2.StringAttribute(name:key, value: value))
+            }
+            for value in unnamedAttributes {
+                attributes.append(Libxml2.Attribute(name: value))
             }
             let descriptor = ElementNodeDescriptor(elementType: .video, attributes: attributes)
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -931,6 +931,18 @@ open class TextStorage: NSTextStorage {
         dom.updateImage(spanning: domRanges, url: url, size: size, alignment: alignment)
     }
 
+    /// Updates the specified VideoAttachment with new HTML contents
+    ///
+    func update(attachment: VideoAttachment) {
+        guard let range = range(for: attachment) else {
+            assertionFailure("Couldn't determine the range for an Attachment")
+            return
+        }
+
+        let stringWithAttachment = NSAttributedString(attachment: attachment)
+        replaceCharacters(in: range, with: stringWithAttachment)
+    }
+
     /// Updates the specified HTMLAttachment with new HTML contents
     ///
     func update(attachment: HTMLAttachment, html: String) {

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -121,7 +121,7 @@ open class TextStorage: NSTextStorage {
 
     var attachmentsDelegate: TextStorageAttachmentsDelegate!
 
-    open func MediaAttachments() -> [MediaAttachment] {
+    open var mediaAttachments: [MediaAttachment] {
         let range = NSMakeRange(0, length)
         var attachments = [MediaAttachment]()
         enumerateAttribute(NSAttachmentAttributeName, in: range, options: []) { (object, range, stop) in

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -591,13 +591,13 @@ open class TextStorage: NSTextStorage {
         let addVideoUrl = originalUrl == nil && newUrl != nil
         let removeVideoUrl = originalUrl != nil && newUrl == nil
 
-        if addVideoUrl {
+        if addVideoUrl, let videoAttachment = new {
             guard let urlToAdd = newUrl else {
                 assertionFailure("This should not be possible.  Review your logic.")
                 return
             }
 
-            dom.replace(range, withVideoURL: urlToAdd, posterURL: new?.posterURL)
+            dom.replace(range, withVideoURL: urlToAdd, posterURL: new?.posterURL, namedAttributes: videoAttachment.namedAttributes, unnamedAttributes: videoAttachment.unnamedAttributes)
         } else if removeVideoUrl {
             dom.removeVideo(spanning: range)
         }
@@ -864,7 +864,7 @@ open class TextStorage: NSTextStorage {
     /// - returns: the attachment object that was created and inserted on the text
     ///
     func insertVideo(sourceURL: URL, posterURL: URL?, atPosition position:Int, placeHolderImage: UIImage, identifier: String = UUID().uuidString) -> VideoAttachment {
-        let attachment = VideoAttachment(identifier: identifier, srcURL: sourceURL, posterURL: posterURL)
+        let attachment = VideoAttachment(identifier: identifier, srcURL: sourceURL, posterURL: posterURL, namedAttributes: [String:String](), unnamedAttributes: [String]())
         attachment.delegate = self
         attachment.image = placeHolderImage
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1109,6 +1109,14 @@ open class TextView: UITextView {
         delegate?.textViewDidChange?(self)
     }
 
+    open func update(attachment: VideoAttachment) {
+        storage.update(attachment: attachment)
+        layoutManager.invalidateLayout(for: attachment)
+        layoutManager.ensureLayoutForContainers()
+        delegate?.textViewDidChange?(self)
+    }
+
+
     /// Updates the Attachment's HTML contents to the new specified value.
     ///
     /// - Parameters:

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -24,7 +24,7 @@ open class VideoAttachment: MediaAttachment
 
     /// Extra unnamed attributes on video
     ///
-    open var unnamedAttributes =  [String]()
+    open var unnamedAttributes = [String]()
 
     /// Video poster image to show, while the video is not played.
     ///

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -18,6 +18,14 @@ open class VideoAttachment: MediaAttachment
     ///
     open var srcURL: URL?
 
+    /// Extra named attributes on video
+    ///
+    open var namedAttributes = [String:String]()
+
+    /// Extra unnamed attributes on video
+    ///
+    open var unnamedAttributes =  [String]()
+
     /// Video poster image to show, while the video is not played.
     ///
     open var posterURL: URL? {
@@ -34,8 +42,10 @@ open class VideoAttachment: MediaAttachment
     ///
     /// - parameter identifier: An unique identifier for the attachment
     ///
-    required public init(identifier: String, srcURL: URL? = nil, posterURL: URL? = nil) {
+    required public init(identifier: String, srcURL: URL? = nil, posterURL: URL? = nil, namedAttributes: [String:String], unnamedAttributes: [String]) {
         self.srcURL = srcURL
+        self.namedAttributes = namedAttributes
+        self.unnamedAttributes = unnamedAttributes
         
         super.init(identifier: identifier, url: posterURL)
 

--- a/AztecTests/TextViewStubAttachmentDelegate.swift
+++ b/AztecTests/TextViewStubAttachmentDelegate.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Aztec
+import Gridicons
+
+class TextViewStubAttachmentDelegate: TextViewAttachmentDelegate {
+
+    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) -> UIImage {
+        return placeholderImage(for: attachment)
+    }
+
+    func textView(_ textView: TextView, placeholderForAttachment attachment: NSTextAttachment) -> UIImage {
+        return placeholderImage(for: attachment)
+    }
+
+    func placeholderImage(for attachment: NSTextAttachment) -> UIImage {
+        let imageSize = CGSize(width:32, height:32)
+        let placeholderImage: UIImage
+        switch attachment {
+        case _ as ImageAttachment:
+            placeholderImage = Gridicon.iconOfType(.image, withSize: imageSize)
+        case _ as VideoAttachment:
+            placeholderImage = Gridicon.iconOfType(.video, withSize: imageSize)
+        default:
+            placeholderImage = Gridicon.iconOfType(.attachment, withSize: imageSize)
+
+        }
+
+        return placeholderImage
+    }
+
+    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL {
+        return URL(string: "placeholder://")!
+    }
+
+    func textView(_ textView: TextView, deletedAttachmentWith attachmentID: String) {
+
+    }
+
+    func textView(_ textView: TextView, selected attachment: NSTextAttachment, atPosition position: CGPoint) {
+    }
+    
+    func textView(_ textView: TextView, deselected attachment: NSTextAttachment, atPosition position: CGPoint) {        
+    }
+}

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -9,6 +9,8 @@ class TextViewTests: XCTestCase {
         static let sampleText1 = " patronum sitanum elanum zoipancoiamum."
     }
 
+    let attachmentDelegate = TextViewStubAttachmentDelegate()
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -24,13 +26,13 @@ class TextViewTests: XCTestCase {
 
     func createEmptyTextView() -> Aztec.TextView {
         let richTextView = Aztec.TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: Gridicon.iconOfType(.attachment))
-
+        richTextView.textAttachmentDelegate = attachmentDelegate
         return richTextView
     }
 
     func createTextView(withHTML html: String) -> Aztec.TextView {
         let richTextView = Aztec.TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: Gridicon.iconOfType(.attachment))
-
+        richTextView.textAttachmentDelegate = attachmentDelegate
         richTextView.setHTML(html)
 
         return richTextView
@@ -39,7 +41,7 @@ class TextViewTests: XCTestCase {
     func createTextViewWithContent() -> Aztec.TextView {
         let paragraph = "Lorem ipsum dolar sit amet.\n"
         let richTextView = Aztec.TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: Gridicon.iconOfType(.attachment))
-
+        richTextView.textAttachmentDelegate = attachmentDelegate
         let attributes = [NSParagraphStyleAttributeName : NSParagraphStyle()]
         let templateString = NSMutableAttributedString(string: paragraph, attributes: attributes)
 
@@ -1353,4 +1355,20 @@ class TextViewTests: XCTestCase {
         
         XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.paragraphSeparator) + String(.paragraphSeparator))
     }
+
+    func testInsertVideo() {
+        let textView = createEmptyTextView()
+        let _ = textView.insertVideo(atLocation: 0, sourceURL: URL(string: "video.mp4")!, posterURL: URL(string: "video.jpg"), placeHolderImage: nil)
+        XCTAssertEqual(textView.getHTML(), "<video src=\"video.mp4\" poster=\"video.jpg\"></video>")
+    }
+
+    func testUpdateVideo() {
+        let textView = createTextView(withHTML: "<video src=\"video.mp4\" poster=\"video.jpg\" alt=\"The video\"></video>")
+        let videoAttachment = textView.storage.MediaAttachments().first! as! VideoAttachment
+        videoAttachment.srcURL = URL(string:"newVideo.mp4")!
+        let _ = textView.update(attachment: videoAttachment)
+
+        XCTAssertEqual(textView.getHTML(), "<video src=\"newVideo.mp4\" poster=\"video.jpg\" alt=\"The video\"></video>")
+    }
+
 }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1364,7 +1364,7 @@ class TextViewTests: XCTestCase {
 
     func testUpdateVideo() {
         let textView = createTextView(withHTML: "<video src=\"video.mp4\" poster=\"video.jpg\" alt=\"The video\"></video>")
-        let videoAttachment = textView.storage.MediaAttachments().first! as! VideoAttachment
+        let videoAttachment = textView.storage.mediaAttachments.first! as! VideoAttachment
         videoAttachment.srcURL = URL(string:"newVideo.mp4")!
         let _ = textView.update(attachment: videoAttachment)
 

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1366,9 +1366,10 @@ class TextViewTests: XCTestCase {
         let textView = createTextView(withHTML: "<video src=\"video.mp4\" poster=\"video.jpg\" alt=\"The video\"></video>")
         let videoAttachment = textView.storage.mediaAttachments.first! as! VideoAttachment
         videoAttachment.srcURL = URL(string:"newVideo.mp4")!
+        videoAttachment.namedAttributes["data-wpvideopress"] = "ABCDEFG"
         let _ = textView.update(attachment: videoAttachment)
 
-        XCTAssertEqual(textView.getHTML(), "<video src=\"newVideo.mp4\" poster=\"video.jpg\" alt=\"The video\"></video>")
+        XCTAssertEqual(textView.getHTML(), "<video src=\"newVideo.mp4\" poster=\"video.jpg\" data-wpvideopress=\"ABCDEFG\" alt=\"The video\"></video>")
     }
 
 }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -315,11 +315,11 @@ class EditorDemoController: UIViewController {
 
         let wordPressVideoProcessor = ShortcodeProcessor(tag:"video", replacer: { (shortcode) in
             var html = "<video "
-            if let src = shortcode.attributes.named["src"] {
-                html += "src=\"\(src)\" "
+            for (key, value) in shortcode.attributes.named {
+                html += "\(key)=\"\(value)\" "
             }
-            if let poster = shortcode.attributes.named["poster"] {
-                html += "poster=\"\(poster)\" "
+            for value in shortcode.attributes.unamed {
+                html += "\(value) "
             }
             html += "/>"
             return html
@@ -330,11 +330,11 @@ class EditorDemoController: UIViewController {
 
         let postWordPressVideoProcessor = HTMLProcessor(tag:"video", replacer: { (shortcode) in
             var html = "[video "
-            if let src = shortcode.attributes.named["src"] {
-                html += "src=\"\(src)\" "
+            for (key, value) in shortcode.attributes.named {
+                html += "\(key)=\"\(value)\" "
             }
-            if let poster = shortcode.attributes.named["poster"] {
-                html += "poster=\"\(poster)\" "
+            for value in shortcode.attributes.unamed {
+                html += "\(value) "
             }
             html += "/]"
             return html

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1058,7 +1058,7 @@ private extension EditorDemoController
         
         let attachment = richTextView.insertImage(sourceURL: fileURL, atPosition: index, placeHolderImage: image)
         let imageID = attachment.identifier
-        let progress = Progress(parent: nil, userInfo: ["imageID": imageID])
+        let progress = Progress(parent: nil, userInfo: [MediaProgressKey.mediaID: imageID])
         progress.totalUnitCount = 100
         
         Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(EditorDemoController.timerFireMethod(_:)), userInfo: progress, repeats: true)
@@ -1077,8 +1077,8 @@ private extension EditorDemoController
         let posterImage = UIImage(cgImage: cgImage)
         let posterURL = saveToDisk(image: posterImage)
         let attachment = richTextView.insertVideo(atLocation: index, sourceURL: URL(string:"placeholder://")!, posterURL: posterURL, placeHolderImage: posterImage)
-        let imageID = attachment.identifier
-        let progress = Progress(parent: nil, userInfo: ["imageID": imageID, "videoURL":videoURL])
+        let mediaID = attachment.identifier
+        let progress = Progress(parent: nil, userInfo: [MediaProgressKey.mediaID: mediaID, MediaProgressKey.videoURL:videoURL])
         progress.totalUnitCount = 100
 
         Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(EditorDemoController.timerFireMethod(_:)), userInfo: progress, repeats: true)
@@ -1086,7 +1086,7 @@ private extension EditorDemoController
 
     @objc func timerFireMethod(_ timer: Timer) {
         guard let progress = timer.userInfo as? Progress,
-              let imageId = progress.userInfo[ProgressUserInfoKey("imageID")] as? String,
+              let imageId = progress.userInfo[MediaProgressKey.mediaID] as? String,
               let attachment = richTextView.attachment(withId: imageId)
         else {
             timer.invalidate()
@@ -1104,7 +1104,7 @@ private extension EditorDemoController
         if progress.fractionCompleted >= 1 {
             timer.invalidate()
             attachment.progress = nil
-            if let videoAttachment = attachment as? VideoAttachment, let videoURL = progress.userInfo[ProgressUserInfoKey("videoURL")] as? URL {
+            if let videoAttachment = attachment as? VideoAttachment, let videoURL = progress.userInfo[MediaProgressKey.mediaID] as? URL {
                 videoAttachment.srcURL = videoURL
                 richTextView.update(attachment: videoAttachment)
             }
@@ -1192,6 +1192,11 @@ extension EditorDemoController {
         static let headers              = [HeaderFormatter.HeaderType.none, .h1, .h2, .h3, .h4, .h5, .h6]
         static let margin               = CGFloat(20)
         static let moreAttachmentText   = "more"
+    }
+
+    struct MediaProgressKey {
+        static let mediaID = ProgressUserInfoKey("mediaID")
+        static let videoURL = ProgressUserInfoKey("videoURL")
     }
 }
 

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -94,7 +94,7 @@ Video:<br/><br/>
 <video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://i2.wp.com/videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg?ssl=1" alt="Video about bunnies" />
 <br/>
 Video with Shortcode:<br/><br/>
-[video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://i2.wp.com/videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg?ssl=1" /]
+[video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://i2.wp.com/videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg?ssl=1" alt="Another video with bunnies"/]
 </p>
 
 <p>

--- a/Example/Tests/ShortcodeProcessorTests.swift
+++ b/Example/Tests/ShortcodeProcessorTests.swift
@@ -44,12 +44,5 @@ class ShortcodeProcessorTests: XCTestCase {
         let parsedText = shortCodeParser.process(text: sampleText)
         XCTAssertEqual(parsedText, "<video src=\"video-source.mp4\" />")
     }
-
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
     
 }


### PR DESCRIPTION
Fixes #165  

This PR add support for editing VideoAttachment properties after they are added to the editor. It also makes the changes to be reflected on the HTML.

To test:

 - Open the demo controller
 - Check if the video display correctly
 - Insert a new video using the add media button on the toolbar
 - Check that video is introduced correctly and that after the fake upload process is finished, the src URL is set correctly.
 