### PR TITLE
Images drawn inside the editor when lists are applied

### DIFF
--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -296,7 +296,7 @@ open class MediaAttachment: NSTextAttachment
         }
 
         let padding = textContainer?.lineFragmentPadding ?? 0
-        let width = lineFrag.width - padding * 2
+        let width = floor((lineFrag.width - position.x ) - ( padding * 2))
 
         let size = CGSize(width: width, height: onScreenHeight(width))
         


### PR DESCRIPTION
Fixes #545 

To test:
 - Start the demo app with empty content
 - Toggle a list
 - Insert an image
 - Check if the image is draw correctly inside the aztec textview

