### PR TITLE
Refactor insertion of Media attachments to use single insert method.

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -244,50 +244,6 @@ open class TextStorage: NSTextStorage {
         return formatter.toggle(in: self, at: applicationRange)
     }
 
-    /// Insert Image Element at the specified range using url as source
-    ///
-    /// - parameter url: the source URL of the image
-    /// - parameter position: the position to insert the image
-    /// - parameter placeHolderImage: an image to display while the image from sourceURL is being prepared
-    ///
-    /// - returns: the attachment object that was created and inserted on the text
-    ///
-    func insertImage(sourceURL url: URL, atPosition position:Int, placeHolderImage: UIImage, identifier: String = UUID().uuidString) -> ImageAttachment {
-        let attachment = ImageAttachment(identifier: identifier)
-        attachment.delegate = self
-        attachment.url = url
-        attachment.image = placeHolderImage
-
-        // Inject the Attachment and Layout
-        let insertionRange = NSMakeRange(position, 0)
-        let attachmentString = NSAttributedString(attachment: attachment)
-        replaceCharacters(in: insertionRange, with: attachmentString)
-
-        return attachment
-    }
-
-    /// Insert Video Element at the specified range using url as source
-    ///
-    /// - parameter sourceURL: the source URL of the video
-    /// - parameter posterURL: an URL pointing to a frame/thumbnail of the video
-    /// - parameter position: the position to insert the image
-    /// - parameter placeHolderImage: an image to display while the image from sourceURL is being prepared
-    ///
-    /// - returns: the attachment object that was created and inserted on the text
-    ///
-    func insertVideo(sourceURL: URL, posterURL: URL?, atPosition position:Int, placeHolderImage: UIImage, identifier: String = UUID().uuidString) -> VideoAttachment {
-        let attachment = VideoAttachment(identifier: identifier, srcURL: sourceURL, posterURL: posterURL)
-        attachment.delegate = self
-        attachment.image = placeHolderImage
-
-        // Inject the Attachment and Layout
-        let insertionRange = NSMakeRange(position, 0)
-        let attachmentString = NSAttributedString(attachment: attachment)
-        replaceCharacters(in: insertionRange, with: attachmentString)
-
-        return attachment
-    }
-
     /// Insert an HR element at the specifice range
     ///
     /// - Parameter range: the range where the element will be inserted

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -926,29 +926,36 @@ open class TextView: UITextView {
 
     // MARK: - Embeds
 
-    /// Inserts an image at the specified index
-    ///
-    /// - Parameters:
-    ///     - image: the image object to be inserted.
-    ///     - sourceURL: The url of the image to be inserted.
-    ///     - position: The character index at which to insert the image.
-    ///
-    /// - Returns: the attachment object that can be used for further calls
-    ///
-    open func insertImage(sourceURL url: URL, atPosition position: Int, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> ImageAttachment {
-
-        let originalText = NSAttributedString(string: "")
-        let finalRange = NSRange(location: position, length: NSAttributedString.lengthOfTextAttachment)
+    func insert(attachment: NSTextAttachment, at range: NSRange) {
+        let originalText = textStorage.attributedSubstring(from: range)
+        let finalRange = NSRange(location: range.location, length: NSAttributedString.lengthOfTextAttachment)
 
         undoManager?.registerUndo(withTarget: self, handler: { [weak self] target in
             self?.undoTextReplacement(of: originalText, finalRange: finalRange)
         })
 
-        let attachment = storage.insertImage(sourceURL: url, atPosition: position, placeHolderImage: placeHolderImage ?? defaultMissingImage, identifier: identifier)
-        let length = NSAttributedString.lengthOfTextAttachment
-        textStorage.addAttributes(typingAttributes, range: NSMakeRange(position, length))
-        selectedRange = NSMakeRange(position+length, 0)
+        storage.replaceCharacters(in: range, with: NSAttributedString(attachment: attachment))
+        selectedRange = NSMakeRange(range.location + NSAttributedString.lengthOfTextAttachment, 0)
         delegate?.textViewDidChange?(self)
+    }
+
+    /// Inserts an image at the specified index
+    ///
+    /// - Parameters:
+    ///     - range: the range where the image will be inserted
+    ///     - sourceURL: The url of the image to be inserted.
+    ///     - placeHolderImage: the image to be used as an placeholder.
+    ///     - identifier: an unique identifier for the image
+    ///
+    /// - Returns: the attachment object that can be used for further calls
+    ///
+    @discardableResult
+    open func insertImage(at range: NSRange, sourceURL url: URL, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> ImageAttachment {
+        let attachment = ImageAttachment(identifier: identifier)
+        attachment.delegate = storage
+        attachment.url = url
+        attachment.image = placeHolderImage
+        insert(attachment: attachment, at: range)
         return attachment
     }
 
@@ -980,7 +987,7 @@ open class TextView: UITextView {
     /// Inserts a Video attachment at the specified index
     ///
     /// - Parameters:
-    ///   - location: the location in the text to insert the video
+    ///   - range: the range in the text to insert the video
     ///   - sourceURL: the video source URL
     ///   - posterURL: the video poster image URL
     ///   - placeHolderImage: an image to use has an placeholder while the video poster is being loaded
@@ -988,19 +995,12 @@ open class TextView: UITextView {
     ///
     /// - Returns: the video attachment object that was inserted.
     ///
-    open func insertVideo(atLocation location: Int, sourceURL: URL, posterURL: URL?, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> VideoAttachment {
-        let originalText = NSAttributedString(string: "")
-        let finalRange = NSRange(location: location, length: NSAttributedString.lengthOfTextAttachment)
-
-        undoManager?.registerUndo(withTarget: self, handler: { [weak self] target in
-            self?.undoTextReplacement(of: originalText, finalRange: finalRange)
-        })
-
-        let attachment = storage.insertVideo(sourceURL: sourceURL, posterURL: posterURL, atPosition: location, placeHolderImage: placeHolderImage ?? defaultMissingImage, identifier: identifier)
-        let length = NSAttributedString.lengthOfTextAttachment
-        textStorage.addAttributes(typingAttributes, range: NSMakeRange(location, length))
-        selectedRange = NSMakeRange(location+length, 0)
-        delegate?.textViewDidChange?(self)
+    @discardableResult
+    open func insertVideo(at range: NSRange, sourceURL: URL, posterURL: URL?, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> VideoAttachment {
+        let attachment = VideoAttachment(identifier: identifier, srcURL: sourceURL, posterURL: posterURL)
+        attachment.delegate = storage
+        attachment.image = placeHolderImage
+        insert(attachment: attachment, at: range)
         return attachment
     }
 

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -91,7 +91,8 @@ class TextStorageTests: XCTestCase
         let storage = TextStorage()
         storage.attachmentsDelegate = mockDelegate
 
-        let attachment = storage.insertImage(sourceURL: URL(string:"test://")!, atPosition: 0, placeHolderImage: UIImage())
+        let attachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"test://")!)
+        storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
 
         storage.replaceCharacters(in: NSRange(location: 0, length: 1) , with: NSAttributedString(string:""))
 
@@ -132,7 +133,8 @@ class TextStorageTests: XCTestCase
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
 
-        let attachment = storage.insertImage(sourceURL: URL(string:"test://")!, atPosition: 0, placeHolderImage: UIImage())
+        let attachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"test://")!)
+        storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
 
         storage.remove(attachmentID: attachment.identifier)
 
@@ -144,7 +146,9 @@ class TextStorageTests: XCTestCase
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
 
-        let attachment = storage.insertImage(sourceURL: URL(string: "https://wordpress.com")!, atPosition: 0, placeHolderImage: UIImage())
+        let attachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"https://wordpress.com")!)
+        storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
+
         let html = storage.getHTML()
 
         XCTAssertEqual(attachment.url, URL(string: "https://wordpress.com"))
@@ -156,7 +160,9 @@ class TextStorageTests: XCTestCase
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
         let url = URL(string: "https://wordpress.com")!
-        let attachment = storage.insertImage(sourceURL: url, atPosition: 0, placeHolderImage: UIImage())
+        let attachment = ImageAttachment(identifier: UUID().uuidString, url: url)
+        storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
+
         storage.update(attachment: attachment, alignment: .left, size: .medium, url: url)
         let html = storage.getHTML()
 
@@ -297,8 +303,12 @@ class TextStorageTests: XCTestCase
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
 
-        let firstAttachment = storage.insertImage(sourceURL: URL(string: "https://wordpress.com")!, atPosition: 0, placeHolderImage: UIImage())
-        let secondAttachment = storage.insertImage(sourceURL: URL(string: "https://wordpress.org")!, atPosition: 1, placeHolderImage: UIImage())
+        let firstAttachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"https://wordpress.com")!)
+        storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: firstAttachment))
+
+        let secondAttachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"https://wordpress.org")!)
+        storage.replaceCharacters(in: NSRange(location:1, length: 0), with: NSAttributedString(attachment: secondAttachment))
+
         let html = storage.getHTML()
 
         XCTAssertEqual(firstAttachment.url, URL(string: "https://wordpress.com"))
@@ -313,8 +323,11 @@ class TextStorageTests: XCTestCase
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
 
-        let firstAttachment = storage.insertImage(sourceURL: URL(string: "https://wordpress.com")!, atPosition: 0, placeHolderImage: UIImage())
-        let secondAttachment = storage.insertImage(sourceURL: URL(string: "https://wordpress.com")!, atPosition: 1, placeHolderImage: UIImage())
+        let firstAttachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"https://wordpress.com")!)
+        storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: firstAttachment))
+
+        let secondAttachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"https://wordpress.com")!)
+        storage.replaceCharacters(in: NSRange(location:1, length: 0), with: NSAttributedString(attachment: secondAttachment))
         let html = storage.getHTML()
 
         XCTAssertEqual(firstAttachment.url, URL(string: "https://wordpress.com"))
@@ -340,7 +353,8 @@ class TextStorageTests: XCTestCase
 
         for _ in 0 ..< count {
             let sourceURL = URL(string:"test://")!
-            let attachment = storage.insertImage(sourceURL: sourceURL, atPosition: 0, placeHolderImage: UIImage())
+            let attachment = ImageAttachment(identifier: UUID().uuidString, url: sourceURL)
+            storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
 
             identifiers.append(attachment.identifier)
         }
@@ -394,7 +408,9 @@ class TextStorageTests: XCTestCase
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
 
-        let _ = storage.insertImage(sourceURL: URL(string: "https://wordpress.com")!, atPosition: 0, placeHolderImage: UIImage())
+        let attachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"https://wordpress.com")!)
+        storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
+
         storage.replaceRangeWithHorizontalRuler(NSRange(location: 0, length:1))
         let html = storage.getHTML()
 

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1358,7 +1358,7 @@ class TextViewTests: XCTestCase {
 
     func testInsertVideo() {
         let textView = createEmptyTextView()
-        let _ = textView.insertVideo(atLocation: 0, sourceURL: URL(string: "video.mp4")!, posterURL: URL(string: "video.jpg"), placeHolderImage: nil)
+        let _ = textView.insertVideo(at: NSRange(location:0, length:0), sourceURL: URL(string: "video.mp4")!, posterURL: URL(string: "video.jpg"), placeHolderImage: nil)
         XCTAssertEqual(textView.getHTML(), "<video src=\"video.mp4\" poster=\"video.jpg\"></video>")
     }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1192,10 +1192,9 @@ private extension EditorDemoController
     
     func insertImage(_ image: UIImage) {
         
-        let index = richTextView.positionForCursor()
         let fileURL = saveToDisk(image: image)
         
-        let attachment = richTextView.insertImage(sourceURL: fileURL, atPosition: index, placeHolderImage: image)
+        let attachment = richTextView.insertImage(at: richTextView.selectedRange, sourceURL: fileURL, placeHolderImage: image)
         let imageID = attachment.identifier
         let progress = Progress(parent: nil, userInfo: [MediaProgressKey.mediaID: imageID])
         progress.totalUnitCount = 100
@@ -1204,9 +1203,6 @@ private extension EditorDemoController
     }
 
     func insertVideo(_ videoURL: URL) {
-
-        let index = richTextView.positionForCursor()
-
         let asset = AVURLAsset(url: videoURL, options: nil)
         let imgGenerator = AVAssetImageGenerator(asset: asset)
         imgGenerator.appliesPreferredTrackTransform = true
@@ -1215,7 +1211,7 @@ private extension EditorDemoController
         }
         let posterImage = UIImage(cgImage: cgImage)
         let posterURL = saveToDisk(image: posterImage)
-        let attachment = richTextView.insertVideo(atLocation: index, sourceURL: URL(string:"placeholder://")!, posterURL: posterURL, placeHolderImage: posterImage)
+        let attachment = richTextView.insertVideo(at: richTextView.selectedRange, sourceURL: URL(string:"placeholder://")!, posterURL: posterURL, placeHolderImage: posterImage)
         let mediaID = attachment.identifier
         let progress = Progress(parent: nil, userInfo: [MediaProgressKey.mediaID: mediaID, MediaProgressKey.videoURL:videoURL])
         progress.totalUnitCount = 100


### PR DESCRIPTION
This PR refactor the code to insert media attachments to a central method. This has the following advantages:

 - central place for insertion code of attachment
 - undo/redo implemented in a single place for attachment
 - notification of changes done in a single place for attachment

Another feature added to match calypso is that you can now select a range of text and press + to replace it with a image or video.

If this is ok  a follow up of this PR could also refactor the following insertions:

 - Horizontal Ruler Attachment
 - More Attachment
 - Comment Attachment
 - Raw HTML Attachment

To test:
 - Make sure the tests are running and passing
 - Start the demo app
 - Insert image and videos on the content
 - Try to insert image or videos by selecting a range first
