### PR TITLE
Rename the textLists attribute of ParagraphStyle to lists.

### DIFF
--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -245,7 +245,7 @@ private extension NSAttributedStringToNodes {
     /// Enumerates all of the "Paragraph ElementNode's" contained within a collection of AttributedString's Atributes.
     ///
     func enumerateParagraphNodes(in style: ParagraphStyle, block: ((ElementNode) -> Void)) {
-        if !style.textLists.isEmpty {
+        if !style.lists.isEmpty {
             let node = ElementNode(type: .li)
             block(node)
         }

--- a/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
@@ -19,12 +19,12 @@ extension NSAttributedString {
         let targetRange = rangeOfEntireString
         guard
             let paragraphStyle = attribute(NSParagraphStyleAttributeName, at: location, longestEffectiveRange: &effectiveRange, in: targetRange) as? ParagraphStyle,
-            let foundList = paragraphStyle.textLists.last,
+            let foundList = paragraphStyle.lists.last,
             foundList == list
         else {
             return nil
         }
-        let listDepth = paragraphStyle.textLists.count
+        let listDepth = paragraphStyle.lists.count
 
         var resultRange = effectiveRange
         //Note: The effective range will only return the range of the in location NSParagraphStyleAttributed 
@@ -33,12 +33,12 @@ extension NSAttributedString {
         while resultRange.location > 0 {
             guard
                 let paragraphStyle = attribute(NSParagraphStyleAttributeName, at: resultRange.location-1, longestEffectiveRange: &effectiveRange, in: targetRange) as? ParagraphStyle,
-                let foundList = paragraphStyle.textLists.last
+                let foundList = paragraphStyle.lists.last
             else {
                     break;
             }
-            if ((listDepth == paragraphStyle.textLists.count && foundList == list) ||
-                listDepth < paragraphStyle.textLists.count) {
+            if ((listDepth == paragraphStyle.lists.count && foundList == list) ||
+                listDepth < paragraphStyle.lists.count) {
                resultRange = resultRange.union(withRange: effectiveRange)
             } else {
                 break;
@@ -47,12 +47,12 @@ extension NSAttributedString {
         while resultRange.endLocation < self.length {
             guard
                 let paragraphStyle = attribute(NSParagraphStyleAttributeName, at: resultRange.endLocation, longestEffectiveRange: &effectiveRange, in: targetRange) as? ParagraphStyle,
-                let foundList = paragraphStyle.textLists.last
+                let foundList = paragraphStyle.lists.last
             else {
                 break;
             }
-            if ((listDepth == paragraphStyle.textLists.count && foundList == list) ||
-                listDepth < paragraphStyle.textLists.count) {
+            if ((listDepth == paragraphStyle.lists.count && foundList == list) ||
+                listDepth < paragraphStyle.lists.count) {
                 resultRange = resultRange.union(withRange: effectiveRange)
             } else {
                 break;
@@ -76,7 +76,7 @@ extension NSAttributedString {
             else {
                 return NSNotFound
         }
-        let listDepth = paragraphStyle.textLists.count
+        let listDepth = paragraphStyle.lists.count
         guard let rangeOfList = range(of:list, at: location) else {
             return NSNotFound
         }
@@ -88,7 +88,7 @@ extension NSAttributedString {
                 return numberInList
             }
             if let paragraphStyle = attribute(NSParagraphStyleAttributeName, at: enclosingRange.location, effectiveRange: nil) as? ParagraphStyle,
-               listDepth == paragraphStyle.textLists.count {
+               listDepth == paragraphStyle.lists.count {
                 numberInList += 1
             }
         }
@@ -108,7 +108,7 @@ extension NSAttributedString {
     /// - Returns: A TextList optional.
     ///
     func textListAttribute(atIndex index: Int) -> TextList? {
-        return (attribute(NSParagraphStyleAttributeName, at: index, effectiveRange: nil) as? ParagraphStyle)?.textLists.last
+        return (attribute(NSParagraphStyleAttributeName, at: index, effectiveRange: nil) as? ParagraphStyle)?.lists.last
     }
 
     /// Returns the TextList attribute, assuming that there is one, spanning the specified Range.
@@ -127,7 +127,7 @@ extension NSAttributedString {
 
         enumerateAttribute(NSParagraphStyleAttributeName, in: range, options: []) { (attribute, range, stop) in
             if let paragraphStyle = attribute as? ParagraphStyle {
-                list = paragraphStyle.textLists.last
+                list = paragraphStyle.lists.last
             }
             stop.pointee = true
         }

--- a/Aztec/Classes/Formatters/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/TextListFormatter.swift
@@ -34,7 +34,7 @@ class TextListFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
 
-        if  (increaseDepth || newParagraphStyle.textLists.isEmpty) {
+        if  (increaseDepth || newParagraphStyle.lists.isEmpty) {
             newParagraphStyle.add(property: TextList(style: self.listStyle))
         } else {
             newParagraphStyle.replaceProperty(ofType: TextList.self, with: TextList(style: self.listStyle))
@@ -48,7 +48,7 @@ class TextListFormatter: ParagraphAttributeFormatter {
 
     func remove(from attributes: [String: Any]) -> [String: Any] {
         guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
-              let currentList = paragraphStyle.textLists.last,
+              let currentList = paragraphStyle.lists.last,
               currentList.style == self.listStyle
         else {
             return attributes
@@ -65,7 +65,7 @@ class TextListFormatter: ParagraphAttributeFormatter {
     }
 
     func present(in attributes: [String : Any]) -> Bool {
-        guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle, let list = style.textLists.last else {
+        guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle, let list = style.lists.last else {
             return false
         }
 
@@ -76,7 +76,7 @@ class TextListFormatter: ParagraphAttributeFormatter {
         guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle else {
             return false
         }
-        return !(style.textLists.isEmpty)
+        return !(style.lists.isEmpty)
     }
 }
 

--- a/Aztec/Classes/TextKit/Header.swift
+++ b/Aztec/Classes/TextKit/Header.swift
@@ -65,6 +65,11 @@ open class Header: ParagraphProperty
         super.init(coder: aDecoder)
     }
 
+    public override func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+        aCoder.encode(level.rawValue, forKey: String(describing: HeaderType.self))
+    }
+
     static func ==(lhs: Header, rhs: Header) -> Bool {
         return lhs.level == rhs.level
     }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -85,7 +85,7 @@ private extension LayoutManager {
 
         let characterRange = self.characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
         textStorage.enumerateAttribute(NSParagraphStyleAttributeName, in: characterRange, options: []) { (object, range, stop) in
-            guard let paragraphStyle = object as? ParagraphStyle, let list = paragraphStyle.textLists.last else {
+            guard let paragraphStyle = object as? ParagraphStyle, let list = paragraphStyle.lists.last else {
                 return
             }
 

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -7,7 +7,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
     public var customMirror: Mirror {
         get {
-            return Mirror(self, children: ["blockquotes": blockquotes as Any, "headerLevel": headerLevel, "htmlParagraph": htmlParagraph as Any, "textList": textLists as Any])
+            return Mirror(self, children: ["blockquotes": blockquotes as Any, "headerLevel": headerLevel, "htmlParagraph": htmlParagraph as Any, "textList": lists as Any])
         }
     }
 
@@ -37,7 +37,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         }
     }
 
-    var textLists : [TextList] {
+    var lists : [TextList] {
         return properties.flatMap { (property) -> TextList? in
             if let textList = property as? TextList {
                 return textList
@@ -110,7 +110,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
     open override var headIndent: CGFloat {
         get {
-            let extra: CGFloat = (CGFloat(textLists.count) * Metrics.listTextIndentation)
+            let extra: CGFloat = (CGFloat(lists.count) * Metrics.listTextIndentation)
 
             return baseHeadIndent + extra
         }
@@ -122,7 +122,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
     open override var firstLineHeadIndent: CGFloat {
         get {
-            let extra: CGFloat = (CGFloat(textLists.count) * Metrics.listTextIndentation)
+            let extra: CGFloat = (CGFloat(lists.count) * Metrics.listTextIndentation)
 
             return baseFirstLineHeadIndent + extra
         }
@@ -244,7 +244,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     }
 
     open override var description: String {
-        return super.description + " Blockquotes: \(String(describing:blockquotes)),\n HeaderLevel: \(headerLevel),\n HTMLParagraph: \(String(describing: htmlParagraph)),\n TextLists: \(textLists)"
+        return super.description + " Blockquotes: \(String(describing:blockquotes)),\n HeaderLevel: \(headerLevel),\n HTMLParagraph: \(String(describing: htmlParagraph)),\n TextLists: \(lists)"
     }
 }
 

--- a/Aztec/Classes/TextKit/TextList.swift
+++ b/Aztec/Classes/TextKit/TextList.swift
@@ -43,6 +43,11 @@ class TextList: ParagraphProperty
         super.init(coder: aDecoder)
     }
 
+    public override func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+        aCoder.encode(style.rawValue, forKey: String(describing: Style.self))
+    }
+
     static func ==(lhs: TextList, rhs: TextList) -> Bool {
         return lhs.style == rhs.style 
     }


### PR DESCRIPTION
Fixes #512 

This PR just renames the `textLists` property in `ParagraphStyle` to `lists`

To test:
 - Run the demo app
 - See if the demo content shows correctly
 - Select text with a list on it
 - Tap copy
 - And paste to another part
 - See if all went well.
 - See if unit tests are not affected


