### PR TITLE
Fix: testBlockquoteToggle2 Test

### DIFF
--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -222,7 +222,7 @@ class TextStorageTests: XCTestCase
 
         let html = storage.getHTML()
 
-        XCTAssertEqual(html, "Hello &#x1F30E;!<br><blockquote>Apply a blockquote!</blockquote>")
+        XCTAssertEqual(html, "Hello &#x1F30E;!<blockquote>Apply a blockquote!</blockquote>")
     }
 
     func testLinkInsert() {


### PR DESCRIPTION
### Details:
In this (super small PR) we're updating a Unit Test condition. In order to test it, please, verify `testBlockquoteToggle2` is green.

Ref #492 

### Scenario:
1. Type `Hello`
2. Enter newline
3. Toggle Blockquote
4. Type `World`

Verify that the generated HTML looks like: `Hello <blockquote>World</blockquote>`. No newline in beteween!
