### PR TITLE
Refactor attachment insert part 2

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -244,19 +244,7 @@ open class TextStorage: NSTextStorage {
         return formatter.toggle(in: self, at: applicationRange)
     }
 
-    /// Insert an HR element at the specifice range
-    ///
-    /// - Parameter range: the range where the element will be inserted
-    ///
-    func replaceRangeWithHorizontalRuler(_ range: NSRange) {
-        let line = LineAttachment()
-
-        let attachmentString = NSAttributedString(attachment: line)
-        replaceCharacters(in: range, with: attachmentString)        
-    }
-
     // MARK: - Attachments
-
 
     /// Return the attachment, if any, corresponding to the id provided
     ///

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -337,16 +337,16 @@ open class TextStorage: NSTextStorage {
 
     /// Inserts the Comment Attachment at the specified position
     ///
-    @discardableResult
-    open func replaceRangeWithCommentAttachment(_ range: NSRange, text: String, attributes: [String: Any]) -> CommentAttachment {
-        let attachment = CommentAttachment()
-        attachment.text = text
-
-        let stringWithAttachment = NSAttributedString(attachment: attachment, attributes: attributes)
-        replaceCharacters(in: range, with: stringWithAttachment)
-
-        return attachment
-    }
+//    @discardableResult
+//    open func replaceRangeWithCommentAttachment(_ range: NSRange, text: String, attributes: [String: Any]) -> CommentAttachment {
+//        let attachment = CommentAttachment()
+//        attachment.text = text
+//
+//        let stringWithAttachment = NSAttributedString(attachment: attachment, attributes: attributes)
+//        replaceCharacters(in: range, with: stringWithAttachment)
+//
+//        return attachment
+//    }
 
     // MARK: - HTML Interaction
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -323,19 +323,6 @@ open class TextStorage: NSTextStorage {
         }
     }
 
-    /// Inserts the Comment Attachment at the specified position
-    ///
-//    @discardableResult
-//    open func replaceRangeWithCommentAttachment(_ range: NSRange, text: String, attributes: [String: Any]) -> CommentAttachment {
-//        let attachment = CommentAttachment()
-//        attachment.text = text
-//
-//        let stringWithAttachment = NSAttributedString(attachment: attachment, attributes: attributes)
-//        replaceCharacters(in: range, with: stringWithAttachment)
-//
-//        return attachment
-//    }
-
     // MARK: - HTML Interaction
 
     open func getHTML(prettyPrint: Bool = false) -> String {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1220,11 +1220,10 @@ open class TextView: UITextView {
     /// - Returns: the attachment object that can be used for further calls
     ///
     @discardableResult
-    open func replaceRangeWithCommentAttachment(_ range: NSRange, text: String) -> CommentAttachment {
-        let attachment = storage.replaceRangeWithCommentAttachment(range, text: text, attributes: typingAttributes)
-
-        selectedRange = NSMakeRange(range.location + NSAttributedString.lengthOfTextAttachment, 0)
-        delegate?.textViewDidChange?(self)
+    open func insertComment(at range: NSRange, text: String) -> CommentAttachment {
+        let attachment = CommentAttachment()
+        attachment.text = text
+        insert(attachment: attachment, at: range)
 
         return attachment
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -704,19 +704,9 @@ open class TextView: UITextView {
     ///
     /// - Parameter range: the range where the ruler will be inserted
     ///
-    open func replaceRangeWithHorizontalRuler(_ range: NSRange) {
-        let originalText = attributedText.attributedSubstring(from: range)
-        let finalRange = NSRange(location: range.location, length: NSAttributedString.lengthOfTextAttachment)
-
-        undoManager?.registerUndo(withTarget: self, handler: { [weak self] target in
-            self?.undoTextReplacement(of: originalText, finalRange: finalRange)
-        })
-
-        storage.replaceRangeWithHorizontalRuler(range)
-        let length = NSAttributedString.lengthOfTextAttachment
-        textStorage.addAttributes(typingAttributes, range: NSMakeRange(range.location, length))
-        selectedRange = NSMakeRange(range.location + length, 0)
-        delegate?.textViewDidChange?(self)
+    open func insertHorizontalRuler(at range: NSRange) {
+        let line = LineAttachment()
+        insert(attachment: line, at: range)
     }
 
     fileprivate lazy var defaultAttributes: [String: Any] = {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -704,9 +704,9 @@ open class TextView: UITextView {
     ///
     /// - Parameter range: the range where the ruler will be inserted
     ///
-    open func insertHorizontalRuler(at range: NSRange) {
+    open func replaceWithHorizontalRuler(at range: NSRange) {
         let line = LineAttachment()
-        insert(attachment: line, at: range)
+        replace(at: range, with: line)
     }
 
     fileprivate lazy var defaultAttributes: [String: Any] = {
@@ -930,7 +930,7 @@ open class TextView: UITextView {
 
     // MARK: - Embeds
 
-    func insert(attachment: NSTextAttachment, at range: NSRange) {
+    func replace(at range: NSRange, with attachment: NSTextAttachment) {
         let originalText = textStorage.attributedSubstring(from: range)
         let finalRange = NSRange(location: range.location, length: NSAttributedString.lengthOfTextAttachment)
 
@@ -954,12 +954,12 @@ open class TextView: UITextView {
     /// - Returns: the attachment object that can be used for further calls
     ///
     @discardableResult
-    open func insertImage(at range: NSRange, sourceURL url: URL, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> ImageAttachment {
+    open func replaceWithImage(at range: NSRange, sourceURL url: URL, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> ImageAttachment {
         let attachment = ImageAttachment(identifier: identifier)
         attachment.delegate = storage
         attachment.url = url
         attachment.image = placeHolderImage
-        insert(attachment: attachment, at: range)
+        replace(at: range, with: attachment)
         return attachment
     }
 
@@ -1000,11 +1000,11 @@ open class TextView: UITextView {
     /// - Returns: the video attachment object that was inserted.
     ///
     @discardableResult
-    open func insertVideo(at range: NSRange, sourceURL: URL, posterURL: URL?, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> VideoAttachment {
+    open func replaceWithVideo(at range: NSRange, sourceURL: URL, posterURL: URL?, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> VideoAttachment {
         let attachment = VideoAttachment(identifier: identifier, srcURL: sourceURL, posterURL: posterURL)
         attachment.delegate = storage
         attachment.image = placeHolderImage
-        insert(attachment: attachment, at: range)
+        replace(at: range, with: attachment)
         return attachment
     }
 
@@ -1210,10 +1210,10 @@ open class TextView: UITextView {
     /// - Returns: the attachment object that can be used for further calls
     ///
     @discardableResult
-    open func insertComment(at range: NSRange, text: String) -> CommentAttachment {
+    open func replaceWithComment(at range: NSRange, text: String) -> CommentAttachment {
         let attachment = CommentAttachment()
         attachment.text = text
-        insert(attachment: attachment, at: range)
+        replace(at: range, with: attachment)
 
         return attachment
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -700,7 +700,7 @@ open class TextView: UITextView {
         forceRedrawCursorAfterDelay()
     }
 
-    /// Inserts an horizontal ruler on the specified range
+    /// Replaces with an horizontal ruler on the specified range
     ///
     /// - Parameter range: the range where the ruler will be inserted
     ///
@@ -943,7 +943,7 @@ open class TextView: UITextView {
         delegate?.textViewDidChange?(self)
     }
 
-    /// Inserts an image at the specified index
+    /// Replaces with an image attachment at the specified range
     ///
     /// - Parameters:
     ///     - range: the range where the image will be inserted
@@ -988,7 +988,7 @@ open class TextView: UITextView {
         delegate?.textViewDidChange?(self)
     }
 
-    /// Inserts a Video attachment at the specified index
+    /// Replaces a Video attachment at the specified range
     ///
     /// - Parameters:
     ///   - range: the range in the text to insert the video
@@ -1201,7 +1201,7 @@ open class TextView: UITextView {
 
     // MARK: - More
 
-    /// Inserts an HTML Comment at the specified position.
+    /// Replaces with an HTML Comment at the specified range.
     ///
     /// - Parameters:
     ///     - range: The character range that must be replaced with a Comment Attachment.

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -417,41 +417,13 @@ class TextStorageTests: XCTestCase
         XCTAssertEqual(html, "<hr>")
     }
 
-    /// This test check if the insertion of a Comment Attachment works correctly and the expected tag gets inserted
-    ///
-    func testReplaceRangeWithCommentAttachmentGeneratesExpectedHTMLComment() {
-        let storage = TextStorage()
-        let mockDelegate = MockAttachmentsDelegate()
-        storage.attachmentsDelegate = mockDelegate
-
-        storage.replaceRangeWithCommentAttachment(.zero, text: "more", attributes: [:])
-        let html = storage.getHTML()
-
-        XCTAssertEqual(html, "<!--more-->")
-    }
-
-    /// This test check if the insertion of a Comment Attachment works correctly and the expected tag gets inserted
-    ///
-    func testReplaceRangeWithCommentAttachmentDoNotCrashTheEditorWhenCalledSequentially() {
-        let storage = TextStorage()
-        let mockDelegate = MockAttachmentsDelegate()
-        storage.attachmentsDelegate = mockDelegate
-
-        storage.replaceRangeWithCommentAttachment(.zero, text: "more", attributes: [:])
-        storage.replaceRangeWithCommentAttachment(.zero, text: "some other comment should go here", attributes: [:])
-
-        let html = storage.getHTML()
-
-        XCTAssertEqual(html, "<!--some other comment should go here--><!--more-->")
-    }
-
     /// This test verifies if we can delete all the content from a storage object that has html with a comment
     ///
     func testDeleteAllSelectionWhenContentHasComments() {
         let storage = TextStorage()
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
-        
+         
         let commentString = "This is a comment"
         let html = "<!--\(commentString)-->"
         storage.setHTML(html, withDefaultFontDescriptor: UIFont.systemFont(ofSize: 14).fontDescriptor)

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -374,49 +374,6 @@ class TextStorageTests: XCTestCase
         }
     }
 
-    /// This test check if the insertion of an horizontal ruler works correctly and the hr tag is inserted
-    ///
-    func testReplaceRangeWithHorizontalRuler() {
-        let storage = TextStorage()
-        let mockDelegate = MockAttachmentsDelegate()
-        storage.attachmentsDelegate = mockDelegate
-
-        storage.replaceRangeWithHorizontalRuler(.zero)
-        let html = storage.getHTML()
-
-        XCTAssertEqual(html, "<hr>")
-    }
-
-    /// This test check if the insertion of antwo horizontal ruler works correctly and the hr tag(s) are inserted
-    ///
-    func testReplaceRangeWithHorizontalRulerGeneratesExpectedHTMLWhenExecutedSequentially() {
-        let storage = TextStorage()
-        let mockDelegate = MockAttachmentsDelegate()
-        storage.attachmentsDelegate = mockDelegate
-
-        storage.replaceRangeWithHorizontalRuler(.zero)
-        storage.replaceRangeWithHorizontalRuler(.zero)
-        let html = storage.getHTML()
-
-        XCTAssertEqual(html, "<hr><hr>")
-    }
-
-    /// This test check if the insertion of an horizontal ruler over an image attachment works correctly and the hr tag is inserted
-    ///
-    func testReplaceRangeWithHorizontalRulerRulerOverImage() {
-        let storage = TextStorage()
-        let mockDelegate = MockAttachmentsDelegate()
-        storage.attachmentsDelegate = mockDelegate
-
-        let attachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"https://wordpress.com")!)
-        storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
-
-        storage.replaceRangeWithHorizontalRuler(NSRange(location: 0, length:1))
-        let html = storage.getHTML()
-
-        XCTAssertEqual(html, "<hr>")
-    }
-
     /// This test verifies if we can delete all the content from a storage object that has html with a comment
     ///
     func testDeleteAllSelectionWhenContentHasComments() {

--- a/AztecTests/TextViewStubAttachmentDelegate.swift
+++ b/AztecTests/TextViewStubAttachmentDelegate.swift
@@ -2,7 +2,7 @@ import Foundation
 import Aztec
 import Gridicons
 
-class TextViewStubAttachmentDelegate: TextViewAttachmentDelegate {
+class TextViewStubAttachmentDelegate: TextViewAttachmentDelegate, TextViewAttachmentImageProvider {
 
     func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) -> UIImage {
         return placeholderImage(for: attachment)
@@ -40,5 +40,17 @@ class TextViewStubAttachmentDelegate: TextViewAttachmentDelegate {
     }
     
     func textView(_ textView: TextView, deselected attachment: NSTextAttachment, atPosition position: CGPoint) {        
+    }
+
+    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
+        return true
+    }
+
+    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
+        return CGRect.zero
+    }
+
+    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
+        return nil
     }
 }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1337,7 +1337,7 @@ class TextViewTests: XCTestCase {
 
     func testInsertVideo() {
         let textView = createEmptyTextView()
-        let _ = textView.insertVideo(at: NSRange(location:0, length:0), sourceURL: URL(string: "video.mp4")!, posterURL: URL(string: "video.jpg"), placeHolderImage: nil)
+        let _ = textView.replaceWithVideo(at: NSRange(location:0, length:0), sourceURL: URL(string: "video.mp4")!, posterURL: URL(string: "video.jpg"), placeHolderImage: nil)
         XCTAssertEqual(textView.getHTML(), "<video src=\"video.mp4\" poster=\"video.jpg\"></video>")
     }
 
@@ -1372,7 +1372,7 @@ class TextViewTests: XCTestCase {
     func testInsertComment() {
         let textView = createEmptyTextView()
 
-        textView.insertComment(at: .zero, text: "more")
+        textView.replaceWithComment(at: .zero, text: "more")
         let html = textView.getHTML()
 
         XCTAssertEqual(html, "<!--more-->")
@@ -1382,8 +1382,8 @@ class TextViewTests: XCTestCase {
     ///
     func testInsertCommentAttachmentDoNotCrashTheEditorWhenCalledSequentially() {
         let textView = createEmptyTextView()
-        textView.insertComment(at: .zero, text: "more")
-        textView.insertComment(at: .zero, text: "some other comment should go here")
+        textView.replaceWithComment(at: .zero, text: "more")
+        textView.replaceWithComment(at: .zero, text: "some other comment should go here")
 
         let html = textView.getHTML()
 
@@ -1395,7 +1395,7 @@ class TextViewTests: XCTestCase {
     func testReplaceRangeWithHorizontalRuler() {
         let textView = createEmptyTextView()
 
-        textView.insertHorizontalRuler(at: .zero)
+        textView.replaceWithHorizontalRuler(at: .zero)
         let html = textView.getHTML()
 
         XCTAssertEqual(html, "<hr>")
@@ -1406,8 +1406,8 @@ class TextViewTests: XCTestCase {
     func testReplaceRangeWithHorizontalRulerGeneratesExpectedHTMLWhenExecutedSequentially() {
         let textView = createEmptyTextView()
 
-        textView.insertHorizontalRuler(at: .zero)
-        textView.insertHorizontalRuler(at: .zero)
+        textView.replaceWithHorizontalRuler(at: .zero)
+        textView.replaceWithHorizontalRuler(at: .zero)
         let html = textView.getHTML()
 
         XCTAssertEqual(html, "<hr><hr>")
@@ -1418,8 +1418,8 @@ class TextViewTests: XCTestCase {
     func testReplaceRangeWithHorizontalRulerRulerOverImage() {
         let textView = createEmptyTextView()
 
-        textView.insertImage(at: .zero, sourceURL: URL(string:"https://wordpress.com")!, placeHolderImage: nil)
-        textView.insertHorizontalRuler(at: NSRange(location: 0, length:1))
+        textView.replaceWithImage(at: .zero, sourceURL: URL(string:"https://wordpress.com")!, placeHolderImage: nil)
+        textView.replaceWithHorizontalRuler(at: NSRange(location: 0, length:1))
 
         let html = textView.getHTML()
         

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1390,4 +1390,41 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(html, "<!--some other comment should go here--><!--more-->")
     }
 
+    /// This test check if the insertion of an horizontal ruler works correctly and the hr tag is inserted
+    ///
+    func testReplaceRangeWithHorizontalRuler() {
+        let textView = createEmptyTextView()
+
+        textView.insertHorizontalRuler(at: .zero)
+        let html = textView.getHTML()
+
+        XCTAssertEqual(html, "<hr>")
+    }
+
+    /// This test check if the insertion of antwo horizontal ruler works correctly and the hr tag(s) are inserted
+    ///
+    func testReplaceRangeWithHorizontalRulerGeneratesExpectedHTMLWhenExecutedSequentially() {
+        let textView = createEmptyTextView()
+
+        textView.insertHorizontalRuler(at: .zero)
+        textView.insertHorizontalRuler(at: .zero)
+        let html = textView.getHTML()
+
+        XCTAssertEqual(html, "<hr><hr>")
+    }
+
+    /// This test check if the insertion of an horizontal ruler over an image attachment works correctly and the hr tag is inserted
+    ///
+    func testReplaceRangeWithHorizontalRulerRulerOverImage() {
+        let textView = createEmptyTextView()
+
+        textView.insertImage(at: .zero, sourceURL: URL(string:"https://wordpress.com")!, placeHolderImage: nil)
+        textView.insertHorizontalRuler(at: NSRange(location: 0, length:1))
+
+        let html = textView.getHTML()
+        
+        XCTAssertEqual(html, "<hr>")
+    }
+
+
 }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -27,6 +27,7 @@ class TextViewTests: XCTestCase {
     func createEmptyTextView() -> Aztec.TextView {
         let richTextView = Aztec.TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: Gridicon.iconOfType(.attachment))
         richTextView.textAttachmentDelegate = attachmentDelegate
+        richTextView.registerAttachmentImageProvider(attachmentDelegate)
         return richTextView
     }
 
@@ -1364,6 +1365,29 @@ class TextViewTests: XCTestCase {
         attachment.namedAttributes["data-wpvideopress"] = "ABCDE"
 
         XCTAssertEqual(textView.getHTML(), "<video src=\"newVideo.mp4\" poster=\"video.jpg\" data-wpvideopress=\"ABCDE\"></video>")
+    }
+
+    /// This test check if the insertion of a Comment Attachment works correctly and the expected tag gets inserted
+    ///
+    func testInsertComment() {
+        let textView = createEmptyTextView()
+
+        textView.insertComment(at: .zero, text: "more")
+        let html = textView.getHTML()
+
+        XCTAssertEqual(html, "<!--more-->")
+    }
+
+    /// This test check if the insertion of a Comment Attachment works correctly and the expected tag gets inserted
+    ///
+    func testInsertCommentAttachmentDoNotCrashTheEditorWhenCalledSequentially() {
+        let textView = createEmptyTextView()
+        textView.insertComment(at: .zero, text: "more")
+        textView.insertComment(at: .zero, text: "some other comment should go here")
+
+        let html = textView.getHTML()
+
+        XCTAssertEqual(html, "<!--some other comment should go here--><!--more-->")
     }
 
 }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -584,7 +584,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
     }
 
     func insertHorizontalRuler() {
-        richTextView.replaceRangeWithHorizontalRuler(richTextView.selectedRange)
+        richTextView.insertHorizontalRuler(at: richTextView.selectedRange)
     }
 
     func toggleHeader(fromItem item: FormatBarItem) {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -771,7 +771,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
     }
 
     func insertMoreAttachment() {
-        richTextView.replaceRangeWithCommentAttachment(richTextView.selectedRange, text: Constants.moreAttachmentText)
+        richTextView.insertComment(at: richTextView.selectedRange, text: Constants.moreAttachmentText)
     }
 
     func showLinkDialog(forURL url: URL?, title: String?, range: NSRange) {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -584,7 +584,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
     }
 
     func insertHorizontalRuler() {
-        richTextView.insertHorizontalRuler(at: richTextView.selectedRange)
+        richTextView.replaceWithHorizontalRuler(at: richTextView.selectedRange)
     }
 
     func toggleHeader(fromItem item: FormatBarItem) {
@@ -771,7 +771,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
     }
 
     func insertMoreAttachment() {
-        richTextView.insertComment(at: richTextView.selectedRange, text: Constants.moreAttachmentText)
+        richTextView.replaceWithComment(at: richTextView.selectedRange, text: Constants.moreAttachmentText)
     }
 
     func showLinkDialog(forURL url: URL?, title: String?, range: NSRange) {
@@ -1194,7 +1194,7 @@ private extension EditorDemoController
         
         let fileURL = saveToDisk(image: image)
         
-        let attachment = richTextView.insertImage(at: richTextView.selectedRange, sourceURL: fileURL, placeHolderImage: image)
+        let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange, sourceURL: fileURL, placeHolderImage: image)
         let imageID = attachment.identifier
         let progress = Progress(parent: nil, userInfo: [MediaProgressKey.mediaID: imageID])
         progress.totalUnitCount = 100
@@ -1211,7 +1211,7 @@ private extension EditorDemoController
         }
         let posterImage = UIImage(cgImage: cgImage)
         let posterURL = saveToDisk(image: posterImage)
-        let attachment = richTextView.insertVideo(at: richTextView.selectedRange, sourceURL: URL(string:"placeholder://")!, posterURL: posterURL, placeHolderImage: posterImage)
+        let attachment = richTextView.replaceWithVideo(at: richTextView.selectedRange, sourceURL: URL(string:"placeholder://")!, posterURL: posterURL, placeHolderImage: posterImage)
         let mediaID = attachment.identifier
         let progress = Progress(parent: nil, userInfo: [MediaProgressKey.mediaID: mediaID, MediaProgressKey.videoURL:videoURL])
         progress.totalUnitCount = 100


### PR DESCRIPTION
Refs: #317 

This continues the refactor of attachment methods on TextView to make them use a single method.
This make it easier to control undo/redo and delegate callbacks.

To test:
 - Make sure unit tests are running ok
 - On the demo app try to insert comment/more and horizontal ruler
 - Undo redo those actions.

