### PR TITLE
FormatBar: Add popovers for pickers on iPad

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -63,6 +63,7 @@ open class FormatBar: UIView {
         self.configureStylesFor(item)
 
         item.addTarget(self, action: #selector(handleToggleButtonAction), for: .touchUpInside)
+        item.addTarget(self, action: #selector(handleButtonTouch), for: .touchDown)
 
         return item
     }()
@@ -284,7 +285,12 @@ open class FormatBar: UIView {
         }
     }
 
+
     // MARK: - Actions
+
+    @IBAction func handleButtonTouch(_ sender: FormatBarItem) {
+        formatter?.formatBarTouchesBegan(self)
+    }
 
     @IBAction func handleButtonAction(_ sender: FormatBarItem) {
         guard let identifier = sender.identifier else { return }
@@ -368,6 +374,7 @@ private extension FormatBar {
         configureStylesFor(item)
 
         item.addTarget(self, action: #selector(handleButtonAction), for: .touchUpInside)
+        item.addTarget(self, action: #selector(handleButtonTouch), for: .touchDown)
     }
 
     func configureStylesFor(_ item: FormatBarItem) {
@@ -396,6 +403,7 @@ private extension FormatBar {
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.alwaysBounceHorizontal = false
         scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.delegate = self
 
         // Add padding at the end to account for overflow button
         scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: Constants.stackButtonWidth)
@@ -522,6 +530,13 @@ private extension FormatBar {
     }
 }
 
+// MARK: - UIScrollViewDelegate
+
+extension FormatBar: UIScrollViewDelegate {
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        formatter?.formatBarTouchesBegan(self)
+    }
+}
 
 // MARK: - Private Constants
 //

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -289,7 +289,7 @@ open class FormatBar: UIView {
     @IBAction func handleButtonAction(_ sender: FormatBarItem) {
         guard let identifier = sender.identifier else { return }
 
-        formatter?.handleActionForIdentifier(identifier)
+        formatter?.handleActionForIdentifier(identifier, barItem: sender)
     }
 
     @IBAction func handleToggleButtonAction(_ sender: FormatBarItem) {

--- a/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
@@ -5,4 +5,5 @@ import UIKit
 public protocol FormatBarDelegate : NSObjectProtocol {
 
     func handleActionForIdentifier(_ identifier: FormattingIdentifier, barItem: FormatBarItem)
+    func formatBarTouchesBegan(_ formatBar: FormatBar)
 }

--- a/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
@@ -4,5 +4,5 @@ import UIKit
 
 public protocol FormatBarDelegate : NSObjectProtocol {
 
-    func handleActionForIdentifier(_ identifier: FormattingIdentifier)
+    func handleActionForIdentifier(_ identifier: FormattingIdentifier, barItem: FormatBarItem)
 }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -199,13 +199,7 @@ class EditorDemoController: UIViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
-        if optionsViewController != nil {
-            if presentedViewController == optionsViewController {
-                dismiss(animated: true, completion: nil)
-            }
-
-            optionsViewController = nil
-        }
+        dismissOptionsViewControllerIfNecessary()
     }
 
     // MARK: - Title and Title placeholder position methods
@@ -358,6 +352,14 @@ class EditorDemoController: UIViewController {
         editingMode.toggle()
     }
 
+    fileprivate func dismissOptionsViewControllerIfNecessary() {
+        if let optionsViewController = optionsViewController,
+            presentedViewController == optionsViewController {
+            dismiss(animated: true, completion: nil)
+
+            self.optionsViewController = nil
+        }
+    }
 
     // MARK: - Keyboard Handling
 
@@ -381,6 +383,7 @@ class EditorDemoController: UIViewController {
         }
 
         refreshInsets(forKeyboardFrame: keyboardFrame)
+        dismissOptionsViewControllerIfNecessary()
     }
 
     fileprivate func refreshInsets(forKeyboardFrame keyboardFrame: CGRect) {
@@ -494,6 +497,10 @@ extension EditorDemoController {
 // MARK: - Format Bar Delegate
 
 extension EditorDemoController : Aztec.FormatBarDelegate {
+    func formatBarTouchesBegan(_ formatBar: FormatBar) {
+        dismissOptionsViewControllerIfNecessary()
+    }
+
     func handleActionForIdentifier(_ identifier: FormattingIdentifier, barItem: FormatBarItem) {
         switch identifier {
         case .bold:
@@ -609,7 +616,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
         if let optionsViewController = optionsViewController,
             optionsViewController.options == options {
             if presentedViewController != nil {
-                dismiss(animated: true, completion: nil)
+              dismiss(animated: true, completion: nil)
             }
 
             self.optionsViewController = nil

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -641,30 +641,39 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
         }
 
         if UIDevice.current.userInterfaceIdiom == .pad  {
-            optionsViewController.modalPresentationStyle = .popover
-            optionsViewController.popoverPresentationController?.permittedArrowDirections = [.down]
-            optionsViewController.popoverPresentationController?.sourceView = view
-
-            let frame = barItem.superview?.convert(barItem.frame, to: UIScreen.main.coordinateSpace)
-
-            optionsViewController.popoverPresentationController?.sourceRect = view.convert(frame!, from: UIScreen.main.coordinateSpace)
-            optionsViewController.popoverPresentationController?.backgroundColor = .white
-            optionsViewController.popoverPresentationController?.delegate = self
-
-            if presentedViewController != nil {
-                dismiss(animated: true, completion: { 
-                    self.present(self.optionsViewController, animated: true, completion: selectRow)
-                })
-            } else {
-                present(optionsViewController, animated: true, completion: selectRow)
-            }
-
+            presentOptionsViewController(optionsViewController, asPopoverFromBarItem: barItem, completion: selectRow)
         } else {
-            self.addChildViewController(optionsViewController)
-            changeRichTextInputView(to: optionsViewController.view)
-            optionsViewController.didMove(toParentViewController: self)
+            presentOptionsViewControllerAsInputView(optionsViewController)
             selectRow()
         }
+    }
+
+    private func presentOptionsViewController(_ optionsViewController: OptionsTableViewController,
+                                              asPopoverFromBarItem barItem: FormatBarItem,
+                                              completion: (() -> Void)? = nil) {
+        optionsViewController.modalPresentationStyle = .popover
+        optionsViewController.popoverPresentationController?.permittedArrowDirections = [.down]
+        optionsViewController.popoverPresentationController?.sourceView = view
+
+        let frame = barItem.superview?.convert(barItem.frame, to: UIScreen.main.coordinateSpace)
+
+        optionsViewController.popoverPresentationController?.sourceRect = view.convert(frame!, from: UIScreen.main.coordinateSpace)
+        optionsViewController.popoverPresentationController?.backgroundColor = .white
+        optionsViewController.popoverPresentationController?.delegate = self
+
+        if presentedViewController != nil {
+            dismiss(animated: true, completion: {
+                self.present(self.optionsViewController, animated: true, completion: completion)
+            })
+        } else {
+            present(optionsViewController, animated: true, completion: completion)
+        }
+    }
+
+    private func presentOptionsViewControllerAsInputView(_ optionsViewController: OptionsTableViewController) {
+        self.addChildViewController(optionsViewController)
+        changeRichTextInputView(to: optionsViewController.view)
+        optionsViewController.didMove(toParentViewController: self)
     }
 
     func changeRichTextInputView(to: UIView?) {

--- a/Example/Example/OptionsTableView.swift
+++ b/Example/Example/OptionsTableView.swift
@@ -14,6 +14,8 @@ struct OptionsTableViewOption: Equatable {
 }
 
 class OptionsTableViewController: UITableViewController {
+    private static let rowHeight: CGFloat = 44.0
+
     typealias OnSelectHandler = (_ selected: Int) -> Void
 
     var options = [OptionsTableViewOption]()
@@ -36,6 +38,8 @@ class OptionsTableViewController: UITableViewController {
 
         view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         tableView.register(OptionsTableViewCell.self, forCellReuseIdentifier: OptionsTableViewCell.reuseIdentifier)
+
+        preferredContentSize = CGSize(width: 0, height: min(CGFloat(options.count), 7.5) * OptionsTableViewController.rowHeight)
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Follows on from #527. This PR displays the Header and List pickers as popovers on iPad. We're doing it at any size class, because it looks fine even when the view is compact, and even if the app is narrow the keyboard is still full width.

It's not my favourite implementation ever, but I feel like popovers are only a stop gap. I'd prefer to use custom views in the future and not actually 'present' another view controller. Let me know what you think.

To test:

* Run the demo app on iPad, and try using the heading and list menus. They should reflect the current state, and dismiss if you tap away from them or interact with the format bar. 
* They should work correctly no matter what size the app is at, and they should dismiss if you rotate the device.

Needs review: @SergioEstevao or @jleandroperez would one of you mind taking a look?
