### PR TITLE
NSAttributedString to HTML: Phase A

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		B577DC651E7B18E90012A1F8 /* NodeDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B577DC641E7B18E90012A1F8 /* NodeDescriptor.swift */; };
 		B577DC671E7B18F80012A1F8 /* CommentNodeDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B577DC661E7B18F80012A1F8 /* CommentNodeDescriptor.swift */; };
 		B57D1C3D1E92C38000EA4B16 /* HTMLAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */; };
+		B58082BE1EE88D60001FDC8D /* NSAttributedStringToNodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58082BD1EE88D60001FDC8D /* NSAttributedStringToNodes.swift */; };
 		B59C9F9F1DF74BB80073B1D6 /* UIFont+Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */; };
 		B5A99D841EBA073D00DED081 /* HTMLStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A99D831EBA073D00DED081 /* HTMLStorage.swift */; };
 		B5AF89321E93CFC80051EFDB /* RenderableAttachmentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF89311E93CFC80051EFDB /* RenderableAttachmentDelegate.swift */; };
@@ -203,6 +204,7 @@
 		B577DC641E7B18E90012A1F8 /* NodeDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NodeDescriptor.swift; path = Descriptors/NodeDescriptor.swift; sourceTree = "<group>"; };
 		B577DC661E7B18F80012A1F8 /* CommentNodeDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommentNodeDescriptor.swift; path = Descriptors/CommentNodeDescriptor.swift; sourceTree = "<group>"; };
 		B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachment.swift; sourceTree = "<group>"; };
+		B58082BD1EE88D60001FDC8D /* NSAttributedStringToNodes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAttributedStringToNodes.swift; sourceTree = "<group>"; };
 		B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Traits.swift"; sourceTree = "<group>"; };
 		B5A99D831EBA073D00DED081 /* HTMLStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLStorage.swift; sourceTree = "<group>"; };
 		B5AF89311E93CFC80051EFDB /* RenderableAttachmentDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RenderableAttachmentDelegate.swift; sourceTree = "<group>"; };
@@ -668,6 +670,7 @@
 				F1FA0E721E6EF25A009D98EE /* DOMEditor.swift */,
 				F1FA0E741E6EF267009D98EE /* DOMLogic.swift */,
 				F1FA0E761E6EF29B009D98EE /* DOMInspector.swift */,
+				B58082BD1EE88D60001FDC8D /* NSAttributedStringToNodes.swift */,
 			);
 			path = Logic;
 			sourceTree = "<group>";
@@ -906,6 +909,7 @@
 				B577DC671E7B18F80012A1F8 /* CommentNodeDescriptor.swift in Sources */,
 				599F25501D8BC9A1002871D6 /* FormattingIdentifier.swift in Sources */,
 				599F25341D8BC9A1002871D6 /* ArrayConverter.swift in Sources */,
+				B58082BE1EE88D60001FDC8D /* NSAttributedStringToNodes.swift in Sources */,
 				F1FA0E811E6EF514009D98EE /* Attribute.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -54,7 +54,12 @@ extension Libxml2 {
         convenience init(descriptor: ElementNodeDescriptor, children: [Node] = [], editContext: EditContext? = nil) {
             self.init(name: descriptor.name, attributes: descriptor.attributes, children: children, editContext: editContext)
         }
-        
+
+        convenience init(type: StandardElementType, attributes: [Attribute] = [], children: [Node] = []) {
+            self.init(name: type.rawValue, attributes: attributes, children: children)
+        }
+
+
         // MARK: - Node Constructors
         
         static func `break`() -> ElementNode {

--- a/Aztec/Classes/Libxml2/DOM/Logic/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Libxml2/DOM/Logic/NSAttributedStringToNodes.swift
@@ -1,0 +1,346 @@
+import Foundation
+import UIKit
+import libxml2
+
+
+
+// MARK: - NSAttributedStringToNodes
+//
+class NSAttributedStringToNodes {
+
+    /// Typealiases
+    ///
+    typealias Node = Libxml2.Node
+    typealias CommentNode = Libxml2.CommentNode
+    typealias ElementNode = Libxml2.ElementNode
+    typealias TextNode = Libxml2.TextNode
+    typealias DOMString = Libxml2.DOMString
+    typealias DOMInspector = Libxml2.DOMInspector
+    typealias Attribute = Libxml2.Attribute
+    typealias StringAttribute = Libxml2.StringAttribute
+
+    ///
+    ///
+    func createNodes(fromParagraph paragraph: NSAttributedString) -> [Node] {
+
+        var children = [Node]()
+
+        guard paragraph.length > 0 else {
+            return []
+        }
+
+        paragraph.enumerateAttributes(in: paragraph.rangeOfEntireString, options: []) { (attrs, range, _) in
+
+            let styles = domStyles(from: attrs)
+            let leaves = leafNodes(from: paragraph.attributedSubstring(from: range))
+            let nodes = createNodes(from: styles, leaves: leaves)
+
+            children.append(contentsOf: nodes)
+        }
+
+        guard let paragraphElement = createParagraphElement(from: paragraph, withChildren: children) else {
+            return children
+        }
+
+        return [paragraphElement]
+    }
+}
+
+
+// MARK: - Leaf Nodes
+//
+private extension NSAttributedStringToNodes {
+
+    ///
+    ///
+    func leafNodes(from attrString: NSAttributedString) -> [Node] {
+        let attachment = attrString.attribute(NSAttachmentAttributeName, at: 0, effectiveRange: nil) as? NSTextAttachment
+        var leafs = [Node]()
+
+        switch attachment {
+        case let lineAttachment as LineAttachment:
+            let node = lineAttachmentToNode(lineAttachment)
+            leafs.append(node)
+        case let commentAttachment as CommentAttachment:
+            let node = commentAttachmentToNode(commentAttachment)
+            leafs.append(node)
+        case let htmlAttachment as HTMLAttachment:
+            let nodes = htmlAttachmentToNode(htmlAttachment)
+            leafs.append(contentsOf: nodes)
+        case let imageAttachment as ImageAttachment:
+            let node = imageAttachmentToNode(imageAttachment)
+            leafs.append(node)
+        default:
+            let nodes = textToNode(attrString.string)
+            leafs.append(contentsOf: nodes)
+        }
+
+        return leafs
+    }
+
+    ///
+    ///
+    private func lineAttachmentToNode(_ lineAttachment: LineAttachment) -> ElementNode {
+        return ElementNode(type: .hr, attributes: [], children: [])
+    }
+
+
+    ///
+    ///
+    private func commentAttachmentToNode(_ attachment: CommentAttachment) -> CommentNode {
+        return CommentNode(text: attachment.text)
+    }
+
+
+    ///
+    ///
+    private func htmlAttachmentToNode(_ attachment: HTMLAttachment) -> [Node] {
+        let converter = Libxml2.In.HTMLConverter()
+
+        guard let rootNode = try? converter.convert(attachment.rawHTML),
+            let firstChild = rootNode.children.first
+        else {
+            return textToNode(attachment.rawHTML)
+        }
+
+        guard rootNode.children.count == 1 else {
+            let spanElement = ElementNode(type: .span, attributes: [], children: rootNode.children)
+            return [spanElement]
+        }
+
+        return [firstChild]
+    }
+
+
+    ///
+    ///
+    private func imageAttachmentToNode(_ attachment: ImageAttachment) -> ElementNode {
+        var attributes = [Attribute]()
+        if let url = attachment.url {
+            let source = StringAttribute(name: "src", value: url.absoluteString)
+            attributes.append(source)
+        }
+
+        return ElementNode(type: .img, attributes: attributes, children: [])
+    }
+
+
+    ///
+    ///
+    private func textToNode(_ text: String) -> [Node] {
+        let substrings = text.components(separatedBy: String(.newline))
+        var output = [Node]()
+
+        for substring in substrings {
+            if output.count > 0 {
+                let newline = ElementNode(type: Libxml2.StandardElementType.br)
+                output.append(newline)
+            }
+            
+            let text = TextNode(text: substring)
+            output.append(text)
+        }
+
+        return output
+    }
+}
+
+
+
+// MARK: - Node Creation
+//
+private extension NSAttributedStringToNodes {
+
+    /// Creates an ElementNode from an AttributedString
+    ///
+    /// - Parameters:
+    ///     - attrString: AttributedString from which we intend to extract the ElementNode
+    ///     - childre: Array of Node instances to be set as children
+    ///
+    /// - Returns: the root ElementNode
+    ///
+    func createParagraphElement(from attrString: NSAttributedString, withChildren children: [Node]) -> ElementNode? {
+
+        guard let paragraphStyle = attrString.attribute(NSParagraphStyleAttributeName, at: 0, effectiveRange: nil) as? ParagraphStyle else {
+            return nil
+        }
+
+        let domParagraphStyles = self.domParagraphStyles(from: paragraphStyle)
+        guard domParagraphStyles.isEmpty == false else {
+            return nil
+        }
+
+        let element = domParagraphStyles.reversed().reduce(children) { (previous, style) -> [Node] in
+            return [ style.toElement(children: previous) ]
+        }
+
+        guard let result = element.first as? ElementNode else {
+            fatalError("The input array of paragraph styles cannot be empty, so this should not be possible.")
+        }
+
+        return result
+    }
+
+
+    ///
+    ///
+    func createNodes(from domStyles: [DOMStyle], leaves: [Node]) -> [Node] {
+        let styleNodes = domStyles.reversed().reduce(leaves) { (children, style) in
+            return [style.toNode(children: children)]
+        }
+
+        return styleNodes
+    }
+}
+
+
+// MARK: - Style Extraction
+//
+private extension NSAttributedStringToNodes {
+
+    /// Converts a ParagraphStyle into an array of DOMParagraphStyle Instances.
+    ///
+    func domParagraphStyles(from style: ParagraphStyle) -> [DOMParagraphStyle] {
+        var styles = [DOMParagraphStyle]()
+
+        if style.blockquote != nil {
+            styles.append(.blockquote)
+        }
+
+        if style.htmlParagraph != nil {
+            styles.append(.paragraph)
+        }
+
+        if style.headerLevel > 0 {
+            styles.append(.header(level: style.headerLevel))
+        }
+
+        for list in style.textLists {
+            if list.style == .ordered {
+                styles.append(.orderedList)
+            } else {
+                styles.append(.unorderedList)
+            }
+        }
+
+        return styles
+    }
+
+
+    /// Converts a collection of NSAttributedString (Key, Value)'s into an array of DOMStyle Instances.
+    ///
+    func domStyles(from attributes: [String: Any]) -> [DOMStyle] {
+        var styles = [DOMStyle]()
+
+        for (key, value) in attributes {
+            styles.append(contentsOf: self.styles(key: key, value: value))
+        }
+
+        return styles
+    }
+
+
+    /// Converts an NSAttributedString Attribute : Value into an array of DOMStyle Instances.
+    ///
+    private func styles(key: String, value: Any) -> [DOMStyle] {
+        var styles = [DOMStyle]()
+
+        switch key {
+        case NSFontAttributeName:
+            guard let font = value as? UIFont else {
+                break
+            }
+
+            if font.containsTraits(.traitBold) == true {
+                styles.append(.bold)
+            }
+
+            if font.containsTraits(.traitItalic) == true {
+                styles.append(.italics)
+            }
+        case NSLinkAttributeName:
+            guard let url = value as? URL else {
+                break
+            }
+
+            styles.append(.anchor(url: url.absoluteString))
+        case NSStrikethroughStyleAttributeName:
+            styles.append(.strike)
+        case NSUnderlineStyleAttributeName:
+            styles.append(.underlined)
+        default:
+            break
+        }
+
+        return styles
+    }
+}
+
+
+// MARK: - Nested Types
+//
+private extension NSAttributedStringToNodes {
+
+    // MARK: - DOMParagraphStyle
+    //
+    enum DOMParagraphStyle {
+        case blockquote
+        case header(level: Int)
+        case horizontalRule
+        case orderedList
+        case paragraph
+        case preformatted
+        case unorderedList
+
+        func toElement(children: [Node]) -> ElementNode {
+            switch self {
+            case .blockquote:
+                return ElementNode(type: .blockquote, children: children)
+            case .header(let level):
+                let header = DOMString.elementTypeForHeaderLevel(level) ?? .h1
+                return ElementNode(type: header, children: children)
+            case .horizontalRule:
+                return ElementNode(type: .hr, children: children)
+            case .orderedList:
+                return ElementNode(type: .ol, children: children)
+            case .paragraph:
+                return ElementNode(type: .p, children: children)
+            case .preformatted:
+                return ElementNode(type: .pre, children: children)
+            case .unorderedList:
+                return ElementNode(type: .ul, children: children)
+            }
+        }
+    }
+
+
+    // MARK: - DOMStyle
+    //
+    enum DOMStyle {
+        case anchor(url: String)
+        case bold
+        case italics
+        case image(url: String)
+        case strike
+        case underlined
+
+        func toNode(children: [Node]) -> ElementNode {
+            switch self {
+            case .anchor(let url):
+                let source = StringAttribute(name: "href", value: url)
+                return ElementNode(type: .a, attributes: [source], children: children)
+            case .bold:
+                return ElementNode(type: .b, children: children)
+            case .italics:
+                return ElementNode(type: .i, children: children)
+            case .image(let url):
+                let source = StringAttribute(name: "src", value: url)
+                return ElementNode(type: .img, attributes: [source])
+            case .strike:
+                return ElementNode(type: .strike, children: children)
+            case .underlined:
+                return ElementNode(type: .u, children: children)
+            }
+        }
+    }
+}

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -112,7 +112,7 @@ extension Libxml2 {
             
             return output
         }
-        
+
         /// Sets the HTML for the DOM.
         ///
         /// - Parameters:

--- a/Aztec/Classes/Libxml2/DOMString.swift
+++ b/Aztec/Classes/Libxml2/DOMString.swift
@@ -503,7 +503,7 @@ extension Libxml2 {
         }
 
         private func removeHeaderSynchronously(headerLevel: Int, spanning range: NSRange) {
-            guard let elementType = elementTypeForHeaderLevel(headerLevel) else {
+            guard let elementType = DOMString.elementTypeForHeaderLevel(headerLevel) else {
                 return
             }
             domEditor.unwrap(range: range, fromElementsNamed: elementType.equivalentNames)
@@ -607,7 +607,7 @@ extension Libxml2 {
         }
 
         func applyHeader(_ headerLevel:Int, spanning range:NSRange) {
-            guard let elementType = elementTypeForHeaderLevel(headerLevel) else {
+            guard let elementType = DOMString.elementTypeForHeaderLevel(headerLevel) else {
                 return
             }
             performAsyncUndoable { [weak self] in
@@ -628,11 +628,11 @@ extension Libxml2 {
 
         // MARK: - Header types
 
-        private func elementTypeForHeaderLevel(_ headerLevel: Int) -> StandardElementType? {
-            if headerLevel < 1 && headerLevel > DOMString.headerLevels.count {
+        class func elementTypeForHeaderLevel(_ headerLevel: Int) -> StandardElementType? {
+            if headerLevel < 1 && headerLevel > headerLevels.count {
                 return nil
             }
-            return DOMString.headerLevels[headerLevel - 1]
+            return headerLevels[headerLevel - 1]
         }
 
         // MARK: - Raw HTML

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -491,7 +491,15 @@ open class TextStorage: NSTextStorage {
     // MARK: - HTML Interaction
 
     open func getHTML(prettyPrint: Bool = false) -> String {
-        return dom.getHTML(prettyPrint: prettyPrint)
+        let converter = NSAttributedStringToNodes()
+
+        // TODO: Testing Code. This will be violently updated!!
+        let nodes = converter.createNodes(fromParagraph: self)
+        let rootNode = Libxml2.RootNode(children: nodes, editContext: nil)
+
+        let serializer = Libxml2.Out.HTMLConverter(prettyPrint: prettyPrint)
+        return serializer.convert(rootNode)
+
     }
 
     func setHTML(_ html: String, withDefaultFontDescriptor defaultFontDescriptor: UIFontDescriptor) {


### PR DESCRIPTION
### Details:
In this PR we're bringing the tool we've implemented in the `return of the newlines` branch: **NSAttributedStringToNodes**, a tool meant to convert a NSAttributedString into it's HTML representation.

Ref. #492

### To test:
1. Launch the demo project
2. Try (Simple) styling, and switch to HTML mode
3. Verify the generated HTML matches with the visual style (partially at least!!).

Note: This is a work in progress. Unit Tests + Code Simplification + Proper newline support coming up next.

cc @diegoreymendez  @SergioEstevao 



