### PR TITLE
LayoutManager: MarkerItem breaks with Emoji Fonts

### DIFF
--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -142,18 +142,16 @@ private extension LayoutManager {
         if let style = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
             indent = style.headIndent
         }
+
         resultAttributes[NSParagraphStyleAttributeName] = markerParagraphStyle(indent: indent)
         resultAttributes.removeValue(forKey: NSUnderlineStyleAttributeName)
         resultAttributes.removeValue(forKey: NSStrikethroughStyleAttributeName)
         resultAttributes.removeValue(forKey: NSLinkAttributeName)
+
         if let font = resultAttributes[NSFontAttributeName] as? UIFont {
-            var traits = font.fontDescriptor.symbolicTraits
-            traits.remove(.traitBold)
-            traits.remove(.traitItalic)
-            let descriptor = font.fontDescriptor.withSymbolicTraits(traits)
-            let newFont = UIFont(descriptor: descriptor!, size: font.pointSize)
-            resultAttributes[NSFontAttributeName] = newFont
+            resultAttributes[NSFontAttributeName] = fixFontForMarkerAttributes(font: font)
         }
+
         return resultAttributes
     }
 
@@ -166,5 +164,24 @@ private extension LayoutManager {
         paragraphStyle.tabStops = [tabStop]
 
         return paragraphStyle
+    }
+
+
+    /// Fixes a UIFont Instance for List Marker Usage:
+    ///
+    /// - Emoji Font is replaced by the System's font, of matching size
+    /// - Bold and Italic styling is neutralized
+    ///
+    private func fixFontForMarkerAttributes(font: UIFont) -> UIFont {
+        guard !font.isAppleEmojiFont else {
+            return UIFont.systemFont(ofSize: font.pointSize)
+        }
+
+        var traits = font.fontDescriptor.symbolicTraits
+        traits.remove(.traitBold)
+        traits.remove(.traitItalic)
+
+        let descriptor = font.fontDescriptor.withSymbolicTraits(traits)
+        return UIFont(descriptor: descriptor!, size: font.pointSize)
     }
 }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -128,8 +128,13 @@ private extension LayoutManager {
         let markerPlain = list.style.markerText(forItemNumber: number)
         let markerText = NSAttributedString(string: markerPlain, attributes: markerAttributes)
 
-        let markerRect = rect.offsetBy(dx: 0, dy: style.paragraphSpacingBefore)
+        var yOffset = -style.paragraphSpacing
 
+        if let font = markerAttributes[NSFontAttributeName] as? UIFont {
+            yOffset += (rect.height - font.lineHeight)
+        }
+
+        let markerRect = rect.offsetBy(dx: 0, dy: yOffset)
         markerText.draw(in: markerRect)
     }
 


### PR DESCRIPTION
Fixes #549

### To test:
1. Enter the following HTML
```
<ol>
  <li>Asdasd &#x1F1E6;&#x1F1E9;</li>
  <li>&#x1F1E6;&#x1F1F4;</li>
  <li>&#x1F1E6;&#x1F1F2;</li>
</ol>
```
2. Switch to Rich Mode
3. Verify everything looks as expected!

cc @diegoreymendez 
Isn't *Obliterating* an awesome word?

