### PR TITLE
FormatBarDelegate: Added overflow toggle state change callback

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -313,6 +313,8 @@ open class FormatBar: UIView {
         rotateOverflowToggleItem(direction, animated: true)
 
         UserDefaults.standard.set(shouldExpand, forKey: Constants.overflowExpandedUserDefaultsKey)
+
+        formatter?.formatBar(self, didChangeOverflowState: (shouldExpand) ? .visible : .hidden)
     }
 
     private func setOverflowItemsVisible(_ visible: Bool, animated: Bool = true) {

--- a/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
@@ -7,7 +7,17 @@ public enum FormatBarOverflowState {
 }
 
 public protocol FormatBarDelegate : NSObjectProtocol {
+    /// Prompts the delegate that the bar item with the specified identifier was tapped,
+    /// and it should take appropriate action.
+    ///
     func handleActionForIdentifier(_ identifier: FormattingIdentifier, barItem: FormatBarItem)
+
+    /// Informs the delegate that a touch down event was received on the format bar.
+    ///
     func formatBarTouchesBegan(_ formatBar: FormatBar)
+
+    /// Called when the overflow items in the format bar are either shown or hidden
+    /// as a result of the user tapping the toggle button.
+    ///
     func formatBar(_ formatBar: FormatBar, didChangeOverflowState overflowState: FormatBarOverflowState)
 }

--- a/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
@@ -1,9 +1,13 @@
 import Foundation
 import UIKit
 
+public enum FormatBarOverflowState {
+    case hidden
+    case visible
+}
 
 public protocol FormatBarDelegate : NSObjectProtocol {
-
     func handleActionForIdentifier(_ identifier: FormattingIdentifier, barItem: FormatBarItem)
     func formatBarTouchesBegan(_ formatBar: FormatBar)
+    func formatBar(_ formatBar: FormatBar, didChangeOverflowState overflowState: FormatBarOverflowState)
 }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -520,6 +520,15 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
         dismissOptionsViewControllerIfNecessary()
     }
 
+    func formatBar(_ formatBar: FormatBar, didChangeOverflowState state: FormatBarOverflowState) {
+        switch state {
+        case .hidden:
+            print("Format bar collapsed")
+        case .visible:
+            print("Format bar expanded")
+        }
+    }
+
     func handleActionForIdentifier(_ identifier: FormattingIdentifier, barItem: FormatBarItem) {
         switch identifier {
         case .bold:


### PR DESCRIPTION
This PR adds a delegate method to the FormatBar to inform of changes to the overflow items visibility.

Required for https://github.com/wordpress-mobile/WordPress-iOS/issues/7408

To test:

* Check the code
* Build and run the demo app and open the editor with sample content
* Ensure a message gets logged to the console when you expand / hide the overflow items in the format bar.

Needs review: @SergioEstevao 