### PR TITLE
FormatBar: Add bottom divider

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -21,9 +21,10 @@ open class FormatBar: UIView {
     fileprivate let scrollableStackView = UIStackView()
 
 
-    /// Top dividing line
+    /// Top and bottom dividing lines
     ///
     fileprivate let topDivider = UIView()
+    fileprivate let bottomDivider = UIView()
 
 
     /// FormatBarItems to be displayed when the bar is in its default collapsed state.
@@ -182,7 +183,7 @@ open class FormatBar: UIView {
     ///
     open var dividerTintColor: UIColor? {
         didSet {
-            for divider in dividers {
+            for divider in (dividers + [topDivider, bottomDivider]) {
                 divider.backgroundColor = dividerTintColor
             }
         }
@@ -237,7 +238,9 @@ open class FormatBar: UIView {
         scrollView.addSubview(scrollableStackView)
 
         topDivider.translatesAutoresizingMaskIntoConstraints = false
+        bottomDivider.translatesAutoresizingMaskIntoConstraints = false
         addSubview(topDivider)
+        addSubview(bottomDivider)
 
         overflowToggleItem.translatesAutoresizingMaskIntoConstraints = false
         addSubview(overflowToggleItem)
@@ -424,7 +427,14 @@ private extension FormatBar {
             topDivider.leadingAnchor.constraint(equalTo: leadingAnchor),
             topDivider.trailingAnchor.constraint(equalTo: trailingAnchor),
             topDivider.topAnchor.constraint(equalTo: topAnchor),
-            topDivider.heightAnchor.constraint(equalToConstant: Constants.topDividerHeight)
+            topDivider.heightAnchor.constraint(equalToConstant: Constants.horizontalDividerHeight)
+        ])
+
+        NSLayoutConstraint.activate([
+            bottomDivider.leadingAnchor.constraint(equalTo: leadingAnchor),
+            bottomDivider.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bottomDivider.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bottomDivider.heightAnchor.constraint(equalToConstant: Constants.horizontalDividerHeight)
         ])
 
         NSLayoutConstraint.activate([
@@ -432,7 +442,7 @@ private extension FormatBar {
             scrollView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -1 * insets.right),
             scrollView.topAnchor.constraint(equalTo: topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: bottomAnchor)
-            ])
+        ])
 
         NSLayoutConstraint.activate([
             scrollableStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
@@ -440,7 +450,7 @@ private extension FormatBar {
             scrollableStackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
             scrollableStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
             scrollableStackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
-            ])
+        ])
     }
 }
 
@@ -559,7 +569,7 @@ private extension FormatBar {
         static let stackViewCompactSpacing = CGFloat(0)
         static let stackViewRegularSpacing = CGFloat(0)
         static let stackButtonWidth = CGFloat(44)
-        static let topDividerHeight = CGFloat(1)
+        static let horizontalDividerHeight = CGFloat(1)
     }
 }
 


### PR DESCRIPTION
Simple, does what it says in the title. The format bar now has a divider on the bottom as well as the top. This helps to visually separate it from the heading / list tables below.

<img width="377" alt="screen shot 2017-06-15 at 16 37 31" src="https://user-images.githubusercontent.com/4780/27189404-27d3fb76-51e9-11e7-9a3d-410444797373.png">

To test:

* Build and run the demo app, check you can see the divider and it looks correct.

Needs review: @SergioEstevao 