### PR TITLE
HTML Generation: Merging to Left!

### DIFF
--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -20,7 +20,11 @@ class NSAttributedStringToNodes: Converter {
     typealias StandardElementType = Libxml2.StandardElementType
 
 
+    /// Converts an Attributed String Instance into it's HTML Tree Representation.
     ///
+    /// -   Parameter attrString: Attributed String that should be converted.
+    ///
+    /// -   Returns: RootNode, representing the DOM Tree.
     ///
     func convert(_ attrString: NSAttributedString) -> RootNode {
         var previous = [Node]()
@@ -44,7 +48,11 @@ class NSAttributedStringToNodes: Converter {
     }
 
 
+    /// Converts a *Paragraph* into a collection of Nodes, representing the internal HTML Entities.
     ///
+    /// - Parameter paragraph: Paragraph's Attributed String that should be converted.
+    ///
+    /// - Returns: Array of Node instances.
     ///
     private func createNodes(fromParagraph paragraph: NSAttributedString) -> [Node] {
         var children = [Node]()
@@ -71,11 +79,11 @@ class NSAttributedStringToNodes: Converter {
 }
 
 
-// MARK: - Restoring Dimensionality
+// MARK: - Dimensionality
 //
 private extension NSAttributedStringToNodes {
 
-    ///
+    /// Attempts to merge the Right array of Element Nodes (Paragraph Level) into the Left array of Nodes.
     ///
     func merge(left: [ElementNode], right: [ElementNode]) -> Bool {
         guard let (target, source) = findLowestMergeableNodes(left: left, right: right) else {
@@ -88,7 +96,7 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Returns the "Right Most" Blocklevel Node from a collection fo nodes.
     ///
     func rightMostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
         return paragraphStyleElements(from: nodes) { children in
@@ -97,7 +105,7 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Returns the "Left Most" Blocklevel Node from a collection fo nodes.
     ///
     func leftMostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
         return paragraphStyleElements(from: nodes) { children in
@@ -106,7 +114,7 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Finds the Deepest node that can be merged "Right to Left", and returns the Left / Right matching touple, if any.
     ///
     private func findLowestMergeableNodes(left: [ElementNode], right: [ElementNode]) -> (ElementNode, ElementNode)? {
         var currentIndex = 0
@@ -128,7 +136,8 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Returns a children Blocklevel Node from a collection of nodes, using a Child Picker to determine the
+    /// navigational-direction.
     ///
     private func paragraphStyleElements(from nodes: [Node], childPicker: (([Node]) -> Node?)) -> [ElementNode] {
         var elements = [ElementNode]()
@@ -153,13 +162,13 @@ private extension NSAttributedStringToNodes {
 //
 private extension NSAttributedStringToNodes {
 
-    /// Creates an ElementNode from an AttributedString
+    /// Extracts the ElementNode contained within a Paragraph's AttributedString.
     ///
     /// - Parameters:
-    ///     - attrString: AttributedString from which we intend to extract the ElementNode
+    ///     - attrString: Paragraph's AttributedString from which we intend to extract the ElementNode
     ///     - children: Array of Node instances to be set as children
     ///
-    /// - Returns: the root ElementNode
+    /// - Returns: ElementNode representing the specified Paragraph.
     ///
     func createParagraphElement(from attrString: NSAttributedString, children: [Node]) -> ElementNode? {
         guard let paragraphStyle = attrString.attribute(NSParagraphStyleAttributeName, at: 0, effectiveRange: nil) as? ParagraphStyle else {
@@ -177,7 +186,13 @@ private extension NSAttributedStringToNodes {
     }
 
 
+    /// Extracts all of the Style Nodes contained within a collection of AttributedString Attributes.
     ///
+    /// - Parameters:
+    ///     - attrs: Collection of attributes that should be converted.
+    ///     - leaves: Leaf nodes that should be used to regen the tree.
+    ///
+    /// - Returns: Style Nodes contained within the specified collection of attributes
     ///
     func createStyleNodes(from attrs: [String: Any], leaves: [Node]) -> [Node] {
         var lastNodes: [ElementNode]?
@@ -191,7 +206,12 @@ private extension NSAttributedStringToNodes {
     }
 
 
+    /// Extract all of the Leaf Nodes contained within an Attributed String. We consider the following as Leaf:
+    /// Plain Text, Attachments of any kind [Line, Comment, HTML, Image].
     ///
+    /// - Parameter attrString: AttributedString that should be converted.
+    ///
+    /// - Returns: Leaf Nodes contained within the specified collection of attributes
     ///
     func createLeafNodes(from attrString: NSAttributedString) -> [Node] {
         let attachment = attrString.attribute(NSAttachmentAttributeName, at: 0, effectiveRange: nil) as? NSTextAttachment
@@ -212,11 +232,11 @@ private extension NSAttributedStringToNodes {
 }
 
 
-// MARK: - Style Extraction
+// MARK: - Enumerators
 //
 private extension NSAttributedStringToNodes {
 
-    ///
+    /// Enumerates all of the "Paragraph ElementNode's" contained within a collection of AttributedString's Atributes.
     ///
     func enumerateParagraphNodes(in style: ParagraphStyle, block: ((ElementNode) -> Void)) {
         if style.blockquote != nil {
@@ -247,7 +267,7 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Enumerates all of the "Style ElementNode's" contained within a collection of AttributedString's Atributes.
     ///
     func enumerateStyleNodes(in attributes: [String: Any], block: ((ElementNode) -> Void)) {
         for (key, value) in attributes {
@@ -296,7 +316,7 @@ private extension NSAttributedStringToNodes {
 //
 private extension NSAttributedStringToNodes {
 
-    ///
+    /// Converts a Line Attachment into it's representing nodes.
     ///
     func lineAttachmentToNodes(_ lineAttachment: LineAttachment) -> [Node] {
         let node = ElementNode(type: .hr)
@@ -304,7 +324,7 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Converts a Comment Attachment into it's representing nodes.
     ///
     func commentAttachmentToNodes(_ attachment: CommentAttachment) -> [Node] {
         let node = CommentNode(text: attachment.text)
@@ -312,7 +332,7 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Converts an HTML Attachment into it's representing nodes.
     ///
     func htmlAttachmentToNode(_ attachment: HTMLAttachment) -> [Node] {
         let converter = Libxml2.In.HTMLConverter()
@@ -332,7 +352,7 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Converts an Image Attachment into it's representing nodes.
     ///
     func imageAttachmentToNodes(_ attachment: ImageAttachment) -> [Node] {
         var attributes = [Attribute]()
@@ -346,7 +366,7 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Converts a String into it's representing nodes.
     ///
     func textToNodes(_ text: String) -> [Node] {
         let substrings = text.components(separatedBy: String(.newline))

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -30,7 +30,10 @@ class NSAttributedStringToNodes: Converter {
             let paragraph = attrString.attributedSubstring(from: paragraphRange)
             let children = createNodes(fromParagraph: paragraph)
 
-            guard !merge(left: previous, right: children) else {
+            let left = rightMostParagraphStyleElements(from: previous)
+            let right = leftMostParagraphStyleElements(from: children)
+
+            guard !merge(left: left, right: right) else {
                 return
             }
             nodes += children
@@ -74,10 +77,7 @@ private extension NSAttributedStringToNodes {
 
     ///
     ///
-    func merge(left: [Node], right: [Node]) -> Bool {
-        let left = rightMostParagraphStyleElements(from: left)
-        let right = leftMostParagraphStyleElements(from: right)
-
+    func merge(left: [ElementNode], right: [ElementNode]) -> Bool {
         guard let (target, source) = findLowestMergeableNodes(left: left, right: right) else {
             return false
         }
@@ -85,6 +85,24 @@ private extension NSAttributedStringToNodes {
         target.children += source.children
 
         return true
+    }
+
+
+    ///
+    ///
+    func rightMostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
+        return paragraphStyleElements(from: nodes) { children in
+            return children.last
+        }
+    }
+
+
+    ///
+    ///
+    func leftMostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
+        return paragraphStyleElements(from: nodes) { children in
+            return children.first
+        }
     }
 
 
@@ -107,24 +125,6 @@ private extension NSAttributedStringToNodes {
         }
         
         return match
-    }
-
-
-    ///
-    ///
-    private func rightMostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
-        return paragraphStyleElements(from: nodes) { children in
-            return children.last
-        }
-    }
-
-
-    ///
-    ///
-    private func leftMostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
-        return paragraphStyleElements(from: nodes) { children in
-            return children.first
-        }
     }
 
 

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -43,39 +43,6 @@ class NSAttributedStringToNodes: Converter {
 
     ///
     ///
-    private func merge(left: [ElementNode], right: [ElementNode]) -> Bool {
-        guard let (target, source) = findLowestMatchingNodes(left: left, right: right) else {
-            return false
-        }
-
-        target.children += source.children
-
-        return true
-    }
-
-
-    private func findLowestMatchingNodes(left: [ElementNode], right: [ElementNode]) -> (ElementNode, ElementNode)? {
-        var currentIndex = 0
-        var match: (ElementNode, ElementNode)?
-
-        while currentIndex < left.count && currentIndex < right.count {
-            let left = left[currentIndex]
-            let right = right[currentIndex]
-
-            guard left.canMergeChildren(of: right) else {
-                break
-            }
-
-            match = (left, right)
-            currentIndex += 1
-        }
-
-        return match
-    }
-
-
-    ///
-    ///
     private func createNodes(fromParagraph paragraph: NSAttributedString) -> ([Node], [ElementNode]) {
         var children = [Node]()
 
@@ -99,6 +66,46 @@ class NSAttributedStringToNodes: Converter {
         }
 
         return ([theParagraphElement], paragraphNodes)
+    }
+}
+
+
+// MARK: - Restoring Dimensionality
+//
+private extension NSAttributedStringToNodes {
+
+    ///
+    ///
+    func merge(left: [ElementNode], right: [ElementNode]) -> Bool {
+        guard let (target, source) = findLowestMergeableNodes(left: left, right: right) else {
+            return false
+        }
+
+        target.children += source.children
+
+        return true
+    }
+
+
+    ///
+    ///
+    private func findLowestMergeableNodes(left: [ElementNode], right: [ElementNode]) -> (ElementNode, ElementNode)? {
+        var currentIndex = 0
+        var match: (ElementNode, ElementNode)?
+
+        while currentIndex < left.count && currentIndex < right.count {
+            let left = left[currentIndex]
+            let right = right[currentIndex]
+
+            guard left.canMergeChildren(of: right) else {
+                break
+            }
+
+            match = (left, right)
+            currentIndex += 1
+        }
+        
+        return match
     }
 }
 

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -34,8 +34,8 @@ class NSAttributedStringToNodes: Converter {
             let paragraph = attrString.attributedSubstring(from: paragraphRange)
             let children = createNodes(fromParagraph: paragraph)
 
-            let left = rightMostParagraphStyleElements(from: previous)
-            let right = leftMostParagraphStyleElements(from: children)
+            let left = rightmostParagraphStyleElements(from: previous)
+            let right = leftmostParagraphStyleElements(from: children)
 
             guard !merge(left: left, right: right) else {
                 return
@@ -96,18 +96,18 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    /// Returns the "Right Most" Blocklevel Node from a collection fo nodes.
+    /// Returns the "Rightmost" Blocklevel Node from a collection fo nodes.
     ///
-    func rightMostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
+    func rightmostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
         return paragraphStyleElements(from: nodes) { children in
             return children.last
         }
     }
 
 
-    /// Returns the "Left Most" Blocklevel Node from a collection fo nodes.
+    /// Returns the "Leftmost" Blocklevel Node from a collection fo nodes.
     ///
-    func leftMostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
+    func leftmostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
         return paragraphStyleElements(from: nodes) { children in
             return children.first
         }

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -75,8 +75,8 @@ private extension NSAttributedStringToNodes {
     ///
     ///
     func merge(left: [Node], right: [Node]) -> Bool {
-        let left = paragraphStyleElements(from: left)
-        let right = paragraphStyleElements(from: right)
+        let left = rightMostParagraphStyleElements(from: left)
+        let right = leftMostParagraphStyleElements(from: right)
 
         guard let (target, source) = findLowestMergeableNodes(left: left, right: right) else {
             return false
@@ -112,9 +112,28 @@ private extension NSAttributedStringToNodes {
 
     ///
     ///
-    private func paragraphStyleElements(from nodes: [Node]) -> [ElementNode] {
+    private func rightMostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
+        return paragraphStyleElements(from: nodes) { children in
+            return children.last
+        }
+    }
+
+
+    ///
+    ///
+    private func leftMostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
+        return paragraphStyleElements(from: nodes) { children in
+            return children.first
+        }
+    }
+
+
+    ///
+    ///
+    private func paragraphStyleElements(from nodes: [Node], childPicker: (([Node]) -> Node?)) -> [ElementNode] {
         var elements = [ElementNode]()
-        var nextElement = nodes.first as? ElementNode
+        var nextElement = childPicker(nodes) as? ElementNode
+
 
         while let currentElement = nextElement {
             guard currentElement.isBlockLevelElement() else {
@@ -122,7 +141,7 @@ private extension NSAttributedStringToNodes {
             }
 
             elements.append(currentElement)
-            nextElement = currentElement.children.first as? ElementNode
+            nextElement = childPicker(currentElement.children) as? ElementNode
         }
 
         return elements

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -17,6 +17,7 @@ class NSAttributedStringToNodes: Converter {
     typealias DOMString = Libxml2.DOMString
     typealias Attribute = Libxml2.Attribute
     typealias StringAttribute = Libxml2.StringAttribute
+    typealias StandardElementType = Libxml2.StandardElementType
 
 
     ///
@@ -61,10 +62,7 @@ class NSAttributedStringToNodes: Converter {
             let left = left[currentIndex]
             let right = right[currentIndex]
 
-            let leftAttributes = Set(arrayLiteral: left.attributes)
-            let rightAttributes = Set(arrayLiteral: right.attributes)
-
-            if left.name != right.name || left.attributes != right.attributes {
+            guard left.canMergeChildren(of: right) else {
                 break
             }
 

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -30,10 +30,11 @@ class NSAttributedStringToNodes: Converter {
             let paragraph = attrString.attributedSubstring(from: paragraphRange)
             let (children, paragraphStyles) = createNodes(fromParagraph: paragraph)
 
-            if !merge(left: previousParagraphStyles, right: paragraphStyles) {
-                nodes += children
+            guard !merge(left: previousParagraphStyles, right: paragraphStyles) else {
+                return
             }
 
+            nodes += children
             previousParagraphStyles = paragraphStyles
         }
 

--- a/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
@@ -3,7 +3,7 @@ extension Libxml2 {
     /// Represents a basic attribute with no value.  This is also the base class for all other
     /// attributes.
     ///
-    class Attribute: CustomReflectable {
+    class Attribute: CustomReflectable, Equatable, Hashable {
         let name: String
         
         // MARK: - CustomReflectable
@@ -19,7 +19,21 @@ extension Libxml2 {
         init(name: String) {
             self.name = name
         }
+
+
+        // MARK - Hashable
+
+        var hashValue: Int {
+            return name.hashValue
+        }
+
+        // MARK: - Equatable
+
+        static func ==(lhs: Attribute, rhs: Attribute) -> Bool {
+            return type(of: lhs) == type(of: rhs) && lhs.name == rhs.name
+        }
     }
+
 
     /// Represents an attribute with an generic string value.  This is useful for storing attributes
     /// that do have a value, which we don't know how to parse.  This is only meant as a mechanism
@@ -40,6 +54,19 @@ extension Libxml2 {
             self.value = value
 
             super.init(name: name)
+        }
+
+        // MARK - Hashable
+
+        override var hashValue: Int {
+            return name.hashValue ^ value.hashValue
+        }
+
+
+        // MARK: - Equatable
+
+        static func ==(lhs: StringAttribute, rhs: StringAttribute) -> Bool {
+            return type(of: lhs) == type(of: rhs) && lhs.name == rhs.name && lhs.value == rhs.value
         }
     }
 }

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -18,6 +18,7 @@ extension Libxml2 {
         }
 
         private static let knownElements: [StandardElementType] = [.a, .b, .br, .blockquote, .del, .div, .em, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .i, .img, .li, .ol, .p, .pre, .s, .span, .strike, .strong, .u, .ul, .video]
+        private static let mergeableElements: [StandardElementType] = [.p, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .ol, .ul, .blockquote]
 
         internal var standardName: StandardElementType? {
             get {
@@ -198,6 +199,22 @@ extension Libxml2 {
         func lastChild(matching filter: (Node) -> Bool) -> Node? {
             return children.filter(filter).last
         }
+
+
+        ///
+        ///
+        func canMergeChildren(of node: ElementNode) -> Bool {
+            guard name == node.name && Set(attributes) == Set(node.attributes) else {
+                return false
+            }
+
+            guard let standardName = self.standardName else {
+                return false
+            }
+
+            return ElementNode.mergeableElements.contains(standardName)
+        }
+
 
         // MARK: - DOM Queries
         

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -10,7 +10,7 @@ extension Libxml2 {
         var attributes = [Attribute]()
         var children: [Node] {
             didSet {
-                for child in children {
+                for child in children where child.parent != self {
                     child.parent?.remove(child)
                     child.parent = self
                 }

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -188,6 +188,7 @@ extension Libxml2 {
         func isNodeType(_ type: StandardElementType) -> Bool {
             return type.equivalentNames.contains(name.lowercased())
         }
+        
 
         /// Retrieves the last child matching a specific filtering closure.
         ///
@@ -201,7 +202,12 @@ extension Libxml2 {
         }
 
 
+        /// Indicates whether the children of the specified node can be merged in, or not.
         ///
+        /// - Parameters:
+        ///     - node: Target node for which we'll determine Merge-ability status.
+        ///
+        /// - Returns: true if both nodes can be merged, or not.
         ///
         func canMergeChildren(of node: ElementNode) -> Bool {
             guard name == node.name && Set(attributes) == Set(node.attributes) else {

--- a/AztecTests/Converters/NSAttributedStringToNodesTests.swift
+++ b/AztecTests/Converters/NSAttributedStringToNodesTests.swift
@@ -6,26 +6,7 @@ import XCTest
 //
 class NSAttributedStringToNodesTests: XCTestCase {
 
-    /// Typealiases
-    ///
-    typealias Node = Libxml2.Node
-    typealias CommentNode = Libxml2.CommentNode
-    typealias ElementNode = Libxml2.ElementNode
-    typealias RootNode = Libxml2.RootNode
-    typealias TextNode = Libxml2.TextNode
-
-
-    ///
-    ///
-    private struct Constants {
-        static let sampleAttributes: [String : Any] = [
-            NSFontAttributeName: UIFont.systemFont(ofSize: UIFont.systemFontSize),
-            NSParagraphStyleAttributeName: NSParagraphStyle()
-        ]
-    }
-
-
-    ///
+    /// Verifies that Bold Style gets effectively mapped.
     ///
     func testBoldStyleEffectivelyMapsIntoItsTreeRepresentation() {
         let attributes = BoldFormatter().apply(to: Constants.sampleAttributes)
@@ -44,7 +25,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
     }
 
 
-    ///
+    /// Verifies that Italics Style gets effectively mapped.
     ///
     func testItalicStyleEffectivelyMapsIntoItsTreeRepresentation() {
         let attributes = ItalicFormatter().apply(to: Constants.sampleAttributes)
@@ -63,7 +44,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
     }
 
 
-    ///
+    /// Verifies that Underline Style gets effectively mapped.
     ///
     func testUnderlineStyleEffectivelyMapsIntoItsTreeRepresentation() {
         let attributes = UnderlineFormatter().apply(to: Constants.sampleAttributes)
@@ -82,7 +63,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
     }
 
 
-    ///
+    /// Verifies that Strike Style gets effectively mapped.
     ///
     func testStrikeStyleEffectivelyMapsIntoItsTreeRepresentation() {
         let attributes = StrikethroughFormatter().apply(to: Constants.sampleAttributes)
@@ -101,7 +82,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
     }
 
 
-    ///
+    /// Verifies that Link Style gets effectively mapped.
     ///
     func testLinkStyleEffectivelyMapsIntoItsTreeRepresentation() {
         let formatter = LinkFormatter()
@@ -123,7 +104,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
     }
 
 
-    ///
+    /// Verifies that Lists get effectively mapped.
     ///
     func testListItemsRemainInTheSameContainingUnorderedList() {
         let firstText = "First Line"
@@ -157,7 +138,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
     }
 
 
-    ///
+    /// Verifies that Comments get effectively mapped.
     ///
     func testCommentsArePreservedAndSerializedBack() {
         let attachment = CommentAttachment()
@@ -187,7 +168,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
     }
 
 
-    ///
+    /// Verifies that Line Attachments get effectively mapped.
     ///
     func testLineElementGetsProperlySerialiedBackIntoItsHtmlRepresentation() {
         let attachment = LineAttachment()
@@ -225,7 +206,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
     }
 
 
-    ///
+    /// Verifies that Header Style gets properly mapped.
     ///
     func testHeaderElementGetsProperlySerialiedBackIntoItsHtmlRepresentation() {
 
@@ -261,7 +242,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
     }
 
 
-    ///
+    /// Verifies that Unknown HTML Attachments get properly mapped, and don't get nuked along the way.
     ///
     func testUnknownHtmlDoesNotGetNuked() {
         let htmlAttachment = HTMLAttachment()
@@ -297,43 +278,29 @@ class NSAttributedStringToNodesTests: XCTestCase {
         XCTAssertEqual(textNode.contents, textString.string)
         XCTAssertEqual(commentNode.comment, commentAttachment.text)
     }
-
-
-//    ///
-//    ///
-//    func testContiguousUnorderedListsGetHeirItemsmerged() {
-//        let input = "<ul><li>First Line</li></ul><ul><li>Second Line</li></ul>"
-//        let expected = "<ul><li>First Line</li><li>Second Line</li></ul>"
-//
-//        let generated = generatedHTML(input: input)
-//        XCTAssertEqual(generated, expected)
-//    }
-//
-//
-//    ///
-//    ///
-//    func testSomething2() {
-//        let input = "<blockquote><ul><li>First Line</li></ul></blockquote><blockquote><ul><li>Second Line</li></ul></blockquote>"
-//        let expected = "<blockquote><ul><li>First Line</li><li>Second Line</li></ul></blockquote>"
-//
-//        let generated = generatedHTML(input: input)
-//        XCTAssertEqual(generated, expected)
-//    }
-//
-//
-//    ///
-//    ///
-//    func testSomething() {
-//        let input = "<ul><li><blockquote>text 1</blockquote></li></ul>" +
-//                    "<ul><li><blockquote>text 2</blockquote></li></ul>"
-//        let expected = "<ul><li><blockquote>text 1</blockquote><blockquote>text 2</blockquote></li></ul>"
-//    }
 }
 
 
 // MARK: - Helpers
 //
 private extension NSAttributedStringToNodesTests {
+
+    /// Typealiases
+    ///
+    typealias Node = Libxml2.Node
+    typealias CommentNode = Libxml2.CommentNode
+    typealias ElementNode = Libxml2.ElementNode
+    typealias RootNode = Libxml2.RootNode
+    typealias TextNode = Libxml2.TextNode
+
+    /// Constants
+    ///
+    struct Constants {
+        static let sampleAttributes: [String : Any] = [
+            NSFontAttributeName: UIFont.systemFont(ofSize: UIFont.systemFontSize),
+            NSParagraphStyleAttributeName: NSParagraphStyle()
+        ]
+    }
 
     /// Converts an AttributedString into it's RootNode Representation
     ///

--- a/AztecTests/Converters/NSAttributedStringToNodesTests.swift
+++ b/AztecTests/Converters/NSAttributedStringToNodesTests.swift
@@ -17,29 +17,137 @@ class NSAttributedStringToNodesTests: XCTestCase {
 
     /// Verifies that `<b>Bold?</b>` gets effectively translated into it's tree representation.
     ///
-    func testBoldStyleGetsEffectivelyConvertedIntoBoldNode() {
+    func testBoldStyleGetsProperlySerializedBackIntoItsHtmlRepresentation() {
         let input = "<b>Bold?</b>"
         let expected = input
 
-        let attrString = attributedString(from: input)
-        let node = rootNode(from: attrString)
-        let generated = html(from: node)
-
+        let generated = generatedHTML(input: input)
         XCTAssertEqual(generated, expected)
     }
 
+
+    /// Verifies that `<i>Italics!</i>` gets effectively translated into it's tree representation.
+    ///
+    func testItalicsStyleGetsProperlySerializedBackIntoItsHtmlRepresentation() {
+        let input = "<i>Italics!</i>"
+        let expected = input
+
+        let generated = generatedHTML(input: input)
+        XCTAssertEqual(generated, expected)
+    }
+
+
     ///
     ///
-    func testListItemsGetEffectivelyMerged() {
+    func testUnderlinedStyleGetsProperlySerializedBackIntoItsHtmlRepresentation() {
+        let input = "<u>Underlined</u>"
+        let expected = input
+
+        let generated = generatedHTML(input: input)
+        XCTAssertEqual(generated, expected)
+    }
+
+
+    ///
+    ///
+    func testStrikeStyleGetsProperlySerializedBackIntoItsHtmlRepresentation() {
+        let input = "<strike>Srike!</strike>"
+        let expected = input
+
+        let generated = generatedHTML(input: input)
+        XCTAssertEqual(generated, expected)
+    }
+
+
+    ///
+    ///
+    func testLinksStyleGetsProperlySerializedBackIntoItsHtmlRepresentation() {
+        let input = "<a href=\"yosemite.com\">Yo! Yose! Yosemite!</a>"
+        let expected = input
+
+        let generated = generatedHTML(input: input)
+        XCTAssertEqual(generated, expected)
+    }
+
+
+    ///
+    ///
+    func testListItemsRemainInTheSameContainingUnorderedList() {
+        let input = "<ul><li>First Line</li><li>Second Line</li></ul>"
+        let expected = input
+
+        let generated = generatedHTML(input: input)
+        XCTAssertEqual(generated, expected)
+    }
+
+
+    ///
+    ///
+    func testCommentsArePreservedAndSerializedBack() {
+        let input = "<!-- I'm a comment. YEAH --><ul><li>Item</li></ul><!-- Tail Comment -->"
+        let expected = input
+
+        let generated = generatedHTML(input: input)
+        XCTAssertEqual(generated, expected)
+    }
+
+
+    ///
+    ///
+    func testUnknownHtmlDoesNotGetNuked() {
+        let input = "<table><tr><td>ROW ROW</td></tr></table><ul><li>Item</li></ul><!-- Tail Comment -->"
+        let expected = input
+
+        let generated = generatedHTML(input: input)
+        XCTAssertEqual(generated, expected)
+    }
+
+
+    ///
+    ///
+    func testHeaderElementGetsProperlySerialiedBackIntoItsHtmlRepresentation() {
+        for level in 1...6 {
+            let input = "<h\(level)>Aztec Rocks</h\(level)>Newline!"
+            let expected = input
+
+            let generated = generatedHTML(input: input)
+            XCTAssertEqual(generated, expected)
+        }
+    }
+
+
+    ///
+    ///
+    func testLineElementGetsProperlySerialiedBackIntoItsHtmlRepresentation() {
+        let input = "<hr>I'm a text line<hr>I'm another text line<hr>And i'm a third one"
+        let expected = "<hr>I&apos;m a text line<hr>I&apos;m another text line<hr>And i&apos;m a third one"
+
+        let generated = generatedHTML(input: input)
+        XCTAssertEqual(generated, expected)
+    }
+
+
+    ///
+    ///
+    func testContiguousUnorderedListsGetHeirItemsmerged() {
+        let input = "<ul><li>First Line</li></ul><ul><li>Second Line</li></ul>"
+        let expected = "<ul><li>First Line</li><li>Second Line</li></ul>"
+
+        let generated = generatedHTML(input: input)
+        XCTAssertEqual(generated, expected)
+    }
+
+
+    ///
+    //
+    func testSomething2() {
         let input = "<blockquote><ul><li>First Line</li></ul></blockquote><blockquote><ul><li>Second Line</li></ul></blockquote>"
         let expected = "<blockquote><ul><li>First Line</li><li>Second Line</li></ul></blockquote>"
 
-        let attrString = attributedString(from: input)
-        let node = rootNode(from: attrString)
-        let generated = html(from: node)
-
+        let generated = generatedHTML(input: input)
         XCTAssertEqual(generated, expected)
     }
+
 
     ///
     ///
@@ -48,10 +156,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
                     "<ul><li><blockquote>text 2</blockquote></li></ul>"
         let expected = "<ul><li><blockquote>text 1</blockquote><blockquote>text 2</blockquote></li></ul>"
 
-        let attrString = attributedString(from: input)
-        let node = rootNode(from: attrString)
-        let generated = html(from: node)
-
+        let generated = generatedHTML(input: input)
         XCTAssertEqual(generated, expected)
     }
 }
@@ -60,6 +165,19 @@ class NSAttributedStringToNodesTests: XCTestCase {
 // MARK: - Helpers
 //
 private extension NSAttributedStringToNodesTests {
+
+    /// Returns the HTML resulting of converting:
+    ///
+    /// 1.  Input >> Attributed String
+    /// 2.  Attributed String >> Node
+    /// 3.  Node >> HTML
+    ///
+    func generatedHTML(input html: String) -> String {
+        let attrString = attributedString(from: html)
+        let node = rootNode(from: attrString)
+
+        return self.html(from: node)
+    }
 
     /// Converts a raw HTML String into it's NSAttributedString Representation
     ///
@@ -71,7 +189,7 @@ private extension NSAttributedStringToNodesTests {
         return attrString
     }
 
-    ///
+    /// Converts an AttributedString into it's RootNode Representation
     ///
     func rootNode(from attrString: NSAttributedString) -> RootNode {
         let converter = NSAttributedStringToNodes()

--- a/AztecTests/Converters/NSAttributedStringToNodesTests.swift
+++ b/AztecTests/Converters/NSAttributedStringToNodesTests.swift
@@ -1,20 +1,53 @@
 import XCTest
+@testable import Aztec
 
 
 // MARK: - NSAttributedStringToNodesTests
 //
 class NSAttributedStringToNodesTests: XCTestCase {
-    
-    override func setUp() {
-        super.setUp()
+
+    /// Typealiases
+    ///
+    typealias Node = Libxml2.Node
+    typealias CommentNode = Libxml2.CommentNode
+    typealias ElementNode = Libxml2.ElementNode
+    typealias RootNode = Libxml2.RootNode
+    typealias TextNode = Libxml2.TextNode
+
+
+    /// Verifies that `<b>Bold?</b>` gets effectively translated into it's tree representation.
+    ///
+    func testBoldStyleGetsEffectivelyConvertedIntoBoldNode() {
+        let html = "<b>Bold?</b>"
+
+        let converter = NSAttributedStringToNodes()
+        let attrString = attributedString(from: html)
+
+        let root = converter.convert(attrString)
+        XCTAssert(root.children.count == 1)
+
+        guard let bold = root.children.first as? ElementNode, let text = bold.children.first as? TextNode else {
+            XCTFail()
+            return
+        }
+
+        XCTAssert(bold.children.count == 1)
+        XCTAssertEqual(text.contents, "Bold?")
     }
-    
-    override func tearDown() {
-        super.tearDown()
-    }
-    
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+
+// MARK: - Helpers
+//
+private extension NSAttributedStringToNodesTests {
+
+    /// Converts a raw HTML String into it's NSAttributedString Representation
+    ///
+    func attributedString(from html: String) -> NSAttributedString {
+        let defaultFont = UIFont.systemFont(ofSize: 12)
+        let converter = HTMLToAttributedString(usingDefaultFontDescriptor: defaultFont.fontDescriptor)
+        let (_, attrString) = try! converter.convert(html)
+
+        return attrString
     }
 }

--- a/AztecTests/Converters/NSAttributedStringToNodesTests.swift
+++ b/AztecTests/Converters/NSAttributedStringToNodesTests.swift
@@ -18,21 +18,41 @@ class NSAttributedStringToNodesTests: XCTestCase {
     /// Verifies that `<b>Bold?</b>` gets effectively translated into it's tree representation.
     ///
     func testBoldStyleGetsEffectivelyConvertedIntoBoldNode() {
-        let html = "<b>Bold?</b>"
+        let input = "<b>Bold?</b>"
+        let expected = input
 
-        let converter = NSAttributedStringToNodes()
-        let attrString = attributedString(from: html)
+        let attrString = attributedString(from: input)
+        let node = rootNode(from: attrString)
+        let generated = html(from: node)
 
-        let root = converter.convert(attrString)
-        XCTAssert(root.children.count == 1)
+        XCTAssertEqual(generated, expected)
+    }
 
-        guard let bold = root.children.first as? ElementNode, let text = bold.children.first as? TextNode else {
-            XCTFail()
-            return
-        }
+    ///
+    ///
+    func testListItemsGetEffectivelyMerged() {
+        let input = "<blockquote><ul><li>First Line</li></ul></blockquote><blockquote><ul><li>Second Line</li></ul></blockquote>"
+        let expected = "<blockquote><ul><li>First Line</li><li>Second Line</li></ul></blockquote>"
 
-        XCTAssert(bold.children.count == 1)
-        XCTAssertEqual(text.contents, "Bold?")
+        let attrString = attributedString(from: input)
+        let node = rootNode(from: attrString)
+        let generated = html(from: node)
+
+        XCTAssertEqual(generated, expected)
+    }
+
+    ///
+    ///
+    func testSomething() {
+        let input = "<ul><li><blockquote>text 1</blockquote></li></ul>" +
+                    "<ul><li><blockquote>text 2</blockquote></li></ul>"
+        let expected = "<ul><li><blockquote>text 1</blockquote><blockquote>text 2</blockquote></li></ul>"
+
+        let attrString = attributedString(from: input)
+        let node = rootNode(from: attrString)
+        let generated = html(from: node)
+
+        XCTAssertEqual(generated, expected)
     }
 }
 
@@ -49,5 +69,19 @@ private extension NSAttributedStringToNodesTests {
         let (_, attrString) = try! converter.convert(html)
 
         return attrString
+    }
+
+    ///
+    ///
+    func rootNode(from attrString: NSAttributedString) -> RootNode {
+        let converter = NSAttributedStringToNodes()
+        return converter.convert(attrString)
+    }
+
+    /// Converts a RootNode into it's HTML Representation
+    ///
+    func html(from node: RootNode) -> String {
+        let converter = Libxml2.Out.HTMLConverter()
+        return converter.convert(node)
     }
 }

--- a/AztecTests/Converters/NSAttributedStringToNodesTests.swift
+++ b/AztecTests/Converters/NSAttributedStringToNodesTests.swift
@@ -15,150 +15,222 @@ class NSAttributedStringToNodesTests: XCTestCase {
     typealias TextNode = Libxml2.TextNode
 
 
-    /// Verifies that `<b>Bold?</b>` gets effectively translated into it's tree representation.
     ///
-    func testBoldStyleGetsProperlySerializedBackIntoItsHtmlRepresentation() {
-        let input = "<b>Bold?</b>"
-        let expected = input
-
-        let generated = generatedHTML(input: input)
-        XCTAssertEqual(generated, expected)
-    }
-
-
-    /// Verifies that `<i>Italics!</i>` gets effectively translated into it's tree representation.
     ///
-    func testItalicsStyleGetsProperlySerializedBackIntoItsHtmlRepresentation() {
-        let input = "<i>Italics!</i>"
-        let expected = input
-
-        let generated = generatedHTML(input: input)
-        XCTAssertEqual(generated, expected)
+    private struct Constants {
+        static let sampleAttributes: [String : Any] = [
+            NSFontAttributeName: UIFont.systemFont(ofSize: UIFont.systemFontSize)
+        ]
     }
 
 
     ///
     ///
-    func testUnderlinedStyleGetsProperlySerializedBackIntoItsHtmlRepresentation() {
-        let input = "<u>Underlined</u>"
-        let expected = input
+    func testBoldStyleEffectivelyMapsIntoItsTreeRepresentation() {
+        let attributes = BoldFormatter().apply(to: Constants.sampleAttributes)
+        let string = NSAttributedString(string: "Bold?", attributes: attributes)
 
-        let generated = generatedHTML(input: input)
-        XCTAssertEqual(generated, expected)
+        // Convert + Verify
+        let node = rootNode(from: string)
+        XCTAssert(node.children.count == 1)
+
+        let bold = node.children.first as? ElementNode
+        XCTAssertEqual(bold?.name, "b")
+        XCTAssert(bold?.children.count == 1)
+
+        let text = bold?.children.first as? TextNode
+        XCTAssertEqual(text?.contents, string.string)
     }
 
 
     ///
     ///
-    func testStrikeStyleGetsProperlySerializedBackIntoItsHtmlRepresentation() {
-        let input = "<strike>Srike!</strike>"
-        let expected = input
+    func testItalicStyleEffectivelyMapsIntoItsTreeRepresentation() {
+        let attributes = ItalicFormatter().apply(to: Constants.sampleAttributes)
+        let string = NSAttributedString(string: "Italics!", attributes: attributes)
 
-        let generated = generatedHTML(input: input)
-        XCTAssertEqual(generated, expected)
+        // Convert + Verify
+        let node = rootNode(from: string)
+        XCTAssert(node.children.count == 1)
+
+        let italic = node.children.first as? ElementNode
+        XCTAssertEqual(italic?.name, "i")
+        XCTAssert(italic?.children.count == 1)
+
+        let text = italic?.children.first as? TextNode
+        XCTAssertEqual(text?.contents, string.string)
     }
 
 
     ///
     ///
-    func testLinksStyleGetsProperlySerializedBackIntoItsHtmlRepresentation() {
-        let input = "<a href=\"yosemite.com\">Yo! Yose! Yosemite!</a>"
-        let expected = input
+    func testUnderlineStyleEffectivelyMapsIntoItsTreeRepresentation() {
+        let attributes = UnderlineFormatter().apply(to: Constants.sampleAttributes)
+        let string = NSAttributedString(string: "Underlined!", attributes: attributes)
 
-        let generated = generatedHTML(input: input)
-        XCTAssertEqual(generated, expected)
+        // Convert + Verify
+        let node = rootNode(from: string)
+        XCTAssert(node.children.count == 1)
+
+        let underlined = node.children.first as? ElementNode
+        XCTAssertEqual(underlined?.name, "u")
+        XCTAssert(underlined?.children.count == 1)
+
+        let text = underlined?.children.first as? TextNode
+        XCTAssertEqual(text?.contents, string.string)
+    }
+
+
+    ///
+    ///
+    func testStrikeStyleEffectivelyMapsIntoItsTreeRepresentation() {
+        let attributes = StrikethroughFormatter().apply(to: Constants.sampleAttributes)
+        let string = NSAttributedString(string: "Strike!", attributes: attributes)
+
+        // Convert + Verify
+        let node = rootNode(from: string)
+        XCTAssert(node.children.count == 1)
+
+        let strike = node.children.first as? ElementNode
+        XCTAssertEqual(strike?.name, "strike")
+        XCTAssert(strike?.children.count == 1)
+
+        let text = strike?.children.first as? TextNode
+        XCTAssertEqual(text?.contents, string.string)
+    }
+
+
+    ///
+    ///
+    func testLinkStyleEffectivelyMapsIntoItsTreeRepresentation() {
+        let formatter = LinkFormatter()
+        formatter.attributeValue = URL(string: "www.yosemite.com") as Any
+
+        let attributes = formatter.apply(to: Constants.sampleAttributes)
+        let string = NSAttributedString(string: "Yo! Yose! Yosemite!", attributes: attributes)
+
+        // Convert + Verify
+        let node = rootNode(from: string)
+        XCTAssert(node.children.count == 1)
+
+        let link = node.children.first as? ElementNode
+        XCTAssertEqual(link?.name, "a")
+        XCTAssert(link?.children.count == 1)
+
+        let text = link?.children.first as? TextNode
+        XCTAssertEqual(text?.contents, string.string)
     }
 
 
     ///
     ///
     func testListItemsRemainInTheSameContainingUnorderedList() {
-        let input = "<ul><li>First Line</li><li>Second Line</li></ul>"
-        let expected = input
+        let firstText = "First Line"
+        let secondText = "Second Line"
 
-        let generated = generatedHTML(input: input)
-        XCTAssertEqual(generated, expected)
+        let attributes = TextListFormatter(style: .ordered).apply(to: Constants.sampleAttributes)
+
+        let text = firstText + String(.newline) + secondText
+        let string = NSMutableAttributedString(string: text, attributes: attributes)
+
+        // Convert + Verify
+        let node = rootNode(from: string)
+        XCTAssert(node.children.count == 1)
+
+        let list = node.children.first as? ElementNode
+        XCTAssertEqual(list?.name, "ol")
+        XCTAssert(list?.children.count == 2)
+
+        let firstListItem = list?.children[0] as? ElementNode
+        let secondListItem = list?.children[1] as? ElementNode
+        XCTAssertEqual(firstListItem?.name, "li")
+        XCTAssertEqual(secondListItem?.name, "li")
+        XCTAssert(firstListItem?.children.count == 1)
+        XCTAssert(secondListItem?.children.count == 1)
+
+        let firstTextItem = firstListItem?.children.first as? TextNode
+        let secondTextItem = secondListItem?.children.first as? TextNode
+
+        XCTAssertEqual(firstTextItem?.contents, firstText)
+        XCTAssertEqual(secondTextItem?.contents, secondText)
     }
 
 
-    ///
-    ///
-    func testCommentsArePreservedAndSerializedBack() {
-        let input = "<!-- I'm a comment. YEAH --><ul><li>Item</li></ul><!-- Tail Comment -->"
-        let expected = input
-
-        let generated = generatedHTML(input: input)
-        XCTAssertEqual(generated, expected)
-    }
-
-
-    ///
-    ///
-    func testUnknownHtmlDoesNotGetNuked() {
-        let input = "<table><tr><td>ROW ROW</td></tr></table><ul><li>Item</li></ul><!-- Tail Comment -->"
-        let expected = input
-
-        let generated = generatedHTML(input: input)
-        XCTAssertEqual(generated, expected)
-    }
-
-
-    ///
-    ///
-    func testHeaderElementGetsProperlySerialiedBackIntoItsHtmlRepresentation() {
-        for level in 1...6 {
-            let input = "<h\(level)>Aztec Rocks</h\(level)>Newline!"
-            let expected = input
-
-            let generated = generatedHTML(input: input)
-            XCTAssertEqual(generated, expected)
-        }
-    }
-
-
-    ///
-    ///
-    func testLineElementGetsProperlySerialiedBackIntoItsHtmlRepresentation() {
-        let input = "<hr>I'm a text line<hr>I'm another text line<hr>And i'm a third one"
-        let expected = "<hr>I&apos;m a text line<hr>I&apos;m another text line<hr>And i&apos;m a third one"
-
-        let generated = generatedHTML(input: input)
-        XCTAssertEqual(generated, expected)
-    }
-
-
-    ///
-    ///
-    func testContiguousUnorderedListsGetHeirItemsmerged() {
-        let input = "<ul><li>First Line</li></ul><ul><li>Second Line</li></ul>"
-        let expected = "<ul><li>First Line</li><li>Second Line</li></ul>"
-
-        let generated = generatedHTML(input: input)
-        XCTAssertEqual(generated, expected)
-    }
-
-
-    ///
-    //
-    func testSomething2() {
-        let input = "<blockquote><ul><li>First Line</li></ul></blockquote><blockquote><ul><li>Second Line</li></ul></blockquote>"
-        let expected = "<blockquote><ul><li>First Line</li><li>Second Line</li></ul></blockquote>"
-
-        let generated = generatedHTML(input: input)
-        XCTAssertEqual(generated, expected)
-    }
-
-
-    ///
-    ///
-    func testSomething() {
-        let input = "<ul><li><blockquote>text 1</blockquote></li></ul>" +
-                    "<ul><li><blockquote>text 2</blockquote></li></ul>"
-        let expected = "<ul><li><blockquote>text 1</blockquote><blockquote>text 2</blockquote></li></ul>"
-
-        let generated = generatedHTML(input: input)
-        XCTAssertEqual(generated, expected)
-    }
+//    ///
+//    ///
+//    func testCommentsArePreservedAndSerializedBack() {
+//        let input = "<!-- I'm a comment. YEAH --><ul><li>Item</li></ul><!-- Tail Comment -->"
+//        let expected = input
+//
+//        let generated = generatedHTML(input: input)
+//        XCTAssertEqual(generated, expected)
+//    }
+//
+//
+//    ///
+//    ///
+//    func testUnknownHtmlDoesNotGetNuked() {
+//        let input = "<table><tr><td>ROW ROW</td></tr></table><ul><li>Item</li></ul><!-- Tail Comment -->"
+//        let expected = input
+//
+//        let generated = generatedHTML(input: input)
+//        XCTAssertEqual(generated, expected)
+//    }
+//
+//
+//    ///
+//    ///
+//    func testHeaderElementGetsProperlySerialiedBackIntoItsHtmlRepresentation() {
+//        for level in 1...6 {
+//            let input = "<h\(level)>Aztec Rocks</h\(level)>Newline!"
+//            let expected = input
+//
+//            let generated = generatedHTML(input: input)
+//            XCTAssertEqual(generated, expected)
+//        }
+//    }
+//
+//
+//    ///
+//    ///
+//    func testLineElementGetsProperlySerialiedBackIntoItsHtmlRepresentation() {
+//        let input = "<hr>I'm a text line<hr>I'm another text line<hr>And i'm a third one"
+//        let expected = "<hr>I&apos;m a text line<hr>I&apos;m another text line<hr>And i&apos;m a third one"
+//
+//        let generated = generatedHTML(input: input)
+//        XCTAssertEqual(generated, expected)
+//    }
+//
+//
+//    ///
+//    ///
+//    func testContiguousUnorderedListsGetHeirItemsmerged() {
+//        let input = "<ul><li>First Line</li></ul><ul><li>Second Line</li></ul>"
+//        let expected = "<ul><li>First Line</li><li>Second Line</li></ul>"
+//
+//        let generated = generatedHTML(input: input)
+//        XCTAssertEqual(generated, expected)
+//    }
+//
+//
+//    ///
+//    //
+//    func testSomething2() {
+//        let input = "<blockquote><ul><li>First Line</li></ul></blockquote><blockquote><ul><li>Second Line</li></ul></blockquote>"
+//        let expected = "<blockquote><ul><li>First Line</li><li>Second Line</li></ul></blockquote>"
+//
+//        let generated = generatedHTML(input: input)
+//        XCTAssertEqual(generated, expected)
+//    }
+//
+//
+//    ///
+//    ///
+//    func testSomething() {
+//        let input = "<ul><li><blockquote>text 1</blockquote></li></ul>" +
+//                    "<ul><li><blockquote>text 2</blockquote></li></ul>"
+//        let expected = "<ul><li><blockquote>text 1</blockquote><blockquote>text 2</blockquote></li></ul>"
+//    }
 }
 
 
@@ -166,40 +238,10 @@ class NSAttributedStringToNodesTests: XCTestCase {
 //
 private extension NSAttributedStringToNodesTests {
 
-    /// Returns the HTML resulting of converting:
-    ///
-    /// 1.  Input >> Attributed String
-    /// 2.  Attributed String >> Node
-    /// 3.  Node >> HTML
-    ///
-    func generatedHTML(input html: String) -> String {
-        let attrString = attributedString(from: html)
-        let node = rootNode(from: attrString)
-
-        return self.html(from: node)
-    }
-
-    /// Converts a raw HTML String into it's NSAttributedString Representation
-    ///
-    func attributedString(from html: String) -> NSAttributedString {
-        let defaultFont = UIFont.systemFont(ofSize: 12)
-        let converter = HTMLToAttributedString(usingDefaultFontDescriptor: defaultFont.fontDescriptor)
-        let (_, attrString) = try! converter.convert(html)
-
-        return attrString
-    }
-
     /// Converts an AttributedString into it's RootNode Representation
     ///
     func rootNode(from attrString: NSAttributedString) -> RootNode {
         let converter = NSAttributedStringToNodes()
         return converter.convert(attrString)
-    }
-
-    /// Converts a RootNode into it's HTML Representation
-    ///
-    func html(from node: RootNode) -> String {
-        let converter = Libxml2.Out.HTMLConverter()
-        return converter.convert(node)
     }
 }


### PR DESCRIPTION
### Details:
In this PR we're implementing Merge-to-Left: as we parse different Paragraphs, we're now merging N and N-1 nodes, as long as `canMergeChildren`'s `Node` (new helper) returns true.

Pendings:
- Newlines Logic
- Merge Explicit Unit Tests
- (And of course!) revisit the Merge Logic

Ref #492

### To test:
1. Verify the Unit Tests and make sure *NSAttributedStringToNodesTests* are green.
2. Try inserting a List with multiple items, and verify the `LI` items get grouped together under the same `OL / UL`

cc @diegoreymendez 
Thanks in advance!!
