### PR TITLE
Obliterating Fragmentation: Mark I + II

### DIFF
--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -61,11 +61,11 @@ class NSAttributedStringToNodes: Converter {
     /// - Returns: Array of Node instances.
     ///
     private func createNodes(fromParagraph paragraph: NSAttributedString) -> [Node] {
-        var children = [Node]()
-
         guard paragraph.length > 0 else {
             return []
         }
+
+        var children = [Node]()
 
         paragraph.enumerateAttributes(in: paragraph.rangeOfEntireString, options: []) { (attrs, range, _) in
 

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -73,18 +73,19 @@ class NSAttributedStringToNodes: Converter {
             let leafNodes = createLeafNodes(from: substring)
             let styleNodes = createStyleNodes(from: attrs)
 
-            let subtree = generateTree(nodes: styleNodes, leaves: leafNodes)
+            let subtree = reduce(nodes: styleNodes, leaves: leafNodes)
             children.append(contentsOf: subtree)
         }
 
         let paragraphNodes = createParagraphNodes(from: paragraph)
-        return generateTree(nodes: paragraphNodes, leaves: children)
+        return reduce(nodes: paragraphNodes, leaves: children)
     }
 
 
+    /// Sets Up a collection of Nodes and Leaves as a chain of Parent-Children, and returns the root node.and
+    /// If the collection of nodes is empty, will return the leaves parameters 'as is'.
     ///
-    ///
-    private func generateTree(nodes: [ElementNode], leaves: [Node]) -> [Node] {
+    private func reduce(nodes: [ElementNode], leaves: [Node]) -> [Node] {
         return nodes.reduce(leaves) { (result, node) in
             node.children = result
             return [node]

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -108,6 +108,29 @@ private extension NSAttributedStringToNodes {
             return [node]
         }
     }
+
+
+    /// Finds the Deepest node that can be merged "Right to Left", and returns the Left / Right matching touple, if any.
+    ///
+    func findMergeableNodes(left: [ElementNode], right: [ElementNode], blocklevelEnforced: Bool = true) -> [MergeablePair]? {
+        var currentIndex = 0
+        var matching = [MergeablePair]()
+
+        while currentIndex < left.count && currentIndex < right.count {
+            let left = left[currentIndex]
+            let right = right[currentIndex]
+
+            guard left.canMergeChildren(of: right, blocklevelEnforced: blocklevelEnforced) else {
+                break
+            }
+
+            let pair = MergeablePair(left: left, right: right)
+            matching.append(pair)
+            currentIndex += 1
+        }
+
+        return matching.isEmpty ? nil : matching
+    }
 }
 
 
@@ -161,7 +184,7 @@ private extension NSAttributedStringToNodes {
     ///
     ///
     private func merge(left: Branch, right: Branch) -> Branch? {
-        guard let mergeableCandidate = findMergeableNodes(left: left.nodes, right: right.nodes),
+        guard let mergeableCandidate = findMergeableNodes(left: left.nodes, right: right.nodes, blocklevelEnforced: false),
             let target = mergeableCandidate.last?.left
         else {
             return nil
@@ -207,8 +230,6 @@ private extension NSAttributedStringToNodes {
             output.append(updated)
             previous = consolidated
         }
-
-        NSLog("Sorted:\n\(output)")
 
         return output
     }
@@ -266,29 +287,6 @@ private extension NSAttributedStringToNodes {
         }
 
         return length
-    }
-
-
-    /// Finds the Deepest node that can be merged "Right to Left", and returns the Left / Right matching touple, if any.
-    ///
-    private func findMergeableNodes(left: [ElementNode], right: [ElementNode]) -> [MergeablePair]? {
-        var currentIndex = 0
-        var matching = [MergeablePair]()
-
-        while currentIndex < left.count && currentIndex < right.count {
-            let left = left[currentIndex]
-            let right = right[currentIndex]
-
-            guard left == right else {
-                break
-            }
-
-            let pair = MergeablePair(left: left, right: right)
-            matching.append(pair)
-            currentIndex += 1
-        }
-
-        return matching.isEmpty ? nil : matching
     }
 }
 
@@ -359,29 +357,6 @@ private extension NSAttributedStringToNodes {
         }
 
         return nodes[0..<sliceIndex]
-    }
-
-
-    /// Finds the Deepest node that can be merged "Right to Left", and returns the Left / Right matching touple, if any.
-    ///
-    private func findMergeableNodes(left: [ElementNode], right: [ElementNode]) -> [MergeablePair]? {
-        var currentIndex = 0
-        var matching = [MergeablePair]()
-
-        while currentIndex < left.count && currentIndex < right.count {
-            let left = left[currentIndex]
-            let right = right[currentIndex]
-
-            guard left.canMergeChildren(of: right) else {
-                break
-            }
-
-            let pair = MergeablePair(left: left, right: right)
-            matching.append(pair)
-            currentIndex += 1
-        }
-
-        return matching.isEmpty ? nil : matching
     }
 }
 

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -266,6 +266,9 @@ private extension NSAttributedStringToNodes {
             case let paragraph as HTMLParagraph:
                 paragraphNodes += processParagraphStyle(paragraph: paragraph)
 
+            case let pre as HTMLPre:
+                paragraphNodes += processPreStyle(pre: pre)
+
             default:
                 continue
             }
@@ -311,6 +314,14 @@ private extension NSAttributedStringToNodes {
     ///
     private func processParagraphStyle(paragraph: HTMLParagraph) -> [ElementNode] {
         let node = paragraph.representation?.toNode() ?? ElementNode(type: .p)
+        return [node]
+    }
+
+
+    ///
+    ///
+    private func processPreStyle(pre: HTMLPre) -> [ElementNode] {
+        let node = pre.representation?.toNode() ?? ElementNode(type: .pre)
         return [node]
     }
 }
@@ -545,7 +556,6 @@ private extension NSAttributedStringToNodes {
     /// Converts a String into it's representing nodes.
     ///
     private func processTextNodes(from text: String) -> [Node] {
-
         let substrings = text.components(separatedBy: String(.lineSeparator))
         var output = [Node]()
 
@@ -590,6 +600,7 @@ private extension NSAttributedStringToNodes {
         guard let source = attachment.url?.absoluteString else {
             return nil
         }
+
         return StringAttribute(name: "src", value: source)
     }
 

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -89,7 +89,7 @@ class NSAttributedStringToNodes: Converter {
 //
 private extension NSAttributedStringToNodes {
 
-    ///
+    /// Defines a Tree Branch: Collection of Nodes, with a set of Leaves
     ///
     typealias Branch = (nodes: [ElementNode], leaves: [Node])
 
@@ -208,7 +208,10 @@ private extension NSAttributedStringToNodes {
     }
 
 
+    /// Arranges a collection of Branches in a (Hopefully) "Defragmented" way:
     ///
+    /// - Nodes will be sorted 'By Length'. Longer nodes will appear on top
+    /// - Nodes that existed in the previous branch are expected to maintain the exact same position
     ///
     private func sort(branches: [Branch]) -> [Branch] {
         var output = [Branch]()
@@ -235,7 +238,11 @@ private extension NSAttributedStringToNodes {
     }
 
 
+    /// Splits a collection of Nodes in two groups: 'Nodes that also exist in a Reference Collection', and
+    /// 'Completely New Nodes'. 
     ///
+    /// *Note*: The order of those Pre Existing nodes will be arranged in the exact same way as they appear
+    /// in the reference collection.
     ///
     private func splitDuplicateNodes(in current: [ElementNode], comparingWith previous: [ElementNode]) -> ([ElementNode], [ElementNode]) {
         var duplicates = [ElementNode]()
@@ -258,7 +265,7 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Determines the length of (ALL) of the Nodes at a specified Column, given a collection of Branches.
     ///
     private func lengthOfElements(atColumnIndex index: Int, in branches: [Branch]) -> [ElementNode: Int] {
         var lengths = [ElementNode: Int]()
@@ -273,7 +280,7 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Determines the length of a Node, given a collection of branches.
     ///
     private func length(of element: ElementNode, in branches: [Branch]) -> Int {
         var length = 0
@@ -742,7 +749,7 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Extracts the Video Source Attribute from a VideoAttachment Instance.
     ///
     private func videoSourceAttribute(from attachment: VideoAttachment) -> StringAttribute? {
         guard let source = attachment.srcURL?.absoluteString else {
@@ -753,7 +760,7 @@ private extension NSAttributedStringToNodes {
     }
 
 
-    ///
+    /// Extracts the Video Poster Attribute from a VideoAttachment Instance.
     ///
     private func videoPosterAttribute(from attachment: VideoAttachment) -> StringAttribute? {
         guard let poster = attachment.posterURL?.absoluteString else {

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -131,29 +131,6 @@ private extension NSAttributedStringToNodes {
 
         return matching.isEmpty ? nil : matching
     }
-
-
-    /// Debug Helper. Disregard!
-    ///
-    func print(node: Node, indentation: String = "") {
-        NSLog(indentation + "Node \(node.name) \(ObjectIdentifier(node))")
-
-        switch node {
-        case let text as TextNode:
-            NSLog(indentation + "Text.Content \(text.contents)")
-
-        case let element as ElementNode:
-            NSLog(indentation + "Element.Children:")
-
-            let deeperIndentation = indentation + String(.space) + String(.space)
-            for child in element.children {
-                print(node: child, indentation: deeperIndentation)
-            }
-
-        default:
-            break
-        }
-    }
 }
 
 
@@ -161,10 +138,10 @@ private extension NSAttributedStringToNodes {
 //
 private extension NSAttributedStringToNodes {
 
-    /// Given a collection of branches, this helper will iterate branch by branch and will:
+    /// Given a collection of branches, this method will iterate branch by branch and will:
     ///
     /// A. Reduce the Nodes: An actuall Parent/Child relationship will be set
-    /// B. Attempt to merge the current Branch with the Left-most-branch
+    /// B. Attempt to merge the current Branch with the Previous Branch
     /// C. Return the collection of Reduced + Merged Nodes
     ///
     func process(branches: [Branch]) -> [Node] {
@@ -173,8 +150,8 @@ private extension NSAttributedStringToNodes {
         var previous: Branch?
 
         for branch in sorted {
-            if let left = previous , let something = merge(left: left, right: branch) {
-                previous = something
+            if let left = previous , let current = merge(left: left, right: branch) {
+                previous = current
                 continue
             }
 
@@ -225,8 +202,6 @@ private extension NSAttributedStringToNodes {
         var previous = [ElementNode]()
 
         for (index, branch) in branches.enumerated() {
-
-            // Calculate Lengths
             let lengths = lengthOfElements(atColumnIndex: index, in: branches)
 
             // Split Duplicates: Nodes that existed in the previous collection (while retaining their original position!)
@@ -235,7 +210,6 @@ private extension NSAttributedStringToNodes {
             // Sort 'Branch New Items' + Consolidate
             let consolidated = sorted + unsorted.sorted(by: { lengths[$0]! > lengths[$1]! })
 
-            // New Branch
             let updated = Branch(nodes: consolidated, leaves: branch.leaves)
             output.append(updated)
             previous = consolidated

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -42,6 +42,17 @@ extension Libxml2 {
                 return Mirror(self, children: ["type": "element", "name": name, "parent": parent.debugDescription, "attributes": attributes, "children": children], ancestorRepresentation: .suppressed)
             }
         }
+
+        // MARK - Hashable
+
+        override public var hashValue: Int {
+            let attributesHash = attributes.reduce(0) { (result, attribute) in
+                return result ^ attribute.hashValue
+            }
+
+            return name.hashValue ^ attributesHash
+        }
+
         
         // MARK: - Initializers
 

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -10,7 +10,7 @@ extension Libxml2 {
         var attributes = [Attribute]()
         var children: [Node] {
             didSet {
-                for child in children where child.parent != self {
+                for child in children where child.parent !== self {
                     child.parent?.remove(child)
                     child.parent = self
                 }

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -27,7 +27,8 @@ extension Libxml2 {
         }
 
         private static let knownElements: [StandardElementType] = [.a, .b, .br, .blockquote, .del, .div, .em, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .i, .img, .li, .ol, .p, .pre, .s, .span, .strike, .strong, .u, .ul, .video]
-        private static let mergeableElements: [StandardElementType] = [.p, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .ol, .ul, .li, .blockquote]
+        private static let mergeableBlocklevelElements: [StandardElementType] = [.p, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .ol, .ul, .li, .blockquote]
+        private static let mergeableStyleElements: [StandardElementType] = [.i, .em, .b, .strong, .strike, .u]
 
         internal var standardName: StandardElementType? {
             get {
@@ -228,7 +229,11 @@ extension Libxml2 {
                 return false
             }
 
-            return blocklevelEnforced == false || ElementNode.mergeableElements.contains(standardName)
+            guard blocklevelEnforced else {
+                return ElementNode.mergeableStyleElements.contains(standardName)
+            }
+
+            return ElementNode.mergeableBlocklevelElements.contains(standardName)
         }
 
 

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -219,7 +219,7 @@ extension Libxml2 {
         ///
         /// - Returns: true if both nodes can be merged, or not.
         ///
-        func canMergeChildren(of node: ElementNode) -> Bool {
+        func canMergeChildren(of node: ElementNode, blocklevelEnforced: Bool) -> Bool {
             guard name == node.name && Set(attributes) == Set(node.attributes) else {
                 return false
             }
@@ -228,7 +228,7 @@ extension Libxml2 {
                 return false
             }
 
-            return ElementNode.mergeableElements.contains(standardName)
+            return blocklevelEnforced == false || ElementNode.mergeableElements.contains(standardName)
         }
 
 

--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -46,7 +46,7 @@ extension Libxml2 {
         // MARK: - DOM Queries
 
         func isLastIn(blockLevelElement element: ElementNode) -> Bool {
-            return element.isBlockLevelElement() && element.children.last == self
+            return element.isBlockLevelElement() && element.children.last === self
         }
 
         /// Checks if the receiver is the last node in its parent.
@@ -115,7 +115,7 @@ extension Libxml2 {
                 return false
             }
 
-            return parent.children.last == self
+            return parent.children.last === self
                 && (parent.isBlockLevelElement()
                     || parent.hasRightBlockLevelSibling()
                     || parent.isLastInAncestorEndingInBlockLevelSeparation())

--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -4,7 +4,7 @@ extension Libxml2 {
 
     /// Base class for all node types.
     ///
-    class Node: Equatable, CustomReflectable {
+    class Node: Equatable, CustomReflectable, Hashable {
         
         let name: String
         
@@ -29,7 +29,14 @@ extension Libxml2 {
                 return Mirror(self, children: ["name": name, "parent": parent as Any])
             }
         }
-        
+
+
+        // MARK - Hashable
+
+        public var hashValue: Int {
+            return name.hashValue
+        }
+
         // MARK: - Initializers
 
         init(name: String) {

--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -149,5 +149,5 @@ extension Libxml2 {
 // MARK: - Node Equatable
 
 func ==(lhs: Libxml2.Node, rhs: Libxml2.Node) -> Bool {
-    return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+    return lhs.name == rhs.name
 }

--- a/AztecTests/Converters/NSAttributedStringToNodesTests.swift
+++ b/AztecTests/Converters/NSAttributedStringToNodesTests.swift
@@ -676,6 +676,34 @@ class NSAttributedStringToNodesTests: XCTestCase {
             }
         }
     }
+
+
+    /// Verifies that the Pre Element is effectively converted into an ElementNode.
+    ///
+    /// - Input: <pre>Ehlo World!</pre>
+    ///
+    /// - Output: The same!!
+    ///
+    func testPreIsEffectivelySerializedIntoPreElement() {
+        let text = "Ehlo World!"
+        let testingString = NSMutableAttributedString(string: text)
+
+        let range = testingString.rangeOfEntireString
+
+        let formatter = PreFormatter()
+        formatter.applyAttributes(to: testingString, at: range)
+
+        // Convert + Verify
+        let node = rootNode(from: testingString)
+        XCTAssert(node.children.count == 1)
+
+        let restoredSpanNode = node.children.first as? ElementNode
+        XCTAssert(restoredSpanNode?.name == "pre")
+        XCTAssert(restoredSpanNode?.children.count == 1)
+
+        let restoredTextNode = restoredSpanNode?.children.first as? TextNode
+        XCTAssert(restoredTextNode?.contents == text)
+    }
 }
 
 


### PR DESCRIPTION
### Details:
This PR also contains the changes introduced in #560:

- NSAttributedStringToNodes Internal API has been updated, so that Elements are first extracted, and Branches assembled 'by hand'
- Sort + Merge algorithm has been implemented, so that we minimize fragmentation (Left to Right analysis).
- Plus: Since i was around, added support to serialize Pre elements (+ Unit Tests!!)

### Testing:
1. Run the unit tests
2. Run a smoke test over the Out Converter
3. Add a `Pre` element, verify it gets serialized properly
4. Try snippets that should generate fragmentation. Few samples below!

```
<u><b>Bold</b>Underlined<i>Italics</i></u>
```

```
<u><i>1</i></u>
<u><b><i>2</i></b></u>
<u><b>3</b></u>
<u><b>4</b></u>
```

cc @diegoreymendez 
