### PR TITLE
Draw HTML Pre background.

### DIFF
--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -66,6 +66,17 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         }
     }
 
+    var htmlPre: HTMLPre? {
+        let htmlPres = properties.flatMap { (property) -> HTMLPre? in
+            if let htmlPre = property as? HTMLPre {
+                return htmlPre
+            } else {
+                return nil
+            }
+        }
+        return htmlPres.first
+    }
+
     override init() {
         super.init()
     }


### PR DESCRIPTION
This PR draws a background similar to block quote for pre elements.

It copies the style used in Calypso

<img width="355" alt="screen shot 2017-06-21 at 23 16 55" src="https://user-images.githubusercontent.com/651601/27409123-c2ca7ffe-56d7-11e7-90eb-586a85f9d624.png">

To test:
 - Open the demo with content
 - Scroll to the text with the header Pre Formatted code
 - Check if the background is correctly drawn.
