### PR TITLE
FormatBar: A couple of RTL improvements

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -414,15 +414,19 @@ private extension FormatBar {
         scrollView.delegate = self
 
         // Add padding at the end to account for overflow button
-        scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: Constants.stackButtonWidth)
+        let layoutDirection = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute)
+        switch layoutDirection {
+        case .leftToRight:
+            scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: Constants.stackButtonWidth)
+        case .rightToLeft:
+            scrollView.contentInset = UIEdgeInsets(top: 0, left: Constants.stackButtonWidth, bottom: 0, right: 0)
+        }
     }
 
 
     /// Sets up the Constraints
     ///
     func configureConstraints() {
-        let insets = Constants.scrollableStackViewInsets
-
         let overflowTrailingConstraint = overflowToggleItem.trailingAnchor.constraint(equalTo: trailingAnchor)
         overflowTrailingConstraint.priority = UILayoutPriorityDefaultLow
 
@@ -448,8 +452,8 @@ private extension FormatBar {
         ])
 
         NSLayoutConstraint.activate([
-            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: insets.left),
-            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -1 * insets.right),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
             scrollView.topAnchor.constraint(equalTo: topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
@@ -581,8 +585,6 @@ private extension FormatBar {
     struct Constants {
         static let overflowExpandedUserDefaultsKey = "AztecFormatBarOverflowExpandedKey"
         static let fixedSeparatorMidPointPaddingX = CGFloat(5)
-        static let fixedStackViewInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-        static let scrollableStackViewInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         static let stackViewCompactSpacing = CGFloat(0)
         static let stackViewRegularSpacing = CGFloat(0)
         static let stackButtonWidth = CGFloat(44)

--- a/Example/Example/MoreAttachmentRenderer.swift
+++ b/Example/Example/MoreAttachmentRenderer.swift
@@ -30,7 +30,11 @@ extension MoreAttachmentRenderer: TextViewAttachmentImageProvider {
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
 
         let label = attachment.text.uppercased()
-        let attributes = [NSForegroundColorAttributeName: textColor]
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.baseWritingDirection = .leftToRight
+        let attributes: [String: Any] = [NSForegroundColorAttributeName: textColor, NSParagraphStyleAttributeName: paragraphStyle]
+
         let colorMessage = NSAttributedString(string: label, attributes: attributes)
 
         let textRect = colorMessage.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)


### PR DESCRIPTION
This PR makes a few improvements to right-to-left support for the format bar. Previously, the overflow toggle was hidden, so it was impossible to show the extra items in the bar. Now it should be visible and usable:

![formatbar-rtl](https://user-images.githubusercontent.com/4780/27384585-4f83ae3a-5687-11e7-80e8-e433f36551d0.png)

There is still an issue where the items in the bar are left aligned instead of right aligned, but I haven't been able to get to the bottom of that yet. At least, with this PR, the entire bar becomes usable. Hopefully we can address the alignment in a future PR.

Needs review: @jleandroperez 