### PR TITLE
Fix image drawing on paragraphs with list and/or block quotes

### DIFF
--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -295,8 +295,12 @@ open class MediaAttachment: NSTextAttachment
             return CGRect.zero
         }
 
-        let padding = textContainer?.lineFragmentPadding ?? 0
-        let width = floor((lineFrag.width - position.x ) - ( padding * 2))
+        var padding = (textContainer?.lineFragmentPadding ?? 0)
+        if let storage = textContainer?.layoutManager?.textStorage,
+           let paragraphStyle = storage.attribute(NSParagraphStyleAttributeName, at: charIndex, effectiveRange: nil) as? NSParagraphStyle {
+            padding += paragraphStyle.firstLineHeadIndent + paragraphStyle.tailIndent
+        }
+        let width = floor(lineFrag.width - (padding * 2))
 
         let size = CGSize(width: width, height: onScreenHeight(width))
         


### PR DESCRIPTION
Fixes #545 

To test:
 - Start the empty demo app
 - Insert one image on the content
 - On the same line insert another image
 - Check that both image show up 
 - add a list style
 - Check that both image show up inside the textview bounds
 -  add a block quote style
 - Check that both image show up inside the textview bounds
