### PR TITLE
Remove preprocessing of paragraphs.

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -114,39 +114,8 @@ open class TextStorage: NSTextStorage {
 
     private func preprocessAttributesForInsertion(_ attributedString: NSAttributedString) -> NSAttributedString {
         let stringWithAttachments = preprocessAttachmentsForInsertion(attributedString)
-        let stringWithParagraphs = preprocessParagraphsForInsertion(stringWithAttachments)
 
-        return stringWithParagraphs
-    }
-
-    private func preprocessParagraphsForInsertion(_ attributedString: NSAttributedString) -> NSAttributedString {
-
-        let fullRange = NSRange(location: 0, length: attributedString.length)
-        let finalString = NSMutableAttributedString(attributedString: attributedString)
-
-        attributedString.enumerateAttribute(NSParagraphStyleAttributeName, in: fullRange, options: []) { (value, subRange, stop) in
-
-            guard value is ParagraphStyle else {
-                return
-            }
-
-            var newlineRange = finalString.mutableString.range(of: String(.newline))
-
-            while newlineRange.location != NSNotFound {
-
-                let originalAttributes = finalString.attributes(at: newlineRange.location, effectiveRange: nil)
-
-                finalString.replaceCharacters(in: newlineRange, with: NSAttributedString(.paragraphSeparator, attributes: originalAttributes))
-
-                let nextLocation = newlineRange.location + newlineRange.length
-                let nextLength = subRange.length - nextLocation
-                let nextRange = NSRange(location: nextLocation, length: nextLength)
-
-                newlineRange = finalString.mutableString.range(of: String(.newline), options: [], range: nextRange)
-            }
-        }
-
-        return finalString
+        return stringWithAttachments
     }
 
     /// Preprocesses an attributed string's attachments for insertion in the storage.

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -944,7 +944,7 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
         textView.insertText(String(.newline))
 
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.paragraphSeparator) + String(.paragraphSeparator))
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.paragraphSeparator) )
     }
 
     /// Verifies that toggling an Ordered List, when editing an empty document, inserts a Newline.
@@ -981,7 +981,7 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
         textView.insertText(String(.newline))
 
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.paragraphSeparator) + String(.paragraphSeparator))
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.paragraphSeparator))
     }
 
 
@@ -1167,7 +1167,7 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
         textView.insertText(String(.newline))
 
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.paragraphSeparator) + String(.paragraphSeparator))
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.paragraphSeparator))
     }
 
 
@@ -1353,7 +1353,7 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
         textView.insertText(String(.newline))
         
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.paragraphSeparator) + String(.paragraphSeparator))
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.paragraphSeparator))
     }
 
     func testInsertVideo() {


### PR DESCRIPTION
This PR removes some preprocessing for paragraphs that is no longer needed.

To test:
 - run the demo app and see that all shows up correctly.
 - check if unit tests are ok.

