### PR TITLE
FormatBar: Fix overflow toggle orientation on first appearance

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -51,6 +51,10 @@ open class FormatBar: UIView {
 
             let overflowVisible = UserDefaults.standard.bool(forKey: Constants.overflowExpandedUserDefaultsKey)
             setOverflowItemsVisible(overflowVisible, animated: false)
+            
+            if overflowVisible {
+                rotateOverflowToggleItem(.vertical, animated: false)
+            }
 
             let hasOverflowItems = !overflowItems.isEmpty
             overflowToggleItem.isHidden = !hasOverflowItems


### PR DESCRIPTION
This PR fixes a small visual bug when the format bar was shown in an initially expanded state, where the overflow toggle button wasn't being rotated.

To test:

* Run the sample app, open the editor
* Expand the bar, notice the toggle flips to a vertical orientation
* Exit the editor
* Re-open the editor, and scroll to the end of the format bar. The toggle should still be in a vertical orientation. If you tap it, it should rotate to horizontal when the items are hidden.
* (Prior to this PR, when you reopened the editor, the toggle would be in the horizontal position and no animation would take place)

Needs review: @SergioEstevao can I bug you again?