### PR TITLE
Backporting AttributedString Helpers

### DIFF
--- a/Aztec/Classes/Extensions/NSRange+Helpers.swift
+++ b/Aztec/Classes/Extensions/NSRange+Helpers.swift
@@ -12,8 +12,39 @@ extension NSRange
     ///
     /// - Returns: `true` if the receiver contains the specified range, `false` otherwise.
     ///
-    func contains(range: NSRange) -> Bool {
+    func contains(_ range: NSRange) -> Bool {
         return intersect(withRange: range) == range
+    }
+
+    /// Checks if the receiver contains the specified location.
+    ///
+    /// - Parameters:
+    ///     - range: the location that the receiver may or may not contain.
+    ///
+    /// - Returns: `true` if the receiver contains the specified location, `false` otherwise.
+    ///
+    func contains(offset: Int) -> Bool {
+        return offset >= location && offset <= location + length
+    }
+
+    /// Calculates the end location for the receiver.
+    ///
+    /// - Returns: the requested end location
+    ///
+    var endLocation: Int {
+        return location + length
+    }
+
+    /// Returns a range equal to the receiver extended to its right side by the specified addition
+    /// value.
+    ///
+    /// - Parameters:
+    ///     - addition: the number that will be added to the length of the range
+    ///
+    /// - Returns: the new range.
+    ///
+    func extendedRight(by addition: Int) -> NSRange {
+        return NSRange(location: location, length: length + addition)
     }
     
     /// Returns the intersection between the receiver and the specified range.
@@ -45,18 +76,47 @@ extension NSRange
         }
     }
 
+    /// Offsets the receiver by the specified value.
+    ///
+    /// - Parameters:
+    ///     - offset: the value to apply for the offset operation.
+    ///
+    /// - Returns: the requested range.
+    ///
+    func offset(by offset: Int) -> NSRange {
+        return NSRange(location: location + offset, length: length)
+    }
+
+    /// Returns a range equal to the receiver shortened on its left side by the specified deduction
+    /// value.
+    ///
+    /// - Parameters:
+    ///     - deduction: the number that will be deducted from the length of the range
+    ///
+    /// - Returns: the new range.
+    ///
+    func shortenedLeft(by deduction: Int) -> NSRange {
+        return NSRange(location: location + deduction, length: length - deduction)
+    }
+
+    /// Returns a range equal to the receiver shortened on its right side by the specified deduction
+    /// value.
+    ///
+    /// - Parameters:
+    ///     - deduction: the number that will be deducted from the length of the range
+    ///
+    /// - Returns: the new range.
+    ///
+    func shortenedRight(by deduction: Int) -> NSRange {
+        return NSRange(location: location, length: length - deduction)
+    }
+
     /// Returns the union with the specified range.
     ///
     /// This is `NSUnionRange` wrapped as an instance method.
     ///
     func union(withRange target: NSRange) -> NSRange {
         return NSUnionRange(self, target)
-    }
-
-    /// Returns the maximum Location.
-    ///
-    var endLocation: Int {
-        return location + length
     }
 
     /// Returns a NSRange instance with location = 0 + length = 0

--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -54,6 +54,17 @@ public extension String
         return lowerBound ..< upperBound
     }
 
+    func range(fromUTF16NSRange utf16NSRange: NSRange) -> Range<String.Index> {
+
+        let swiftUTF16Range = utf16.range(from: utf16NSRange)
+
+        guard let swiftRange = range(from: swiftUTF16Range) else {
+            fatalError("Out of bounds!")
+        }
+
+        return swiftRange
+    }
+
     /// Converts a UTF16 NSRange into a `Range<String.Index>` for this string.
     ///
     /// - Parameters:

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -511,7 +511,7 @@ extension Libxml2 {
             onMatchFound matchFound: NodeIntersectionReport?,
             onMatchNotFound matchNotFound: RangeReport?) {
 
-            assert(range().contains(range: targetRange))
+            assert(range().contains(targetRange))
             assert(matchFound != nil || matchNotFound != nil)
 
             guard !isMatch(self) else {

--- a/Aztec/Classes/Libxml2/DOM/Logic/DOMEditor.swift
+++ b/Aztec/Classes/Libxml2/DOM/Logic/DOMEditor.swift
@@ -226,7 +226,7 @@ extension Libxml2 {
         ///
         fileprivate func forceWrapChildren(of element: ElementNode, intersecting targetRange: NSRange, inElement elementDescriptor: ElementNodeDescriptor) {
 
-            assert(element.range().contains(range: targetRange))
+            assert(element.range().contains(targetRange))
 
             let childNodesAndRanges = element.childNodes(intersectingRange: targetRange)
 

--- a/AztecTests/Extensions/NSAttributedStringListsTests.swift
+++ b/AztecTests/Extensions/NSAttributedStringListsTests.swift
@@ -6,45 +6,6 @@ import XCTest
 //
 class NSAttributedStringListsTests: XCTestCase {
 
-    /// Tests that `rangeOfTextList` works.
-    ///
-    /// Set up:
-    /// - Sample NSAttributedString, with no TextList
-    ///
-    /// Expected result:
-    /// - nil for the whole String Length
-    ///
-    func testRangeOfTextListReturnsNilWhenStringDoesntContainTextLists() {
-        for index in (0 ... samplePlainString.length) {
-            XCTAssertNil(samplePlainString.rangeOfTextList(atIndex: index))
-        }
-    }
-
-    /// Tests that `rangeOfTextList` works.
-    ///
-    /// Set up:
-    /// - Sample NSAttributedString, with a TextList associated to a substring
-    ///
-    /// Expected result:
-    /// - The "Text List Substring" range, when applicable.
-    ///
-    func testRangeOfTextListReturnsTheExpectedRange() {
-        let string = sampleListString
-        let expected = sampleListRange
-
-        for index in (0 ..< string.length) {
-            let retrieved = string.rangeOfTextList(atIndex: index)
-
-            if isIndexWithinListRange(index) {
-                XCTAssert(retrieved != nil)
-                XCTAssert(expected.location == retrieved!.location)
-                XCTAssert(expected.length == retrieved!.length)
-            } else {
-                XCTAssert(retrieved == nil)
-            }
-        }
-    }
-
     /// Tests that `rangeOfEntireString` works.
     ///
     /// Set up:
@@ -75,86 +36,6 @@ class NSAttributedStringListsTests: XCTestCase {
 
         XCTAssert(range.location == 0)
         XCTAssert(range.length == string.length)
-    }
-
-    /// Tests that `rangeOfLine` returns, effectively, the range of the line that matches with the given index.
-    ///
-    /// Set up:
-    /// - Sample text with two lines
-    ///
-    /// Expected result:
-    /// - Range of the first (OR) second line, whenever the index parameter falls within the required values.
-    ///
-    func testRangeOfLineEffectivelyReturnsTheRangeOfTheCurrentLine() {
-        // Setup
-        let firstText = "this would be a line\n"
-        let secondText = "and this too\n"
-        let fullText = NSAttributedString(string: firstText + secondText)
-
-        // Expected Ranges
-        let foundationText = fullText.string as NSString
-        let firstRange = foundationText.range(of: firstText)
-        let secondRange = foundationText.range(of: secondText)
-
-
-        // Check
-        for index in (0 ..< fullText.length) {
-            guard let range = fullText.rangeOfLine(atIndex: index) else {
-                XCTFail()
-                return
-            }
-
-            var target = secondRange
-            if index >= firstRange.location && index < NSMaxRange(firstRange) {
-                target = firstRange
-            }
-
-            XCTAssert(range.location == target.location && range.length == target.length)
-        }
-    }
-
-    /// Tests that `textListContents` returns nil, whenever there is no Text List.
-    ///
-    /// Set up:
-    /// - Sample (NON empty) NSAttributedString, but with no TextList
-    ///
-    /// Expected result:
-    /// - nil for the whole String Length.
-    ///
-    func testTextListContentsReturnsNilWheneverTheReceiverHasNoTextList() {
-        let string = samplePlainString
-
-        for index in (0 ..< string.length) {
-            let contents = string.textListContents(followingIndex: index)
-            XCTAssertNil(contents)
-        }
-    }
-
-    /// Tests that `textListContents` returns the expected TestList Contents.
-    ///
-    /// Set up:
-    /// - Sample (NON empty) NSAttributedString, with a TextList range.
-    ///
-    /// Expected result:
-    /// - Text List Contents. YAY!.
-    ///
-    func testTextListContentsReturnsTheAssociatedTextListContents() {
-        let string = sampleListString
-        let expectedContents = sampleListContents
-        let expectedRange = sampleListRange
-
-        for index in (0 ..< string.length) {
-            let retrievedContents = string.textListContents(followingIndex: index)
-
-            if isIndexWithinListRange(index) {
-                XCTAssertNotNil(retrievedContents)
-                let delta = index - expectedRange.location
-                let expectedSubstring = expectedContents.substring(from: expectedContents.characters.index(expectedContents.startIndex, offsetBy: delta))
-                XCTAssertEqual(retrievedContents!.string, expectedSubstring)
-            } else {
-                XCTAssertNil(retrievedContents)
-            }
-        }
     }
 
     /// Tests that `textListAttribute` returns the expected TestList, when applicable.
@@ -207,7 +88,7 @@ class NSAttributedStringListsTests: XCTestCase {
 
         for index in (0 ..< string.length) {
             let range = NSRange(location: index, length: 1)
-            XCTAssertNil(string.textListAttribute(spanningRange: range))
+            XCTAssertNil(string.textListAttribute(spanning: range))
         }
     }
 
@@ -224,7 +105,7 @@ class NSAttributedStringListsTests: XCTestCase {
 
         for index in (0 ..< string.length) {
             let range = NSRange(location: index, length: 1)
-            let attribute = string.textListAttribute(spanningRange: range)
+            let attribute = string.textListAttribute(spanning: range)
 
             if isIndexWithinListRange(index) {
                 XCTAssertNotNil(attribute)
@@ -245,7 +126,7 @@ class NSAttributedStringListsTests: XCTestCase {
     ///
     func testTextListAttributeSpanningRangeReturnsTextListAttributeWhenPassedFullRange() {
         let string = sampleListString
-        let attribute = string.textListAttribute(spanningRange: sampleListRange)
+        let attribute = string.textListAttribute(spanning: sampleListRange)
 
         XCTAssertNotNil(attribute)
     }
@@ -260,25 +141,8 @@ class NSAttributedStringListsTests: XCTestCase {
     ///
     func testParagraphRangesReturnEmptyArrayForEmptyStrings() {
         let string = NSAttributedString()
-        let paragraphRanges = string.paragraphRanges(spanningRange: NSRange(location: 0, length: 0))
+        let paragraphRanges = string.paragraphRanges(spanning: NSRange(location: 0, length: 0))
 
-        XCTAssert(paragraphRanges.isEmpty)
-    }
-
-    /// Tests that `paragraphRanges` returns an empty array, when the spanning range is beyond the actual 
-    /// receiver's full range.
-    ///
-    /// Set up:
-    /// - Sample (NON empty) NSAttributedString.
-    ///
-    /// Expected result:
-    /// - Empty array.
-    ///
-    func testParagraphRangesReturnEmptyArrayWhenSpanningRangeIsBiggerThanReceiverString() {
-        let string = samplePlainString
-        let range = NSRange(location: string.length, length: string.length)
-
-        let paragraphRanges = string.paragraphRanges(spanningRange: range)
         XCTAssert(paragraphRanges.isEmpty)
     }
 
@@ -295,17 +159,11 @@ class NSAttributedStringListsTests: XCTestCase {
         let string = sampleSingleLine
         let expected = string.rangeOfEntireString
 
-        for index in (0..<string.length) {
-            let spanningRange = NSRange(location: index, length: 1)
-            let paragraphRanges = string.paragraphRanges(spanningRange: spanningRange)
+        for index in (0 ..< string.length) {
+            let targetRange = NSRange(location: index, length: 1)
+            let paragraphRange = string.paragraphRange(for: targetRange)
 
-            XCTAssert(paragraphRanges.count == 1)
-            guard let retrieved = paragraphRanges.first else {
-                XCTFail()
-                return
-            }
-
-            XCTAssert(retrieved.location == expected.location && retrieved.length == expected.length)
+            XCTAssert(paragraphRange == expected)
         }
     }
 
@@ -326,10 +184,13 @@ class NSAttributedStringListsTests: XCTestCase {
         let expected = [first, second, third]
         let text = NSAttributedString(string: first + second + third)
 
-        let ranges = text.paragraphRanges(spanningRange: text.rangeOfEntireString)
+        let ranges = text.paragraphRanges(spanning: text.rangeOfEntireString)
         XCTAssert(ranges.count == 3)
 
-        let paragraphs = ranges.map { text.attributedSubstring(from: $0).string }
+        let paragraphs = ranges.map { (_, enclosingRange) in
+            text.attributedSubstring(from: enclosingRange).string
+        }
+
         for (index, retrieved) in paragraphs.enumerated() {
             let expected = expected[index]
             XCTAssert(expected == retrieved)
@@ -352,126 +213,16 @@ class NSAttributedStringListsTests: XCTestCase {
         let text = NSAttributedString(string: first + second)
         let rangeExpected = (text.string as NSString).range(of: first)
 
-        let rangesForParagraphs = text.paragraphRanges(spanningRange: rangeExpected)
+        let rangesForParagraphs = text.paragraphRanges(spanning: rangeExpected)
         XCTAssert(rangesForParagraphs.count == 1)
 
-        guard let rangeRetrieved = rangesForParagraphs.first else {
+        guard let (_, encapsulatedRange) = rangesForParagraphs.first else {
             XCTFail()
             return
         }
 
-        XCTAssert(rangeRetrieved.location == rangeExpected.location)
-        XCTAssert(rangeRetrieved.length == rangeExpected.length)
-    }
-
-
-    /// Tests that `paragraphRanges(atIndex: matchingListStyle)` returns the pargraph ranges, whenever the list
-    /// style matches.
-    ///
-    /// Set up:
-    /// - Attributed String with three list-paragraphs
-    ///
-    /// Expected result:
-    /// - Array with three ranges, whenever the method is passed an index that lies within the list range.
-    ///
-    func testParagraphRangesOfListStyleReturnsTheListRangeAtTheSpecifiedIndexWhenStyleMatches() {
-        let string = sampleListString
-
-        for index in (0 ..< string.length) {
-            let ranges = string.paragraphRanges(atIndex: index, matchingListStyle: sampleListStyle)
-            if isIndexWithinListRange(index) {
-                XCTAssert(ranges.count == 4)
-            } else {
-                XCTAssert(ranges.isEmpty)
-            }
-        }
-    }
-
-    /// Tests that `paragraphRanges(atIndex: matchingListStyle)` returns an empty array, whenever the list
-    /// style doesn't match.
-    ///
-    /// Set up:
-    /// - Attributed String with three list-paragraphs
-    ///
-    /// Expected result:
-    /// - Array with zero entities.
-    ///
-    func testParagraphRangesOfListStyleReturnsAnEmptyArrayWheneverStyleWontMatch() {
-        let string = sampleListString
-
-        for index in (0 ..< string.length) {
-            for listStyle in listStyles where listStyle != sampleListStyle {
-                let ranges = string.paragraphRanges(atIndex: index, matchingListStyle: listStyle)
-                XCTAssert(ranges.isEmpty)
-            }
-        }
-    }
-
-    /// Tests that `paragraphRanges(atIndex: matchingListStyle)` returns an empty array, whenever there is no textList.
-    ///
-    /// Set up:
-    /// - Attributed String with no text lists.
-    ///
-    /// Expected result:
-    /// - Array with zero entities.
-    ///
-    func testParagraphRangesOfListStyleReturnsAnEmptyArrayWheneverThereIsNoList() {
-        let string = samplePlainString
-
-        for index in (0 ..< string.length) {
-            for listStyle in listStyles {
-                let ranges = string.paragraphRanges(atIndex: index, matchingListStyle: listStyle)
-                XCTAssert(ranges.isEmpty)
-            }
-        }
-    }
-
-    /// Tests that `paragraphRanges(preceedingAndSucceding: matchingListStyle)` the same ranges received, whenever there is no
-    /// surrounding list.
-    ///
-    /// Set up:
-    /// - Attributed String with no text lists.
-    /// - Ranges of all of the string's paragraphs
-    ///
-    /// Expected result:
-    /// - Same Input Ranges
-    ///
-    func testParagraphRangesPreceedingAndSucceedingRangesReturnTheReceivedRangesIfThereIsNoSurroundingList() {
-        let string = samplePlainString
-        let ranges = string.paragraphRanges(spanningRange: string.rangeOfEntireString)
-
-        for style in listStyles {
-            let retrieved = string.paragraphRanges(preceedingAndSucceding: ranges, matchingListStyle: style)
-            XCTAssert(retrieved.count == ranges.count)
-        }
-    }
-
-    /// Tests that `paragraphRanges(preceedingAndSucceding: matchingListStyle)` returns all of the list's paragraph ranges,
-    /// when a single paragraph is fed.
-    ///
-    /// Set up:
-    /// - Attributed String with a text list.
-    /// - Ranges of all of the string's paragraphs
-    ///
-    /// Expected result:
-    /// - Full List Ranges, whenever each one of the List Item Ranges is sent over
-    ///
-    func testParagraphRangesPreceedingAndSucceedingRangesEffectivelyInjectSurroundingListRanges() {
-        let listString = sampleListString
-        let listRange = sampleListRange
-        let listParagraphRanges = listString.paragraphRanges(spanningRange: listRange)
-        XCTAssert(listParagraphRanges.count == 4)
-
-        for itemRange in listParagraphRanges {
-            let retrievedRanges = listString.paragraphRanges(preceedingAndSucceding: [itemRange], matchingListStyle: sampleListStyle)
-            XCTAssert(retrievedRanges.count == listParagraphRanges.count)
-            
-            for retrievedRange in retrievedRanges {
-                XCTAssertTrue(listParagraphRanges.contains(where: { (range) -> Bool in
-                    listParagraphRanges.contains(retrievedRange)
-                }))
-            }
-        }
+        XCTAssert(encapsulatedRange.location == rangeExpected.location)
+        XCTAssert(encapsulatedRange.length == rangeExpected.length)
     }
 }
 

--- a/AztecTests/Formatters/BlockquoteFormatterTests.swift
+++ b/AztecTests/Formatters/BlockquoteFormatterTests.swift
@@ -114,7 +114,7 @@ private extension BlockquoteFormatterTests {
     }
 
     func paragraphRanges(inString string: NSAttributedString) -> [NSRange] {
-        return string.paragraphRanges(spanningRange: string.rangeOfEntireString)
+        return string.paragraphRanges(spanning: string.rangeOfEntireString)
     }
 
     func existsBlockquote(for string: NSMutableAttributedString, in range: NSRange) -> Bool {

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -272,7 +272,7 @@ class TextListFormatterTests: XCTestCase {
 
         // Verify we got a single big orderedList
         let ranges = paragraphRanges(inString: list)
-        let lists = ranges.flatMap { list.textListAttribute(spanningRange: $0) }
+        let lists = ranges.flatMap { list.textListAttribute(spanning: $0) }
 
         XCTAssert(lists[0].style == .ordered)
         XCTAssert(lists[1].style == .ordered)
@@ -313,7 +313,7 @@ class TextListFormatterTests: XCTestCase {
         // Verify
         let paragraphs = paragraphRanges(inString: string)
         for (index, range) in paragraphs.enumerated() {
-            let list = string.textListAttribute(spanningRange: range)
+            let list = string.textListAttribute(spanning: range)
             XCTAssertNotNil(list)
             XCTAssert(list!.style == .ordered)
 
@@ -349,7 +349,7 @@ class TextListFormatterTests: XCTestCase {
         // Verify
         let paragraphs = paragraphRanges(inString: string)
         for (index, range) in paragraphs.enumerated() {
-            guard let list = string.textListAttribute(spanningRange: range) else
+            guard let list = string.textListAttribute(spanning: range) else
             {
                 XCTFail()
                 return
@@ -499,12 +499,12 @@ private extension TextListFormatterTests
     }
 
     func paragraphRanges(inString string: NSAttributedString) -> [NSRange] {
-        return string.paragraphRanges(spanningRange: string.rangeOfEntireString)
+        return string.paragraphRanges(spanning: string.rangeOfEntireString)
     }
 
     func textListAttributes(inString string: NSAttributedString, atRanges ranges: [NSRange]) -> [TextList] {
         return ranges.flatMap {
-            string.textListAttribute(spanningRange: $0)
+            string.textListAttribute(spanning: $0)
         }
     }
 }


### PR DESCRIPTION
### Details:
This PR contains no new code. We're just backporting all of the NSAttributedString and NSRange new helpers, developed in the New Lines branch

### To test:
Run a smoke test over the sample app, and verify it works as before (in the working branch!!)

cc @diegoreymendez 
thanks in advance!
