### PR TITLE
No longer removes non-encoded nbsp; characters from input.

### DIFF
--- a/Aztec/Classes/Extensions/Character+Name.swift
+++ b/Aztec/Classes/Extensions/Character+Name.swift
@@ -4,6 +4,7 @@ import UIKit
 extension Character {
 
     enum Name: Character {
+        case nonBreakingSpace = "\u{00A0}"
         case lineSeparator = "\u{2028}"
         case newline = "\n"
         case objectReplacement = "\u{FFFC}"

--- a/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
@@ -167,7 +167,14 @@ extension Libxml2.In {
             let hasAnEndingSpace = text.hasSuffix(String(.space))
             let hasAStartingSpace = text.hasPrefix(String(.space))
 
-            let trimmedText = text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+            // We cannot use CharacterSet.whitespacesAndNewlines directly, because it includes
+            // U+000A, which is non-breaking space.  We need to maintain it.
+            //
+            let whitespace = CharacterSet.whitespacesAndNewlines
+            let whitespaceToKeep = CharacterSet(charactersIn: String(.nonBreakingSpace))
+            let whitespaceToRemove = whitespace.subtracting(whitespaceToKeep)
+
+            let trimmedText = text.trimmingCharacters(in: whitespaceToRemove)
             var singleSpaceText = trimmedText
             let doubleSpace = "  "
             let singleSpace = " "


### PR DESCRIPTION
Fixes #550 

To test:

- Edit the demo content .html file.
- Add a single line with non-encoded nbsp (`U+00A0`) characters between chunks of text.
- Run the app and load the demo with content.

Please DM me for a sample string, as it seems copying it here makes the string lose its `nbsp`s.