### PR TITLE
Supporting Unsupported HTML

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		B577DC671E7B18F80012A1F8 /* CommentNodeDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B577DC661E7B18F80012A1F8 /* CommentNodeDescriptor.swift */; };
 		B57D1C3D1E92C38000EA4B16 /* HTMLAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */; };
 		B59C9F9F1DF74BB80073B1D6 /* UIFont+Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */; };
+		B5A5277C1EF1B44800E7D2FD /* UnsupportedHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5277B1EF1B44800E7D2FD /* UnsupportedHTML.swift */; };
 		B5A99D841EBA073D00DED081 /* HTMLStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A99D831EBA073D00DED081 /* HTMLStorage.swift */; };
 		B5AF89321E93CFC80051EFDB /* RenderableAttachmentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF89311E93CFC80051EFDB /* RenderableAttachmentDelegate.swift */; };
 		B5B86D371DA3EC250083DB3F /* NSRange+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */; };
@@ -209,6 +210,7 @@
 		B577DC661E7B18F80012A1F8 /* CommentNodeDescriptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommentNodeDescriptor.swift; path = Descriptors/CommentNodeDescriptor.swift; sourceTree = "<group>"; };
 		B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachment.swift; sourceTree = "<group>"; };
 		B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Traits.swift"; sourceTree = "<group>"; };
+		B5A5277B1EF1B44800E7D2FD /* UnsupportedHTML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnsupportedHTML.swift; sourceTree = "<group>"; };
 		B5A99D831EBA073D00DED081 /* HTMLStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLStorage.swift; sourceTree = "<group>"; };
 		B5AF89311E93CFC80051EFDB /* RenderableAttachmentDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RenderableAttachmentDelegate.swift; sourceTree = "<group>"; };
 		B5B86D3B1DA41A550083DB3F /* TextListFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextListFormatter.swift; sourceTree = "<group>"; };
@@ -599,6 +601,14 @@
 			path = Converters;
 			sourceTree = "<group>";
 		};
+		B5A5277A1EF1B44800E7D2FD /* Styles */ = {
+			isa = PBXGroup;
+			children = (
+				B5A5277B1EF1B44800E7D2FD /* UnsupportedHTML.swift */,
+			);
+			path = Styles;
+			sourceTree = "<group>";
+		};
 		B5B86D3A1DA41A550083DB3F /* Formatters */ = {
 			isa = PBXGroup;
 			children = (
@@ -661,6 +671,7 @@
 			isa = PBXGroup;
 			children = (
 				F16DD2C91EE99B850083A098 /* HTML */,
+				B5A5277A1EF1B44800E7D2FD /* Styles */,
 			);
 			path = NSAttributedString;
 			sourceTree = "<group>";
@@ -905,6 +916,7 @@
 				F1C05B9D1E37FA77007510EA /* String+CharacterName.swift in Sources */,
 				FF2774A61EEFE85800D7F2BD /* ParagraphProperty.swift in Sources */,
 				FFFEC7DB1EA7698900F4210F /* VideoAttachment.swift in Sources */,
+				B5A5277C1EF1B44800E7D2FD /* UnsupportedHTML.swift in Sources */,
 				F1288BB01DD0B1EF00E67ABC /* HTMLToAttributedString.swift in Sources */,
 				B5DA1C1D1EBD1CCE000AAB45 /* OutHTMLConverter.swift in Sources */,
 				E11B77641DBA6ADC0024E455 /* AttributeFormatter.swift in Sources */,

--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		B57D1C3D1E92C38000EA4B16 /* HTMLAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */; };
 		B59C9F9F1DF74BB80073B1D6 /* UIFont+Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */; };
 		B5A5277C1EF1B44800E7D2FD /* UnsupportedHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5277B1EF1B44800E7D2FD /* UnsupportedHTML.swift */; };
+		B5A5277E1EF1BAC000E7D2FD /* HMTLNodeToNSAttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5277D1EF1BAC000E7D2FD /* HMTLNodeToNSAttributedStringTests.swift */; };
 		B5A99D841EBA073D00DED081 /* HTMLStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A99D831EBA073D00DED081 /* HTMLStorage.swift */; };
 		B5AF89321E93CFC80051EFDB /* RenderableAttachmentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF89311E93CFC80051EFDB /* RenderableAttachmentDelegate.swift */; };
 		B5B86D371DA3EC250083DB3F /* NSRange+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */; };
@@ -211,6 +212,7 @@
 		B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachment.swift; sourceTree = "<group>"; };
 		B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Traits.swift"; sourceTree = "<group>"; };
 		B5A5277B1EF1B44800E7D2FD /* UnsupportedHTML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnsupportedHTML.swift; sourceTree = "<group>"; };
+		B5A5277D1EF1BAC000E7D2FD /* HMTLNodeToNSAttributedStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HMTLNodeToNSAttributedStringTests.swift; sourceTree = "<group>"; };
 		B5A99D831EBA073D00DED081 /* HTMLStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLStorage.swift; sourceTree = "<group>"; };
 		B5AF89311E93CFC80051EFDB /* RenderableAttachmentDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RenderableAttachmentDelegate.swift; sourceTree = "<group>"; };
 		B5B86D3B1DA41A550083DB3F /* TextListFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextListFormatter.swift; sourceTree = "<group>"; };
@@ -597,6 +599,7 @@
 			isa = PBXGroup;
 			children = (
 				B5657C171EE99AF500579FE1 /* NSAttributedStringToNodesTests.swift */,
+				B5A5277D1EF1BAC000E7D2FD /* HMTLNodeToNSAttributedStringTests.swift */,
 			);
 			path = Converters;
 			sourceTree = "<group>";
@@ -979,6 +982,7 @@
 			files = (
 				FF7DCB4B1E815F9400AB77CB /* UIColorHexParserTests.swift in Sources */,
 				594C9D741D8BE6C700D74542 /* InNodeConverterTests.swift in Sources */,
+				B5A5277E1EF1BAC000E7D2FD /* HMTLNodeToNSAttributedStringTests.swift in Sources */,
 				B5F84B631E706B720089A76C /* NSAttributedStringAnalyzerTests.swift in Sources */,
 				F10BE61C1EA7B1DB002E4625 /* NSAttributedStringReplaceOcurrencesTests.swift in Sources */,
 				59FEA0751D8BDFA700D138DF /* NodeTests.swift in Sources */,

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -351,7 +351,7 @@ private extension HTMLNodeToNSAttributedString {
         if let elementFormatter = formatter(for: elementRepresentation) {
             finalAttributes = elementFormatter.apply(to: finalAttributes, andStore: elementRepresentation)
         } else {
-            finalAttributes = store(elementRepresentation: elementRepresentation, in: finalAttributes)
+            finalAttributes = self.attributes(storing: elementRepresentation, in: finalAttributes)
         }
 
         for attributeRepresentation in elementRepresentation.attributes {
@@ -393,7 +393,7 @@ private extension HTMLNodeToNSAttributedString {
     ///
     /// - Returns: A collection of NSAttributedString Attributes, including the specified HTMLElementRepresentation.
     ///
-    private func store(elementRepresentation: HTMLElementRepresentation, in attributes: [String: Any]) -> [String: Any] {
+    private func attributes(storing elementRepresentation: HTMLElementRepresentation, in attributes: [String: Any]) -> [String: Any] {
         let unsupportedHTML = attributes[UnsupportedHTMLAttributeName] as? UnsupportedHTML ?? UnsupportedHTML()
         unsupportedHTML.add(element: elementRepresentation)
 

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -36,7 +36,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
     func convert(_ node: Node) -> NSAttributedString {
-        return convert(node, inheritingAttributes: defaultAttributes)
+        return convert(node, inheriting: defaultAttributes)
     }
 
     /// Recursive conversion method.  Useful for maintaining the font style of parent nodes when
@@ -48,25 +48,25 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
-    fileprivate func convert(_ node: Node, inheritingAttributes attributes: [String:Any]) -> NSAttributedString {
+    fileprivate func convert(_ node: Node, inheriting attributes: [String:Any]) -> NSAttributedString {
 
-        let string = convertContents(of: node, inheritingAttributes: attributes)
+        let string = convertContents(of: node, inheriting: attributes)
 
         guard node.needsClosingParagraphSeparator() else {
             return string
         }
 
-        return appendParagraphSeparator(to: string, inheritingAttributes: attributes)
+        return appendParagraphSeparator(to: string, inheriting: attributes)
     }
 
-    private func convertContents(of node: Node, inheritingAttributes attributes: [String:Any]) -> NSAttributedString {
+    private func convertContents(of node: Node, inheriting attributes: [String:Any]) -> NSAttributedString {
         switch node {
         case let textNode as TextNode:
-            return convertTextNode(textNode, inheritingAttributes: attributes)
+            return convertTextNode(textNode, inheriting: attributes)
         case let commentNode as CommentNode:
-            return convertCommentNode(commentNode, inheritingAttributes: attributes)
+            return convertCommentNode(commentNode, inheriting: attributes)
         case let elementNode as ElementNode:
-            return convertElementNode(elementNode, inheritingAttributes: attributes)
+            return convertElementNode(elementNode, inheriting: attributes)
         default:
             fatalError("Nodes can be either text, comment or element nodes.")
         }
@@ -80,12 +80,12 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
-    fileprivate func convertTextNode(_ node: TextNode, inheritingAttributes inheritedAttributes: [String:Any]) -> NSAttributedString {
+    fileprivate func convertTextNode(_ node: TextNode, inheriting attributes: [String:Any]) -> NSAttributedString {
         guard node.length() > 0 else {
             return NSAttributedString()
         }
 
-        return NSAttributedString(string: node.text(), attributes: inheritedAttributes)
+        return NSAttributedString(string: node.text(), attributes: attributes)
     }
 
     /// Converts a `CommentNode` to `NSAttributedString`.
@@ -96,7 +96,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
-    fileprivate func convertCommentNode(_ node: CommentNode, inheritingAttributes attributes: [String:Any]) -> NSAttributedString {
+    fileprivate func convertCommentNode(_ node: CommentNode, inheriting attributes: [String:Any]) -> NSAttributedString {
         let attachment = CommentAttachment()
         attachment.text = node.comment
 
@@ -111,9 +111,9 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
-    fileprivate func convertElementNode(_ node: ElementNode, inheritingAttributes attributes: [String: Any]) -> NSAttributedString {
+    fileprivate func convertElementNode(_ node: ElementNode, inheriting attributes: [String: Any]) -> NSAttributedString {
         guard !node.isSupportedByEditor() else {
-            return stringForNode(node, inheritingAttributes: attributes)
+            return stringForNode(node, inheriting: attributes)
         }
 
         let converter = Libxml2.Out.HTMLConverter()
@@ -127,7 +127,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
 
     // MARK: - Paragraph Separator
 
-    private func appendParagraphSeparator(to string: NSAttributedString, inheritingAttributes inheritedAttributes: [String: Any]) -> NSAttributedString {
+    private func appendParagraphSeparator(to string: NSAttributedString, inheriting inheritedAttributes: [String: Any]) -> NSAttributedString {
 
         let stringWithSeparator = NSMutableAttributedString(attributedString: string)
 
@@ -143,14 +143,14 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     /// - Parameters:
     ///     - node: the element node to generate a representation string of.
-    ///     - inheritedAttributes: the inherited attributes from parent nodes.
+    ///     - attributes: the inherited attributes from parent nodes.
     ///
     /// - Returns: the attributed string representing the specified element node.
     ///
     ///
-    fileprivate func stringForNode(_ node: ElementNode, inheritingAttributes inheritedAttributes: [String:Any]) -> NSAttributedString {
+    fileprivate func stringForNode(_ node: ElementNode, inheriting attributes: [String:Any]) -> NSAttributedString {
         
-        let childAttributes = attributes(forNode: node, inheritingAttributes: inheritedAttributes)
+        let childAttributes = self.attributes(forNode: node, inheriting: attributes)
         
         if let nodeType = node.standardName,
             let implicitRepresentation = nodeType.implicitRepresentation(withAttributes: childAttributes) {
@@ -161,7 +161,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         let content = NSMutableAttributedString()
         
         for child in node.children {
-            let childContent = convert(child, inheritingAttributes: childAttributes)
+            let childContent = convert(child, inheriting: childAttributes)
             content.append(childContent)
         }
         
@@ -213,7 +213,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     ///
     /// - Returns: an attributes dictionary, for use in an NSAttributedString.
     ///
-    fileprivate func attributes(forNode node: ElementNode, inheritingAttributes inheritedAttributes: [String:Any]) -> [String:Any] {
+    fileprivate func attributes(forNode node: ElementNode, inheriting attributes: [String: Any]) -> [String: Any] {
 
         let representation = HTMLElementRepresentation(for: node)
         let attributes: [String:Any]

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -327,12 +327,12 @@ private extension HTMLNodeToNSAttributedString {
     ///
     func attributes(forNode node: ElementNode, inheriting attributes: [String: Any]) -> [String: Any] {
 
-        guard node.needsToBePreservedDuringRegeneration() else {
+        guard !(node is RootNode) else {
             return attributes
         }
 
         let elementRepresentation = HTMLElementRepresentation(for: node)
-        return attributes(for: elementRepresentation, inheriting: inheritedAttributes)
+        return self.attributes(for: elementRepresentation, inheriting: attributes)
     }
 
     /// Calculates the attributes for the specified element representation.  Returns a dictionary
@@ -344,17 +344,15 @@ private extension HTMLNodeToNSAttributedString {
     ///
     /// - Returns: an attributes dictionary, for use in an NSAttributedString.
     ///
-    private func attributes(for elementRepresentation: HTMLElementRepresentation, inheriting attributes: [String:Any]) -> [String:Any] {
-
-        let attributes: [String:Any]
-
-        if let elementFormatter = formatter(for: elementRepresentation) {
-            attributes = elementFormatter.apply(to: attributes, andStore: elementRepresentation)
-        } else {
-            attributes = store(elementRepresentation: elementRepresentation, in: attributes)
-        }
+    private func attributes(for elementRepresentation: HTMLElementRepresentation, inheriting attributes: [String: Any]) -> [String: Any] {
 
         var finalAttributes = attributes
+
+        if let elementFormatter = formatter(for: elementRepresentation) {
+            finalAttributes = elementFormatter.apply(to: finalAttributes, andStore: elementRepresentation)
+        } else {
+            finalAttributes = store(elementRepresentation: elementRepresentation, in: finalAttributes)
+        }
 
         for attributeRepresentation in elementRepresentation.attributes {
             finalAttributes = self.attributes(for: attributeRepresentation, inheriting: finalAttributes)
@@ -373,7 +371,7 @@ private extension HTMLNodeToNSAttributedString {
     ///
     /// - Returns: an attributes dictionary, for use in an NSAttributedString.
     ///
-    private func attributes(for attributeRepresentation: HTMLAttributeRepresentation, inheriting inheritedAttributes: [String:Any]) -> [String:Any] {
+    private func attributes(for attributeRepresentation: HTMLAttributeRepresentation, inheriting inheritedAttributes: [String: Any]) -> [String: Any] {
 
         let attributes: [String:Any]
 

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -16,6 +16,7 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     /// 
     let defaultFontDescriptor: UIFontDescriptor
 
+
     // MARK: - Initializers
 
     required init(usingDefaultFontDescriptor defaultFontDescriptor: UIFontDescriptor) {
@@ -26,6 +27,8 @@ class HMTLNodeToNSAttributedString: SafeConverter {
         let defaultFont = UIFont(descriptor: self.defaultFontDescriptor, size: self.defaultFontDescriptor.pointSize)
         return [NSFontAttributeName: defaultFont]
     }()
+
+
     // MARK: - Conversion
 
     /// Main conversion method.
@@ -216,15 +219,22 @@ class HMTLNodeToNSAttributedString: SafeConverter {
     fileprivate func attributes(forNode node: ElementNode, inheriting attributes: [String: Any]) -> [String: Any] {
 
         let representation = HTMLElementRepresentation(for: node)
-        let attributes: [String:Any]
 
         if let formatter = self.formatter(for: representation) {
-            attributes = formatter.apply(to: inheritedAttributes, andStore: representation)
-        } else {
-            attributes = inheritedAttributes
+            return formatter.apply(to: attributes, andStore: representation)
         }
 
-        return attributes
+        guard node.needsToBePreservedDuringRegeneration() else {
+            return attributes
+        }
+
+        let unsupportedHTML = attributes[UnsupportedHTMLAttributeName] as? UnsupportedHTML ?? UnsupportedHTML()
+        unsupportedHTML.add(element: representation)
+
+        var updated = attributes
+        updated[UnsupportedHTMLAttributeName] = unsupportedHTML
+
+        return updated
     }
 
 

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -372,6 +372,15 @@ private extension NSAttributedStringToNodes {
                 let node = ElementNode(type: .u)
                 block(node)
 
+            case UnsupportedHTMLAttributeName:
+                guard let unsupported = value as? UnsupportedHTML else {
+                    break
+                }
+
+                for element in unsupported.elements.reversed() {
+                    block(element.toNode())
+                }
+
             default:
                 break
             }

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -366,6 +366,12 @@ extension Libxml2 {
 
             return ElementNode.knownElements.contains(standardName)
         }
+
+        /// Indicates if the current Element Node should be preserved during the DOM regeneration
+        ///
+        func needsToBePreservedDuringRegeneration() -> Bool {
+            return true
+        }
     }
 
 
@@ -400,6 +406,10 @@ extension Libxml2 {
 
         override func isSupportedByEditor() -> Bool {
             return true
+        }
+
+        override func needsToBePreservedDuringRegeneration() -> Bool {
+            return false
         }
     }
 }

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -366,12 +366,6 @@ extension Libxml2 {
 
             return ElementNode.knownElements.contains(standardName)
         }
-
-        /// Indicates if the current Element Node should be preserved during the DOM regeneration
-        ///
-        func needsToBePreservedDuringRegeneration() -> Bool {
-            return true
-        }
     }
 
 
@@ -406,10 +400,6 @@ extension Libxml2 {
 
         override func isSupportedByEditor() -> Bool {
             return true
-        }
-
-        override func needsToBePreservedDuringRegeneration() -> Bool {
-            return false
         }
     }
 }

--- a/Aztec/Classes/NSAttributedString/HTML/HTMLAttributeRepresentation.swift
+++ b/Aztec/Classes/NSAttributedString/HTML/HTMLAttributeRepresentation.swift
@@ -20,6 +20,8 @@ class HTMLAttributeRepresentation: HTMLRepresentation, Equatable {
     ///
     let value: String?
 
+    /// Initializes the HTMLAttributeRepresentation Instance
+    ///
     init(for attribute: Attribute, in element: HTMLElementRepresentation? = nil) {
 
         self.element = element
@@ -27,6 +29,17 @@ class HTMLAttributeRepresentation: HTMLRepresentation, Equatable {
 
         let stringAttribute = attribute as? StringAttribute
         value = stringAttribute?.value
+    }
+
+
+    /// Returns the Attribute instance for the current representation
+    ///
+    func toAttribute() -> Attribute {
+        guard let value = value else {
+            return Attribute(name: name)
+        }
+
+        return StringAttribute(name: name, value: value)
     }
 
 

--- a/Aztec/Classes/NSAttributedString/HTML/HTMLAttributeRepresentation.swift
+++ b/Aztec/Classes/NSAttributedString/HTML/HTMLAttributeRepresentation.swift
@@ -1,5 +1,9 @@
+import Foundation
 
-class HTMLAttributeRepresentation: HTMLRepresentation {
+
+// MARK: - HTMLAttributeRepresentation
+//
+class HTMLAttributeRepresentation: HTMLRepresentation, Equatable {
 
     typealias Attribute = Libxml2.Attribute
     typealias StringAttribute = Libxml2.StringAttribute
@@ -23,5 +27,12 @@ class HTMLAttributeRepresentation: HTMLRepresentation {
 
         let stringAttribute = attribute as? StringAttribute
         value = stringAttribute?.value
+    }
+
+
+    // MARK: - Equatable
+
+    static func ==(lhs: HTMLAttributeRepresentation, rhs: HTMLAttributeRepresentation) -> Bool {
+        return type(of: lhs) == type(of: rhs) && lhs.name == rhs.name && lhs.value == rhs.value
     }
 }

--- a/Aztec/Classes/NSAttributedString/HTML/HTMLElementRepresentator.swift
+++ b/Aztec/Classes/NSAttributedString/HTML/HTMLElementRepresentator.swift
@@ -1,6 +1,9 @@
+import Foundation
 
 
-class HTMLElementRepresentation: HTMLRepresentation {
+// MARK: - HTMLElementRepresentation
+//
+class HTMLElementRepresentation: HTMLRepresentation, Equatable {
 
     typealias ElementNode = Libxml2.ElementNode
 
@@ -18,5 +21,12 @@ class HTMLElementRepresentation: HTMLRepresentation {
         for attribute in element.attributes {
             attributes.append(HTMLAttributeRepresentation(for: attribute))
         }
+    }
+
+
+    // MARK: - Equatable
+
+    static func ==(lhs: HTMLElementRepresentation, rhs: HTMLElementRepresentation) -> Bool {
+        return type(of: lhs) == type(of: rhs) && lhs.name == rhs.name && lhs.attributes == rhs.attributes
     }
 }

--- a/Aztec/Classes/NSAttributedString/HTML/HTMLElementRepresentator.swift
+++ b/Aztec/Classes/NSAttributedString/HTML/HTMLElementRepresentator.swift
@@ -23,6 +23,16 @@ class HTMLElementRepresentation: HTMLRepresentation, Equatable {
         }
     }
 
+    /// Returns the ElementNode Instance for the current definition.
+    ///
+    func toNode() -> ElementNode {
+        let attributes = self.attributes.flatMap { representation in
+            return representation.toAttribute()
+        }
+
+        return ElementNode(name: name, attributes: attributes, children: [])
+    }
+
 
     // MARK: - Equatable
 

--- a/Aztec/Classes/NSAttributedString/Styles/UnsupportedHTML.swift
+++ b/Aztec/Classes/NSAttributedString/Styles/UnsupportedHTML.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+
+// MARK: - UnsupportedHTML NSAttributedString Attribute Name
+//
+let UnsupportedHTMLAttributeName = "UnsupportedHTMLAttributeName"
+
+
+// MARK: - UnsupportedHTML
+//
+class UnsupportedHTML {
+
+    /// Typealiases
+    ///
+    typealias ElementNode = Libxml2.ElementNode
+
+    /// Nodes not supported by the Editor (which will be re-serialized!!)
+    ///
+    private(set) var nodes = [ElementNode]()
+
+    /// Adds the specified ElementNode Instance
+    ///
+    func add(node: ElementNode) {
+        nodes.append(node)
+    }
+
+    /// Removes the specified ElementNode Instance
+    ///
+    func remove(node: ElementNode) {
+        guard let index = nodes.index(where: { $0 == node }) else {
+            return
+        }
+
+        nodes.remove(at: index)
+    }
+}

--- a/Aztec/Classes/NSAttributedString/Styles/UnsupportedHTML.swift
+++ b/Aztec/Classes/NSAttributedString/Styles/UnsupportedHTML.swift
@@ -10,27 +10,23 @@ let UnsupportedHTMLAttributeName = "UnsupportedHTMLAttributeName"
 //
 class UnsupportedHTML {
 
-    /// Typealiases
-    ///
-    typealias ElementNode = Libxml2.ElementNode
-
     /// Nodes not supported by the Editor (which will be re-serialized!!)
     ///
-    private(set) var nodes = [ElementNode]()
+    private(set) var elements = [HTMLElementRepresentation]()
 
-    /// Adds the specified ElementNode Instance
+    /// Adds the specified Element Representation
     ///
-    func add(node: ElementNode) {
-        nodes.append(node)
+    func add(element: HTMLElementRepresentation) {
+        elements.append(element)
     }
 
-    /// Removes the specified ElementNode Instance
+    /// Removes the specified Element Representation
     ///
-    func remove(node: ElementNode) {
-        guard let index = nodes.index(where: { $0 == node }) else {
+    func remove(element: HTMLElementRepresentation) {
+        guard let index = elements.index(where: { $0 == element }) else {
             return
         }
 
-        nodes.remove(at: index)
+        elements.remove(at: index)
     }
 }

--- a/AztecTests/Converters/HMTLNodeToNSAttributedStringTests.swift
+++ b/AztecTests/Converters/HMTLNodeToNSAttributedStringTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import Aztec
+
+
+// MARK: - HMTLNodeToNSAttributedStringTests
+//
+class HMTLNodeToNSAttributedStringTests: XCTestCase {
+
+    func testExample() {
+
+    }
+}


### PR DESCRIPTION
### Details:
Best Issue Title *Ever*. In this PR we're implementing a new NSAttributedString attribute, responsible of holding references to the HTML Entities, present in the original HTML, that aren't directly editable, but should be maintained.

Unit Tests coming up in a different PR.

Ref. #521 

### To test:
1. Launch the Empty Editor
2. Switch to HTML mode
3. Enter `<span class="i am"><span class="evil>YEAH!</span></span>`
4. Switch back to Rich Mode
5. Switch back to HTML mode

Verify that the SPAN entities are there.

cc @diegoreymendez 
Thanks in advance!!
