### PR TITLE
LayoutManager: Wiring the *right* analyzer

### DIFF
--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -94,7 +94,8 @@ private extension LayoutManager {
             // Draw Paragraph Markers
             enumerateLineFragments(forGlyphRange: listGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
                 let location = self.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil).location
-                guard textStorage.string.isStartOfNewLine(at: location) else {
+
+                guard textStorage.string.isStartOfNewLine(atUTF16Offset: location) else {
                     return
                 }
 


### PR DESCRIPTION
Closes #546

### To test:
1. Toggle HTML Mode
2. Write:
```
<ol>
  <li><strong>Revenue:</strong> &#xA0;&#x1F4B0;</li>
  <li><strong>Growth:</strong> &#xA0;&#x1F4C8;</li>
  <li><strong>Engagement:</strong> &#xA0;&#x1F48D;</li>
</ol>
```
3. Switch to Rich
4. Verify the bullets are actually there!

