### PR TITLE
Only detect touches on media if the actual image is tapped.

### DIFF
--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -208,15 +208,22 @@ open class MediaAttachment: NSTextAttachment
         return glyphImage
     }
 
-    fileprivate func glyph(basedOnImage image:UIImage, forBounds bounds: CGRect) -> UIImage? {
-
+    func mediaBounds(forBounds bounds: CGRect) -> CGRect {
         let containerWidth = bounds.size.width
         let origin = CGPoint(x: xPosition(forContainerWidth: bounds.size.width), y: imageMargin)
         let size = CGSize(width: onScreenWidth(containerWidth), height: onScreenHeight(containerWidth) - imageMargin)
+        return CGRect(origin: origin, size: size)
+    }
+
+    fileprivate func glyph(basedOnImage image:UIImage, forBounds bounds: CGRect) -> UIImage? {
 
         UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0)
 
-        image.draw(in: CGRect(origin: origin, size: size))
+        let mediaBounds = self.mediaBounds(forBounds: bounds)
+        let origin = mediaBounds.origin
+        let size = mediaBounds.size
+
+        image.draw(in: mediaBounds)
 
         drawOverlay(at: origin, size: size)
         drawProgress(at: origin, size: size)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1029,6 +1029,18 @@ open class TextView: UITextView {
         bounds.origin.x += textContainerInset.left
         bounds.origin.y += textContainerInset.top
 
+        // Let's check if we have media attachment in place
+        var mediaBounds: CGRect = .zero
+        if let mediaAttachment = attachment as? MediaAttachment {
+            mediaBounds = mediaAttachment.mediaBounds(forBounds: bounds)
+        }
+
+        // Correct the bounds taking in account the dimesion of the media image being used
+        bounds.origin.x += mediaBounds.origin.x
+        bounds.origin.y += mediaBounds.origin.y
+        bounds.size.width = mediaBounds.size.width
+        bounds.size.height = mediaBounds.size.height
+
         if bounds.contains(point) {
             return attachment
         }


### PR DESCRIPTION
Fixes #570 

This PR adds code to detect touch only then actual image representation of attachment is pressed.

To test:
 - Check the original issue steps to reproduce it
