### PR TITLE
Implement multiple styles using a single array

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -515,16 +515,14 @@
 		599F252E1D8BC9A1002871D6 /* TextKit */ = {
 			isa = PBXGroup;
 			children = (
-				FF7C89A71E3A2B7C000472A8 /* Blockquote.swift */,
+				FF07C9951EEAB40000134E31 /* ParagraphAttributes */,
 				B5AF89311E93CFC80051EFDB /* RenderableAttachmentDelegate.swift */,
 				B572AC271E817CFE008948C2 /* CommentAttachment.swift */,
 				B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */,
-				F1ABC1B21EAE2816002E52FE /* HTMLParagraph.swift */,
 				FF7A1C501E5651EA00C4C7C8 /* LineAttachment.swift */,
 				599F25301D8BC9A1002871D6 /* MediaAttachment.swift */,
 				FF4E265F1EA8DF1E005E8E42 /* ImageAttachment.swift */,
 				FFFEC7DA1EA7698900F4210F /* VideoAttachment.swift */,
-				B5BC4FF51DA2D76600614582 /* TextList.swift */,
 				599F25311D8BC9A1002871D6 /* TextStorage.swift */,
 				599F25321D8BC9A1002871D6 /* TextView.swift */,
 				E109B51B1DC33F2C0099605E /* LayoutManager.swift */,
@@ -732,6 +730,16 @@
 				F1FA0E801E6EF514009D98EE /* TextNode.swift */,
 			);
 			path = Data;
+			sourceTree = "<group>";
+		};
+		FF07C9951EEAB40000134E31 /* ParagraphAttributes */ = {
+			isa = PBXGroup;
+			children = (
+				FF7C89A71E3A2B7C000472A8 /* Blockquote.swift */,
+				F1ABC1B21EAE2816002E52FE /* HTMLParagraph.swift */,
+				B5BC4FF51DA2D76600614582 /* TextList.swift */,
+			);
+			name = ParagraphAttributes;
 			sourceTree = "<group>";
 		};
 		FF20D63C1EDC389A00294B78 /* Processor */ = {

--- a/Aztec/Classes/Constants/Metrics.swift
+++ b/Aztec/Classes/Constants/Metrics.swift
@@ -8,8 +8,8 @@ enum Metrics {
 
     static let defaultIndentation       = CGFloat(12)
     static let maxIndentation           = CGFloat(200)
-    static let listBulletIndentation    = CGFloat(30)
-    static let listTextIndentation      = CGFloat(36)
+    static let listBulletIndentation    = CGFloat(20)
+    static let listTextIndentation      = CGFloat(24)
     static let tabStepInterval          = 8
     static let tabStepCount             = 12
 }

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -27,11 +27,11 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
         }
 
         if newParagraphStyle.blockquote == nil {
-            newParagraphStyle.headIndent += Metrics.defaultIndentation
-            newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
-            newParagraphStyle.tailIndent -= Metrics.defaultIndentation
-            newParagraphStyle.paragraphSpacing += Metrics.defaultIndentation
-            newParagraphStyle.paragraphSpacingBefore += Metrics.defaultIndentation
+            //newParagraphStyle.headIndent += Metrics.defaultIndentation
+            //newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
+            //newParagraphStyle.tailIndent -= Metrics.defaultIndentation
+            //newParagraphStyle.paragraphSpacing += Metrics.defaultIndentation
+            //newParagraphStyle.paragraphSpacingBefore += Metrics.defaultIndentation
         }
 
         newParagraphStyle.blockquote = Blockquote()
@@ -50,11 +50,11 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
 
         let newParagraphStyle = ParagraphStyle()
         newParagraphStyle.setParagraphStyle(paragraphStyle)
-        newParagraphStyle.headIndent -= Metrics.defaultIndentation
-        newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
-        newParagraphStyle.tailIndent += Metrics.defaultIndentation
-        newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
-        newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
+        //newParagraphStyle.headIndent -= Metrics.defaultIndentation
+        //newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
+        //newParagraphStyle.tailIndent += Metrics.defaultIndentation
+        //newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
+        //newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
         newParagraphStyle.blockquote = nil
 
         var resultingAttributes = attributes

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -35,8 +35,8 @@ class TextListFormatter: ParagraphAttributeFormatter {
         }
 
         if  (increaseDepth || newParagraphStyle.textLists.isEmpty) {
-            newParagraphStyle.headIndent += Metrics.listTextIndentation
-            newParagraphStyle.firstLineHeadIndent += Metrics.listTextIndentation
+            //newParagraphStyle.headIndent += Metrics.listTextIndentation
+            //newParagraphStyle.firstLineHeadIndent += Metrics.listTextIndentation
             newParagraphStyle.textLists.append(TextList(style: self.listStyle))
         } else {
             newParagraphStyle.textLists.removeLast()
@@ -59,8 +59,8 @@ class TextListFormatter: ParagraphAttributeFormatter {
 
         let newParagraphStyle = ParagraphStyle()
         newParagraphStyle.setParagraphStyle(paragraphStyle)
-        newParagraphStyle.headIndent -= Metrics.listTextIndentation
-        newParagraphStyle.firstLineHeadIndent -= Metrics.listTextIndentation
+        //newParagraphStyle.headIndent -= Metrics.listTextIndentation
+        //newParagraphStyle.firstLineHeadIndent -= Metrics.listTextIndentation
         newParagraphStyle.textLists.removeLast()
 
         var resultingAttributes = attributes

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -34,13 +34,15 @@ class TextListFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
 
-        if  (increaseDepth || newParagraphStyle.textLists.isEmpty) {
+        if  increaseDepth || !(newParagraphStyle.has(paragraphHint: ParagraphHint.orderedList) || newParagraphStyle.has(paragraphHint: .unorderedList)) {
             //newParagraphStyle.headIndent += Metrics.listTextIndentation
             //newParagraphStyle.firstLineHeadIndent += Metrics.listTextIndentation
-            newParagraphStyle.textLists.append(TextList(style: self.listStyle))
+            //newParagraphStyle.textLists.append(TextList(style: self.listStyle))
+            newParagraphStyle.add(paragraphHint: self.listStyle == .ordered ? ParagraphHint.orderedList : ParagraphHint.unorderedList)
         } else {
-            newParagraphStyle.textLists.removeLast()
-            newParagraphStyle.textLists.append(TextList(style: self.listStyle))
+            //newParagraphStyle.textLists.removeLast()
+            //newParagraphStyle.textLists.append(TextList(style: self.listStyle))
+            newParagraphStyle.replace(paragraphHint: self.listStyle == .ordered ? ParagraphHint.orderedList : ParagraphHint.unorderedList)
         }
 
         var resultingAttributes = attributes
@@ -51,8 +53,7 @@ class TextListFormatter: ParagraphAttributeFormatter {
 
     func remove(from attributes: [String: Any]) -> [String: Any] {
         guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
-              let currentList = paragraphStyle.textLists.last,
-              currentList.style == self.listStyle
+              paragraphStyle.has(paragraphHint: self.listStyle == .ordered ? ParagraphHint.orderedList : ParagraphHint.unorderedList)
         else {
             return attributes
         }
@@ -61,7 +62,8 @@ class TextListFormatter: ParagraphAttributeFormatter {
         newParagraphStyle.setParagraphStyle(paragraphStyle)
         //newParagraphStyle.headIndent -= Metrics.listTextIndentation
         //newParagraphStyle.firstLineHeadIndent -= Metrics.listTextIndentation
-        newParagraphStyle.textLists.removeLast()
+        //newParagraphStyle.textLists.removeLast()
+        newParagraphStyle.remove(paragraphHint: self.listStyle == .ordered ? ParagraphHint.orderedList : ParagraphHint.unorderedList)
 
         var resultingAttributes = attributes
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
@@ -70,18 +72,21 @@ class TextListFormatter: ParagraphAttributeFormatter {
     }
 
     func present(in attributes: [String : Any]) -> Bool {
-        guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle, let list = style.textLists.last else {
+        guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle
+        //,let list = style.textLists.last 
+        else {
             return false
         }
 
-        return list.style == listStyle
+        return style.has(paragraphHint: self.listStyle == .ordered ? ParagraphHint.orderedList : ParagraphHint.unorderedList)
     }
 
     static func listsOfAnyKindPresent(in attributes: [String: Any]) -> Bool {
         guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle else {
             return false
         }
-        return !(style.textLists.isEmpty)
+        //return !(style.textLists.isEmpty)
+        return style.has(paragraphHint: ParagraphHint.orderedList) || style.has(paragraphHint: .unorderedList)
     }
 }
 

--- a/Aztec/Classes/Libxml2/DOM/Logic/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Libxml2/DOM/Logic/NSAttributedStringToNodes.swift
@@ -224,10 +224,10 @@ private extension NSAttributedStringToNodes {
             styles.append(.header(level: style.headerLevel))
         }
 
-        for list in style.textLists {
-            if list.style == .ordered {
+        for paragraphHint in style.paragraphHints {
+            if paragraphHint == .orderedList {
                 styles.append(.orderedList)
-            } else {
+            } else if paragraphHint == .unorderedList {
                 styles.append(.unorderedList)
             }
         }

--- a/Aztec/Classes/Libxml2/DOM/Logic/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Libxml2/DOM/Logic/NSAttributedStringToNodes.swift
@@ -19,6 +19,15 @@ class NSAttributedStringToNodes {
     typealias Attribute = Libxml2.Attribute
     typealias StringAttribute = Libxml2.StringAttribute
 
+    func createNodes(fromText text: NSAttributedString) -> [Node] {
+        var result = [Node]()
+        let ranges = text.paragraphRanges()
+        for range in ranges {
+            let paragraph = text.attributedSubstring(from: range)
+            result.append(contentsOf:createNodes(fromParagraph: paragraph))
+        }
+        return result
+    }
     ///
     ///
     func createNodes(fromParagraph paragraph: NSAttributedString) -> [Node] {
@@ -297,7 +306,7 @@ private extension NSAttributedStringToNodes {
             case .blockquote:
                 return ElementNode(type: .blockquote, children: children)
             case .header(let level):
-                let header = DOMString.elementTypeForHeaderLevel(level) ?? .h1
+                let header = DOMString.elementTypeForHeaderLevel(level) ?? .p
                 return ElementNode(type: header, children: children)
             case .horizontalRule:
                 return ElementNode(type: .hr, children: children)

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -127,7 +127,7 @@ private extension LayoutManager {
         let markerPlain = list.style.markerText(forItemNumber: number)
         let markerText = NSAttributedString(string: markerPlain, attributes: markerAttributes)
 
-        let markerRect = rect.offsetBy(dx: style.headIndent - Metrics.listTextIndentation, dy: style.paragraphSpacingBefore)
+        let markerRect = rect.offsetBy(dx: style.headIndent - Metrics.listTextIndentation, dy: style.paragraphSpacingBefore + style.paragraphSpacing)
 
         markerText.draw(in: markerRect)
     }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -85,9 +85,12 @@ private extension LayoutManager {
 
         let characterRange = self.characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
         textStorage.enumerateAttribute(NSParagraphStyleAttributeName, in: characterRange, options: []) { (object, range, stop) in
-            guard let paragraphStyle = object as? ParagraphStyle, let list = paragraphStyle.textLists.last else {
+            guard let paragraphStyle = object as? ParagraphStyle,
+                let paragraphHint = paragraphStyle.deepest(paragraphHintsToSearch: [ParagraphHint.orderedList, ParagraphHint.unorderedList])
+            else {
                 return
             }
+            let list = (paragraphHint == .orderedList) ? TextList(style: .ordered) : TextList(style: .unordered)
 
             let listGlyphRange = glyphRange(forCharacterRange:range, actualCharacterRange: nil)
 

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -53,12 +53,90 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     override open func setParagraphStyle(_ obj: NSParagraphStyle) {
         super.setParagraphStyle(obj)
         if let paragrahStyle = obj as? ParagraphStyle {
+            headIndent = 0
+            firstLineHeadIndent = 0
+            tailIndent = 0
+            paragraphSpacing = 0
+            paragraphSpacingBefore = 0
+
+            baseHeadIndent = paragrahStyle.baseHeadIndent
+            baseFistLineHeadIndent = paragrahStyle.baseFistLineHeadIndent
+            baseTailIndent = paragrahStyle.baseTailIndent
+            baseParagraphSpacing = paragrahStyle.baseParagraphSpacing
+            baseParagraphSpacingBefore = paragrahStyle.baseParagraphSpacingBefore
+
             blockquote = paragrahStyle.blockquote
             headerLevel = paragrahStyle.headerLevel
             htmlParagraph = paragrahStyle.htmlParagraph
             textLists = paragrahStyle.textLists
         }
     }
+
+    open override var headIndent: CGFloat {
+        get {
+            let extra: CGFloat = (CGFloat(textLists.count) * Metrics.listTextIndentation)
+
+            return baseHeadIndent + extra
+        }
+
+        set {
+            baseHeadIndent = newValue
+        }
+    }
+
+    open override var firstLineHeadIndent: CGFloat {
+        get {
+            let extra: CGFloat = (CGFloat(textLists.count) * Metrics.listTextIndentation)
+
+            return baseFistLineHeadIndent + extra
+        }
+
+        set {
+            baseFistLineHeadIndent = newValue
+        }
+    }
+
+    open override var tailIndent: CGFloat {
+        get {
+            let extra: CGFloat = (self.blockquote == nil ? 0 : 1) * Metrics.defaultIndentation
+
+            return baseTailIndent - extra
+        }
+
+        set {
+            baseTailIndent = newValue
+        }
+    }
+
+    open override var paragraphSpacing: CGFloat {
+        get {
+            let extra: CGFloat = (self.blockquote == nil ? 0 : 1) * Metrics.defaultIndentation
+
+            return baseParagraphSpacing + extra
+        }
+
+        set {
+            baseParagraphSpacing = newValue
+        }
+    }
+
+    open override var paragraphSpacingBefore: CGFloat {
+        get {
+            let extra: CGFloat = (self.blockquote == nil ? 0 : 1) * Metrics.defaultIndentation
+
+            return baseParagraphSpacingBefore + extra
+        }
+
+        set {
+            baseParagraphSpacingBefore = newValue
+        }
+    }
+
+    var baseHeadIndent: CGFloat = 0
+    var baseFistLineHeadIndent: CGFloat = 0
+    var baseTailIndent: CGFloat = 0
+    var baseParagraphSpacing: CGFloat = 0
+    var baseParagraphSpacingBefore: CGFloat = 0
 
     open override class var `default`: NSParagraphStyle {
         let style = ParagraphStyle()

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -494,7 +494,7 @@ open class TextStorage: NSTextStorage {
         let converter = NSAttributedStringToNodes()
 
         // TODO: Testing Code. This will be violently updated!!
-        let nodes = converter.createNodes(fromParagraph: self)
+        let nodes = converter.createNodes(fromText: self)
         let rootNode = Libxml2.RootNode(children: nodes)
 
         let serializer = Libxml2.Out.HTMLConverter(prettyPrint: prettyPrint)


### PR DESCRIPTION
This PR has two things:

 - Implements the ParagraphStyle properties (indent, paragraph spacing, etc..) based on the current state of styles applied to the paragraph ( block quotes, lists, paragraphs, etc)
 - Implement the lists using a generic array of styles, at the moment only lists are implemented using it, but all the other styles (block quotes, headers) could be migrated to it.

