### PR TITLE
Call the super method instead of invoking itself to infinity…

### DIFF
--- a/Aztec/Classes/TextKit/ParagraphProperty/Blockquote.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/Blockquote.swift
@@ -3,7 +3,7 @@ import Foundation
 class Blockquote: ParagraphProperty {
 
     public override func encode(with aCoder: NSCoder) {
-        encode(with: aCoder)
+        super.encode(with: aCoder)
     }
 
     override public init(with representation: HTMLElementRepresentation? = nil) {

--- a/Aztec/Classes/TextKit/ParagraphProperty/HTMLParagraph.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/HTMLParagraph.swift
@@ -3,7 +3,7 @@ import Foundation
 class HTMLParagraph: ParagraphProperty {
     
     override public func encode(with aCoder: NSCoder) {
-        encode(with: aCoder)
+        super.encode(with: aCoder)
     }
 
     override public init(with representation: HTMLElementRepresentation? = nil) {

--- a/Aztec/Classes/TextKit/ParagraphProperty/HTMLPre.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/HTMLPre.swift
@@ -3,7 +3,7 @@ import Foundation
 class HTMLPre: ParagraphProperty {
 
     override public func encode(with aCoder: NSCoder) {
-        encode(with: aCoder)
+        super.encode(with: aCoder)
     }
 
     override public init(with representation: HTMLElementRepresentation? = nil) {


### PR DESCRIPTION
This PR fix some ParagraphProperty encoding methods that where recursive instead of calling the super class method

To test:
 - Start de demo app
 - Select all text
 - Tap on copy
 - Check that app doesn't get in infinite loop
