### PR TITLE
Make sure attributes are applied to attachment insertions/replacements.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -938,8 +938,7 @@ open class TextView: UITextView {
         undoManager?.registerUndo(withTarget: self, handler: { [weak self] target in
             self?.undoTextReplacement(of: originalText, finalRange: finalRange)
         })
-        let attachmentString = NSMutableAttributedString(attributedString: NSAttributedString(attachment: attachment))
-        attachmentString.addAttributes(typingAttributes, range: NSRange(location:0, length: NSAttributedString.lengthOfTextAttachment))
+        let attachmentString = NSAttributedString(attachment: attachment, attributes: typingAttributes)        
         storage.replaceCharacters(in: range, with: attachmentString)
         selectedRange = NSMakeRange(range.location + NSAttributedString.lengthOfTextAttachment, 0)
         delegate?.textViewDidChange?(self)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -938,8 +938,9 @@ open class TextView: UITextView {
         undoManager?.registerUndo(withTarget: self, handler: { [weak self] target in
             self?.undoTextReplacement(of: originalText, finalRange: finalRange)
         })
-
-        storage.replaceCharacters(in: range, with: NSAttributedString(attachment: attachment))
+        let attachmentString = NSMutableAttributedString(attributedString: NSAttributedString(attachment: attachment))
+        attachmentString.addAttributes(typingAttributes, range: NSRange(location:0, length: NSAttributedString.lengthOfTextAttachment))
+        storage.replaceCharacters(in: range, with: attachmentString)
         selectedRange = NSMakeRange(range.location + NSAttributedString.lengthOfTextAttachment, 0)
         delegate?.textViewDidChange?(self)
     }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1426,5 +1426,20 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(html, "<hr>")
     }
 
+    func testReplaceRangeWithAttachmentDontDisableDefaultParagraph() {
+        let textView = createEmptyTextView()
 
+        textView.replaceWithImage(at: .zero, sourceURL: URL(string:"https://wordpress.com")!, placeHolderImage: nil)
+
+        let html = textView.getHTML()
+
+        XCTAssertEqual(html, "<img src=\"https://wordpress.com\">")
+
+        textView.selectedRange = NSRange(location: NSAttributedString.lengthOfTextAttachment, length: 1)
+        guard let font = textView.typingAttributes[NSFontAttributeName] as? UIFont else {
+            XCTFail("Font should be set")
+            return
+        }
+        XCTAssertEqual(font, textView.defaultFont)
+    }
 }


### PR DESCRIPTION
Refs #485 

This PR makes sure the typing attributes are applied when inserting attachments (media, more, hr) to the content.

To test:
 - Start the demo app
 - Insert a image on the start of the content
 - Write just after image and see if the text has the correct style.

