### PR TITLE
FormatBars: Consolidating multiple bars

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -195,6 +195,8 @@ open class FormatBar: UIView {
             for item in items {
                 item.isEnabled = enabled
             }
+
+            overflowToggleItem.isEnabled = enabled
         }
     }
 

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -211,7 +211,7 @@ open class FormatBar: UIView {
         }
     }
 
-    func updateVisibleItemsForCurrentBounds() {
+    fileprivate func updateVisibleItemsForCurrentBounds() {
         guard overflowItemsHidden else { return }
 
         // Ensure that any items that wouldn't fit are hidden


### PR DESCRIPTION
This PR makes a couple of small tweaks to the way format bars are used in the demo. Instead of creating one per text view, we're now sharing one between them. I've also made a few changes to the way items are disabled in the bar.

To test:

* Open the sample editor and test tapping between the different text views – title and rich text view. In the title view, all buttons in the toolbar should be disabled.
* In the rich text view, try toggling to HTML mode, and back again. In HTML mode, only the HTML button should stay enabled. When you toggle it back off, all buttons should become enabled again.

Needs review: @SergioEstevao 