### PR TITLE
Shift + enter no longer breaks paragraphs.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -494,8 +494,8 @@
 				B5B96DAA1E01B2F300791315 /* UIPasteboard+Helpers.swift */,
 				B5C99D3E1E72E2E700335355 /* UIStackView+Helpers.swift */,
 				599F25271D8BC9A1002871D6 /* UITextView+Helpers.swift */,
-				F1A218141E02D5B3000AF5EB /* UndoManager.swift */,
 				F1DE83D41EF20493009269E6 /* UIColor+Parsers.swift */,
+				F1A218141E02D5B3000AF5EB /* UndoManager.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -615,17 +615,17 @@ private extension NSAttributedStringToNodes {
     /// Converts a String into it's representing nodes.
     ///
     func processTextNodes(from text: String) -> [Node] {
-        let substrings = text.components(separatedBy: String(.newline))
+
+        let substrings = text.components(separatedBy: String(.lineSeparator))
         var output = [Node]()
 
-        for substring in substrings {
-            if output.count > 0 {
-                let newline = ElementNode(type: .br)
-                output.append(newline)
-            }
+        for (index, substring) in substrings.enumerated() {
 
-            let node = TextNode(text: substring)
-            output.append(node)
+            output.append(TextNode(text: substring))
+
+            if index < substrings.count - 1 {
+                output.append(ElementNode(type: .br))
+            }
         }
         
         return output

--- a/Aztec/Classes/Extensions/Character+Name.swift
+++ b/Aztec/Classes/Extensions/Character+Name.swift
@@ -4,9 +4,10 @@ import UIKit
 extension Character {
 
     enum Name: Character {
+        case lineFeed = "\u{000A}"
+        case carriageReturn = "\u{000D}"
         case nonBreakingSpace = "\u{00A0}"
         case lineSeparator = "\u{2028}"
-        case newline = "\n"
         case objectReplacement = "\u{FFFC}"
         case paragraphSeparator = "\u{2029}"
         case space = " "

--- a/Aztec/Classes/Extensions/String+EndOfLine.swift
+++ b/Aztec/Classes/Extensions/String+EndOfLine.swift
@@ -46,7 +46,7 @@ extension String {
     ///
     func isEndOfLine() -> Bool {
         return self == String(.lineSeparator)
-            || self == String(.newline)
+            || self == String(.lineFeed)
             || self == String(.paragraphSeparator)
     }
 

--- a/Aztec/Classes/Formatters/Base/ParagraphAttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/Base/ParagraphAttributeFormatter.swift
@@ -32,7 +32,7 @@ extension ParagraphAttributeFormatter {
     func applyAttributes(to text: NSMutableAttributedString, at range: NSRange) -> NSRange {
         let rangeToApply = applicationRange(for: range, in: text)
 
-        text.replaceOcurrences(of: String(.newline), with: String(.paragraphSeparator), within: rangeToApply)
+        text.replaceOcurrences(of: String(.lineFeed), with: String(.paragraphSeparator), within: rangeToApply)
 
         text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, _) in
             let currentAttributes = text.attributes(at: range.location, effectiveRange: nil)
@@ -51,7 +51,7 @@ extension ParagraphAttributeFormatter {
     func removeAttributes(from text: NSMutableAttributedString, at range: NSRange) -> NSRange {
         let rangeToApply = applicationRange(for: range, in: text)
 
-        text.replaceOcurrences(of: String(.paragraphSeparator), with: String(.newline), within: rangeToApply)
+        text.replaceOcurrences(of: String(.paragraphSeparator), with: String(.lineFeed), within: rangeToApply)
 
         text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, stop) in
             let currentAttributes = text.attributes(at: range.location, effectiveRange: nil)

--- a/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
@@ -183,7 +183,7 @@ extension Libxml2.In {
                 singleSpaceText = singleSpaceText.replacingOccurrences(of: doubleSpace, with: singleSpace)
             }
 
-            let noBreaksText = singleSpaceText.replacingOccurrences(of: String(.newline), with: "")
+            let noBreaksText = singleSpaceText.replacingOccurrences(of: String(.lineFeed), with: "")
             let endingSpace = !noBreaksText.isEmpty && hasAnEndingSpace ? String(.space) : ""
             let startingSpace = !noBreaksText.isEmpty && hasAStartingSpace ? String(.space) : ""
             return "\(startingSpace)\(noBreaksText)\(endingSpace)"

--- a/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
@@ -143,14 +143,14 @@ private extension Libxml2.Out.HTMLConverter {
     ///
     private func prefixForTag(at level: Int) -> String {
         let indentation = level > 0 ? String(repeating: String(.space), count: level * indentationSpaces) : ""
-        return String(.newline) + indentation
+        return String(.lineFeed) + indentation
     }
 
 
     /// Returns the Tag Posfix String
     ///
     private func posfixForTag() -> String {
-        return String(.newline)
+        return String(.lineFeed)
     }
 
 

--- a/Aztec/Classes/Libxml2/DOM/Data/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/StandardElementType.swift
@@ -91,7 +91,7 @@ extension Libxml2 {
             case .video:
                 return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
             case .br:
-                return NSAttributedString(.newline, attributes: attributes)
+                return NSAttributedString(.lineSeparator, attributes: attributes)
             case .hr:
                 return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
             default:

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -290,7 +290,10 @@ open class TextView: UITextView {
 
     override open var keyCommands: [UIKeyCommand]? {
         get {
-            return [UIKeyCommand(input: "\r", modifierFlags: .shift , action: #selector(handleShiftEnter(command:)))]
+            // When the keyboard "enter" key is pressed, the keycode corresponds to .carriageReturn,
+            // even if it's later converted to .lineFeed by default.
+            //
+            return [UIKeyCommand(input: String(.carriageReturn), modifierFlags: .shift , action: #selector(handleShiftEnter(command:)))]
         }
     }
 
@@ -803,7 +806,7 @@ open class TextView: UITextView {
     /// Blockquote's background.
     ///
     private func ensureInsertionOfEndOfLine(beforeInserting text: String) {
-        guard text == String(.newline) else {
+        guard text == String(.lineFeed) else {
             return
         }
 
@@ -870,7 +873,7 @@ open class TextView: UITextView {
     /// This method was meant as a workaround for Issue #144.
     ///
     func ensureCursorRedraw(afterEditing text: String) {
-        guard text == String(.newline) else {
+        guard text == String(.lineFeed) else {
             return
         }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -286,6 +286,17 @@ open class TextView: UITextView {
         selectedRange = NSRange(location: selectedRange.location + string.length, length: 0)
     }
 
+    // MARK: - Intercept Keystrokes
+
+    override open var keyCommands: [UIKeyCommand]? {
+        get {
+            return [UIKeyCommand(input: "\r", modifierFlags: .shift , action: #selector(handleShiftEnter(command:)))]
+        }
+    }
+
+    func handleShiftEnter(command: UIKeyCommand) {
+        insertText(String(.lineSeparator))
+    }
 
     // MARK: - Pasteboard Helpers
 

--- a/AztecTests/Converters/NSAttributedStringToNodesTests.swift
+++ b/AztecTests/Converters/NSAttributedStringToNodesTests.swift
@@ -136,7 +136,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
 
         let attributes = TextListFormatter(style: .unordered).apply(to: Constants.sampleAttributes)
 
-        let text = firstText + String(.newline) + secondText
+        let text = firstText + String(.lineFeed) + secondText
         let testingString = NSMutableAttributedString(string: text, attributes: attributes)
 
         // Convert + Verify
@@ -177,7 +177,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
 
         let attributes = TextListFormatter(style: .ordered).apply(to: Constants.sampleAttributes)
 
-        let text = firstText + String(.newline) + secondText
+        let text = firstText + String(.lineFeed) + secondText
         let testingString = NSMutableAttributedString(string: text, attributes: attributes)
 
         // Convert + Verify
@@ -438,7 +438,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
         let firstText = "First Line"
         let secondText = "Second Line"
 
-        let text = firstText + String(.newline) + secondText
+        let text = firstText + String(.lineFeed) + secondText
         let testingString = NSMutableAttributedString(string: text, attributes: Constants.sampleAttributes)
         let testingRange = testingString.rangeOfEntireString
 
@@ -495,7 +495,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
         let firstText = "First Line"
         let secondText = "Second Line"
 
-        let text = firstText + String(.newline) + secondText
+        let text = firstText + String(.lineFeed) + secondText
         let testingString = NSMutableAttributedString(string: text, attributes: Constants.sampleAttributes)
         let testingRange = testingString.rangeOfEntireString
 
@@ -555,7 +555,7 @@ class NSAttributedStringToNodesTests: XCTestCase {
         let firstText = "Hello"
         let secondText = "World"
 
-        let text = firstText + String(.newline) + secondText
+        let text = firstText + String(.lineFeed) + secondText
         let testingString = NSMutableAttributedString(string: text, attributes: Constants.sampleAttributes)
         let testingRange = testingString.rangeOfEntireString
 

--- a/AztecTests/StringEndOfLineTests.swift
+++ b/AztecTests/StringEndOfLineTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class StringEndOfLineTests: XCTestCase {
 
-    private let endOfLineSeparators = [String(.newline), String(.lineSeparator), String(.paragraphSeparator)]
+    private let endOfLineSeparators = [String(.lineFeed), String(.lineSeparator), String(.paragraphSeparator)]
 
     // MARK: - Setup
 

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -560,11 +560,11 @@ class TextViewTests: XCTestCase {
     /// Tests that deleting a newline works by merging the component around it.
     ///
     /// Input:
-    ///     - Initial HTML: "<ol><li>First</li><li>Second</li></ol>Ahoi<br>Arr!"
+    ///     - Initial HTML: "<ol><li>First</li><li>Second</li></ol><ul><li>Third</li><li>Fourth</li></ul>"
     ///     - Deletion range: (loc: 12, len 1)
     ///
     /// Output:
-    ///     - Final HTML: "<ol><li>First</li><li>SecondAhoi</li></ol>Arr!"
+    ///     - Final HTML: "<ol><li>First</li><li>Second</li><li>Third</li></ol><ul><li>Fourth</li></u"
     ///
     func testDeleteNewline6() {
 
@@ -576,29 +576,7 @@ class TextViewTests: XCTestCase {
 
         textView.replace(range, withText: "")
 
-        XCTAssertEqual(textView.getHTML(), "<ol><li>First</li><li>SecondAhoi</li></ol>Arr!")
-    }
-
-    /// Tests that deleting a newline works by merging the component around it.
-    ///
-    /// Input:
-    ///     - Initial HTML: "<ol><li>First</li><li>Second</li></ol><ul><li>Third</li><li>Fourth</li></ul>"
-    ///     - Deletion range: (loc: 12, len 1)
-    ///
-    /// Output:
-    ///     - Final HTML: "<ol><li>First</li><li>Second</li><li>Third</li></ol><ul><li>Fourth</li></u"
-    ///
-    func testDeleteNewline7() {
-
-        let textView = createTextView(withHTML: "<ol><li>First</li><li>Second</li></ol>Ahoi<br>Arr!")
-
-        let rangeStart = textView.position(from: textView.beginningOfDocument, offset: 12)!
-        let rangeEnd = textView.position(from: rangeStart, offset: 1)!
-        let range = textView.textRange(from: rangeStart, to: rangeEnd)!
-
-        textView.replace(range, withText: "")
-
-        XCTAssertEqual(textView.getHTML(), "<ol><li>First</li><li>SecondAhoi</li></ol>Arr!")
+        XCTAssertEqual(textView.getHTML(), "<ol><li>First</li><li>SecondAhoi<br>Arr!</li></ol>")
     }
 
     /// Tests that deleting a newline works at the end of text with paragraph with header before works.

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -793,7 +793,7 @@ class TextViewTests: XCTestCase {
     /// Ref. Scenario Mark III on Issue https://github.com/wordpress-mobile/AztecEditor-iOS/pull/425
     ///
     func testNewLinesAreInsertedAfterEmptyList() {
-        let newline = String(.newline)
+        let newline = String(.lineFeed)
         let textView = createTextView(withHTML: "")
 
         // Toggle List + Move the selection to the EOD
@@ -820,7 +820,7 @@ class TextViewTests: XCTestCase {
     /// Ref. Scenario Mark IV on Issue https://github.com/wordpress-mobile/AztecEditor-iOS/pull/425
     ///
     func testNewLinesGetBulletStyleEvenAfterDeletingEndOfDocumentNewline() {
-        let newline = String(.newline)
+        let newline = String(.lineFeed)
 
         let textView = createTextView(withHTML: "")
 
@@ -875,7 +875,7 @@ class TextViewTests: XCTestCase {
         let textView = createTextView(withHTML: "")
 
         textView.toggleOrderedList(range: .zero)
-        textView.insertText(String(.newline))
+        textView.insertText(String(.lineFeed))
 
         let formatter = TextListFormatter(style: .ordered)
         let attributedText = textView.attributedText!
@@ -920,9 +920,9 @@ class TextViewTests: XCTestCase {
 
         textView.selectedTextRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
         textView.insertText(Constants.sampleText1)
-        textView.insertText(String(.newline))
+        textView.insertText(String(.lineFeed))
 
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.paragraphSeparator) )
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.paragraphSeparator) )
     }
 
     /// Verifies that toggling an Ordered List, when editing an empty document, inserts a Newline.
@@ -957,9 +957,9 @@ class TextViewTests: XCTestCase {
 
         textView.selectedTextRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
         textView.insertText(Constants.sampleText1)
-        textView.insertText(String(.newline))
+        textView.insertText(String(.lineFeed))
 
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.paragraphSeparator))
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.paragraphSeparator))
     }
 
 
@@ -1018,7 +1018,7 @@ class TextViewTests: XCTestCase {
     /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/422
     ///
     func testNewLinesAreInsertedAfterEmptyBlockquote() {
-        let newline = String(.newline)
+        let newline = String(.lineFeed)
         let textView = createTextView(withHTML: "")
 
         textView.toggleBlockquote(range: .zero)
@@ -1043,7 +1043,7 @@ class TextViewTests: XCTestCase {
     /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/422
     ///
     func testNewLinesGetBlockquoteStyleEvenAfterDeletingEndOfDocumentNewline() {
-        let newline = String(.newline)
+        let newline = String(.lineFeed)
 
         let textView = createTextView(withHTML: "")
 
@@ -1096,7 +1096,7 @@ class TextViewTests: XCTestCase {
         let textView = createTextView(withHTML: "")
 
         textView.toggleBlockquote(range: .zero)
-        textView.insertText(String(.newline))
+        textView.insertText(String(.lineFeed))
 
         let formatter = BlockquoteFormatter()
         let attributedText = textView.attributedText!
@@ -1143,9 +1143,9 @@ class TextViewTests: XCTestCase {
 
         textView.selectedTextRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
         textView.insertText(Constants.sampleText1)
-        textView.insertText(String(.newline))
+        textView.insertText(String(.lineFeed))
 
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.paragraphSeparator))
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.paragraphSeparator))
     }
 
 
@@ -1204,7 +1204,7 @@ class TextViewTests: XCTestCase {
     /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/420
     ///
     func testNewLinesAreInsertedAfterEmptyPre() {
-        let newline = String(.newline)
+        let newline = String(.lineFeed)
         let textView = createTextView(withHTML: "")
 
         textView.togglePre(range: .zero)
@@ -1229,7 +1229,7 @@ class TextViewTests: XCTestCase {
     /// Ref. Issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/420
     ///
     func testNewLinesGetPreStyleEvenAfterDeletingEndOfDocumentNewline() {
-        let newline = String(.newline)
+        let newline = String(.lineFeed)
 
         let textView = createTextView(withHTML: "")
 
@@ -1282,7 +1282,7 @@ class TextViewTests: XCTestCase {
         let textView = createTextView(withHTML: "")
 
         textView.togglePre(range: .zero)
-        textView.insertText(String(.newline))
+        textView.insertText(String(.lineFeed))
 
         let formatter = PreFormatter()
         let attributedText = textView.attributedText!
@@ -1329,9 +1329,9 @@ class TextViewTests: XCTestCase {
 
         textView.selectedTextRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
         textView.insertText(Constants.sampleText1)
-        textView.insertText(String(.newline))
+        textView.insertText(String(.lineFeed))
         
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.newline) + String(.paragraphSeparator))
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.paragraphSeparator))
     }
 
     func testInsertVideo() {


### PR DESCRIPTION
Fixes #553 

To test:

* Launch the Demo with data, and make sure the lists look fine.
* Launch the empty Demo, and insert a list.
* Pressing shift + enter should no longer break paragraphs, and produce `<br>` elements in the HTML.
