### PR TITLE
Refactor style application

### DIFF
--- a/Aztec/Classes/Constants/Metrics.swift
+++ b/Aztec/Classes/Constants/Metrics.swift
@@ -6,10 +6,11 @@ import Foundation
 ///
 enum Metrics {
 
-    static let defaultIndentation       = CGFloat(12)
-    static let maxIndentation           = CGFloat(200)
-    static let listBulletIndentation    = CGFloat(20)
-    static let listTextIndentation      = CGFloat(24)
-    static let tabStepInterval          = 8
-    static let tabStepCount             = 12
+    static let defaultIndentation = CGFloat(12)
+    static let maxIndentation = CGFloat(200)
+    static let listBulletIndentation = CGFloat(20)
+    static let listTextIndentation = CGFloat(24)
+    static let tabStepInterval = 8
+    static let tabStepCount = 12
+    static let paragraphSpacing = CGFloat(6)
 }

--- a/Aztec/Classes/Constants/Metrics.swift
+++ b/Aztec/Classes/Constants/Metrics.swift
@@ -8,8 +8,8 @@ enum Metrics {
 
     static let defaultIndentation       = CGFloat(12)
     static let maxIndentation           = CGFloat(200)
-    static let listBulletIndentation    = CGFloat(30)
-    static let listTextIndentation      = CGFloat(36)
+    static let listBulletIndentation    = CGFloat(20)
+    static let listTextIndentation      = CGFloat(24)
     static let tabStepInterval          = 8
     static let tabStepCount             = 12
 }

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -27,11 +27,11 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
         }
 
         if newParagraphStyle.blockquote == nil {
-            newParagraphStyle.headIndent += Metrics.defaultIndentation
-            newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
-            newParagraphStyle.tailIndent -= Metrics.defaultIndentation
-            newParagraphStyle.paragraphSpacing += Metrics.defaultIndentation
-            newParagraphStyle.paragraphSpacingBefore += Metrics.defaultIndentation
+            //newParagraphStyle.headIndent += Metrics.defaultIndentation
+            //newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
+            //newParagraphStyle.tailIndent -= Metrics.defaultIndentation
+            //newParagraphStyle.paragraphSpacing += Metrics.defaultIndentation
+            //newParagraphStyle.paragraphSpacingBefore += Metrics.defaultIndentation
         }
 
         newParagraphStyle.blockquote = Blockquote()
@@ -50,11 +50,11 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
 
         let newParagraphStyle = ParagraphStyle()
         newParagraphStyle.setParagraphStyle(paragraphStyle)
-        newParagraphStyle.headIndent -= Metrics.defaultIndentation
-        newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
-        newParagraphStyle.tailIndent += Metrics.defaultIndentation
-        newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
-        newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
+        //newParagraphStyle.headIndent -= Metrics.defaultIndentation
+        //newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
+        //newParagraphStyle.tailIndent += Metrics.defaultIndentation
+        //newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
+        //newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
         newParagraphStyle.blockquote = nil
 
         var resultingAttributes = attributes

--- a/Aztec/Classes/Formatters/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/BlockquoteFormatter.swift
@@ -26,14 +26,6 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
 
-        if newParagraphStyle.blockquote == nil {
-            //newParagraphStyle.headIndent += Metrics.defaultIndentation
-            //newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
-            //newParagraphStyle.tailIndent -= Metrics.defaultIndentation
-            //newParagraphStyle.paragraphSpacing += Metrics.defaultIndentation
-            //newParagraphStyle.paragraphSpacingBefore += Metrics.defaultIndentation
-        }
-
         newParagraphStyle.blockquote = Blockquote()
 
         var resultingAttributes = attributes
@@ -49,12 +41,7 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
         }
 
         let newParagraphStyle = ParagraphStyle()
-        newParagraphStyle.setParagraphStyle(paragraphStyle)
-        //newParagraphStyle.headIndent -= Metrics.defaultIndentation
-        //newParagraphStyle.firstLineHeadIndent = newParagraphStyle.headIndent
-        //newParagraphStyle.tailIndent += Metrics.defaultIndentation
-        //newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
-        //newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
+        newParagraphStyle.setParagraphStyle(paragraphStyle)        
         newParagraphStyle.blockquote = nil
 
         var resultingAttributes = attributes

--- a/Aztec/Classes/Formatters/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/HeaderFormatter.swift
@@ -67,10 +67,7 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
-        if newParagraphStyle.headerLevel == .none  && headerLevel != .none {
-            newParagraphStyle.paragraphSpacing += Metrics.defaultIndentation
-            newParagraphStyle.paragraphSpacingBefore += Metrics.defaultIndentation
-        }
+
         newParagraphStyle.headerLevel = headerLevel.rawValue
 
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
@@ -91,10 +88,6 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
             return resultingAttributes
         }
         newParagraphStyle.setParagraphStyle(paragraphStyle)
-        if newParagraphStyle.headerLevel != .none  && headerLevel == .none {
-            newParagraphStyle.paragraphSpacing -= Metrics.defaultIndentation
-            newParagraphStyle.paragraphSpacingBefore -= Metrics.defaultIndentation
-        }
         newParagraphStyle.headerLevel = HeaderType.none.rawValue
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
 

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -35,8 +35,8 @@ class TextListFormatter: ParagraphAttributeFormatter {
         }
 
         if  (increaseDepth || newParagraphStyle.textLists.isEmpty) {
-            newParagraphStyle.headIndent += Metrics.listTextIndentation
-            newParagraphStyle.firstLineHeadIndent += Metrics.listTextIndentation
+            //newParagraphStyle.headIndent += Metrics.listTextIndentation
+            //newParagraphStyle.firstLineHeadIndent += Metrics.listTextIndentation
             newParagraphStyle.textLists.append(TextList(style: self.listStyle))
         } else {
             newParagraphStyle.textLists.removeLast()
@@ -59,8 +59,8 @@ class TextListFormatter: ParagraphAttributeFormatter {
 
         let newParagraphStyle = ParagraphStyle()
         newParagraphStyle.setParagraphStyle(paragraphStyle)
-        newParagraphStyle.headIndent -= Metrics.listTextIndentation
-        newParagraphStyle.firstLineHeadIndent -= Metrics.listTextIndentation
+        //newParagraphStyle.headIndent -= Metrics.listTextIndentation
+        //newParagraphStyle.firstLineHeadIndent -= Metrics.listTextIndentation
         newParagraphStyle.textLists.removeLast()
 
         var resultingAttributes = attributes

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -35,8 +35,6 @@ class TextListFormatter: ParagraphAttributeFormatter {
         }
 
         if  (increaseDepth || newParagraphStyle.textLists.isEmpty) {
-            //newParagraphStyle.headIndent += Metrics.listTextIndentation
-            //newParagraphStyle.firstLineHeadIndent += Metrics.listTextIndentation
             newParagraphStyle.textLists.append(TextList(style: self.listStyle))
         } else {
             newParagraphStyle.textLists.removeLast()
@@ -59,8 +57,6 @@ class TextListFormatter: ParagraphAttributeFormatter {
 
         let newParagraphStyle = ParagraphStyle()
         newParagraphStyle.setParagraphStyle(paragraphStyle)
-        //newParagraphStyle.headIndent -= Metrics.listTextIndentation
-        //newParagraphStyle.firstLineHeadIndent -= Metrics.listTextIndentation
         newParagraphStyle.textLists.removeLast()
 
         var resultingAttributes = attributes

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -127,7 +127,7 @@ private extension LayoutManager {
         let markerPlain = list.style.markerText(forItemNumber: number)
         let markerText = NSAttributedString(string: markerPlain, attributes: markerAttributes)
 
-        let markerRect = rect.offsetBy(dx: style.headIndent - Metrics.listTextIndentation, dy: style.paragraphSpacingBefore)
+        let markerRect = rect.offsetBy(dx: style.headIndent - Metrics.listTextIndentation, dy: style.paragraphSpacingBefore + style.paragraphSpacing)
 
         markerText.draw(in: markerRect)
     }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -127,7 +127,7 @@ private extension LayoutManager {
         let markerPlain = list.style.markerText(forItemNumber: number)
         let markerText = NSAttributedString(string: markerPlain, attributes: markerAttributes)
 
-        let markerRect = rect.offsetBy(dx: style.headIndent - Metrics.listTextIndentation, dy: style.paragraphSpacingBefore + style.paragraphSpacing)
+        let markerRect = rect.offsetBy(dx: style.headIndent, dy: style.paragraphSpacingBefore + style.paragraphSpacing)
 
         markerText.draw(in: markerRect)
     }
@@ -137,7 +137,11 @@ private extension LayoutManager {
     ///
     private func markerAttributesBasedOnParagraph(attributes: [String: Any]) -> [String: Any] {
         var resultAttributes = attributes
-        resultAttributes[NSParagraphStyleAttributeName] = markerParagraphStyle()
+        var indent: CGFloat = 0
+        if let style = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
+            indent = style.headIndent
+        }
+        resultAttributes[NSParagraphStyleAttributeName] = markerParagraphStyle(indent: indent)
         resultAttributes.removeValue(forKey: NSUnderlineStyleAttributeName)
         resultAttributes.removeValue(forKey: NSStrikethroughStyleAttributeName)
         resultAttributes.removeValue(forKey: NSLinkAttributeName)
@@ -155,8 +159,8 @@ private extension LayoutManager {
 
     /// Returns the Marker Paratraph Attributes
     ///
-    private func markerParagraphStyle() -> NSParagraphStyle {
-        let tabStop = NSTextTab(textAlignment: .right, location: Metrics.listBulletIndentation, options: [:])
+    private func markerParagraphStyle(indent: CGFloat) -> NSParagraphStyle {
+        let tabStop = NSTextTab(textAlignment: .right, location: indent, options: [:])
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.tabStops = [tabStop]
 

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -53,12 +53,90 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     override open func setParagraphStyle(_ obj: NSParagraphStyle) {
         super.setParagraphStyle(obj)
         if let paragrahStyle = obj as? ParagraphStyle {
+            headIndent = 0
+            firstLineHeadIndent = 0
+            tailIndent = 0
+            paragraphSpacing = 0
+            paragraphSpacingBefore = 0
+
+            baseHeadIndent = paragrahStyle.baseHeadIndent
+            baseFistLineHeadIndent = paragrahStyle.baseFistLineHeadIndent
+            baseTailIndent = paragrahStyle.baseTailIndent
+            baseParagraphSpacing = paragrahStyle.baseParagraphSpacing
+            baseParagraphSpacingBefore = paragrahStyle.baseParagraphSpacingBefore
+
             blockquote = paragrahStyle.blockquote
             headerLevel = paragrahStyle.headerLevel
             htmlParagraph = paragrahStyle.htmlParagraph
             textLists = paragrahStyle.textLists
         }
     }
+
+    open override var headIndent: CGFloat {
+        get {
+            let extra: CGFloat = (CGFloat(textLists.count) * Metrics.listTextIndentation)
+
+            return baseHeadIndent + extra
+        }
+
+        set {
+            baseHeadIndent = newValue
+        }
+    }
+
+    open override var firstLineHeadIndent: CGFloat {
+        get {
+            let extra: CGFloat = (CGFloat(textLists.count) * Metrics.listTextIndentation)
+
+            return baseFistLineHeadIndent + extra
+        }
+
+        set {
+            baseFistLineHeadIndent = newValue
+        }
+    }
+
+    open override var tailIndent: CGFloat {
+        get {
+            let extra: CGFloat = (self.blockquote == nil ? 0 : 1) * Metrics.defaultIndentation
+
+            return baseTailIndent - extra
+        }
+
+        set {
+            baseTailIndent = newValue
+        }
+    }
+
+    open override var paragraphSpacing: CGFloat {
+        get {
+            let extra: CGFloat = (self.blockquote == nil ? 0 : 1) * Metrics.defaultIndentation
+
+            return baseParagraphSpacing + extra
+        }
+
+        set {
+            baseParagraphSpacing = newValue
+        }
+    }
+
+    open override var paragraphSpacingBefore: CGFloat {
+        get {
+            let extra: CGFloat = (self.blockquote == nil ? 0 : 1) * Metrics.defaultIndentation
+
+            return baseParagraphSpacingBefore + extra
+        }
+
+        set {
+            baseParagraphSpacingBefore = newValue
+        }
+    }
+
+    var baseHeadIndent: CGFloat = 0
+    var baseFistLineHeadIndent: CGFloat = 0
+    var baseTailIndent: CGFloat = 0
+    var baseParagraphSpacing: CGFloat = 0
+    var baseParagraphSpacingBefore: CGFloat = 0
 
     open override class var `default`: NSParagraphStyle {
         let style = ParagraphStyle()

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -60,7 +60,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
             paragraphSpacingBefore = 0
 
             baseHeadIndent = paragrahStyle.baseHeadIndent
-            baseFistLineHeadIndent = paragrahStyle.baseFistLineHeadIndent
+            baseFirstLineHeadIndent = paragrahStyle.baseFirstLineHeadIndent
             baseTailIndent = paragrahStyle.baseTailIndent
             baseParagraphSpacing = paragrahStyle.baseParagraphSpacing
             baseParagraphSpacingBefore = paragrahStyle.baseParagraphSpacingBefore
@@ -88,11 +88,11 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         get {
             let extra: CGFloat = (CGFloat(textLists.count) * Metrics.listTextIndentation)
 
-            return baseFistLineHeadIndent + extra
+            return baseFirstLineHeadIndent + extra
         }
 
         set {
-            baseFistLineHeadIndent = newValue
+            baseFirstLineHeadIndent = newValue
         }
     }
 
@@ -108,9 +108,13 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         }
     }
 
+    private func calculateExtraParagraphSpacing() -> CGFloat {         
+        return min(((self.blockquote == nil ? 0.0 : 1.0) + (self.headerLevel == 0 ? 0.0 : 1.0)), 1.0) * Metrics.paragraphSpacing
+    }
+
     open override var paragraphSpacing: CGFloat {
         get {
-            let extra: CGFloat = (self.blockquote == nil ? 0 : 1) * Metrics.defaultIndentation
+            let extra = calculateExtraParagraphSpacing()
 
             return baseParagraphSpacing + extra
         }
@@ -122,7 +126,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
     open override var paragraphSpacingBefore: CGFloat {
         get {
-            let extra: CGFloat = (self.blockquote == nil ? 0 : 1) * Metrics.defaultIndentation
+            let extra = calculateExtraParagraphSpacing()
 
             return baseParagraphSpacingBefore + extra
         }
@@ -133,7 +137,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     }
 
     var baseHeadIndent: CGFloat = 0
-    var baseFistLineHeadIndent: CGFloat = 0
+    var baseFirstLineHeadIndent: CGFloat = 0
     var baseTailIndent: CGFloat = 0
     var baseParagraphSpacing: CGFloat = 0
     var baseParagraphSpacingBefore: CGFloat = 0


### PR DESCRIPTION
This PR refactor the way formatters applies styles to the paragraphs.

Instead of directly changing values on the ParagraphStyle, the formatters only set the corresponding property to set the style, and then the ParagraphStyle itself decides how this should be applied.

This allows a better separation of the style metrics and the formatters. It also permits better combination of styles like Headers+Blockquotes or List+Blockquotes.

To test:
 - Run the demo app
 - Check if the the properties are still applied properly on the paragraphs
 - Check if using the toolbar to set paragraph styles still work correctly

