### PR TITLE
Implement undo and redo when removing attachments by code.

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -298,6 +298,7 @@ open class TextStorage: NSTextStorage {
     ///
     /// - Parameter attachmentID: the id of the attachment
     /// - Returns: the range of the attachment
+    ///
     open func rangeFor(attachmentID: String) -> NSRange? {
         var foundRange: NSRange?
         enumerateAttachmentsOfType(MediaAttachment.self) { (attachment, range, stop) in
@@ -307,19 +308,6 @@ open class TextStorage: NSTextStorage {
             }
         }
         return foundRange
-    }
-
-    /// Removes the attachments that match the attachament identifier provided from the storage
-    ///
-    /// - Parameter attachmentID: the unique id of the attachment
-    ///
-    open func remove(attachmentID: String) {
-        enumerateAttachmentsOfType(MediaAttachment.self) { (attachment, range, stop) in
-            if attachment.identifier == attachmentID {
-                self.replaceCharacters(in: range, with: NSAttributedString(string: ""))
-                stop.pointee = true
-            }
-        }
     }
 
     /// Removes all of the TextAttachments from the storage

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -293,7 +293,22 @@ open class TextStorage: NSTextStorage {
         let stringWithAttachment = NSAttributedString(attachment: attachment)
         replaceCharacters(in: range, with: stringWithAttachment)
     }
-    
+
+    /// Return the range of an attachment with the specified identifier if any
+    ///
+    /// - Parameter attachmentID: the id of the attachment
+    /// - Returns: the range of the attachment
+    open func rangeFor(attachmentID: String) -> NSRange? {
+        var foundRange: NSRange?
+        enumerateAttachmentsOfType(MediaAttachment.self) { (attachment, range, stop) in
+            if attachment.identifier == attachmentID {
+                foundRange = range
+                stop.pointee = true
+            }
+        }
+        return foundRange
+    }
+
     /// Removes the attachments that match the attachament identifier provided from the storage
     ///
     /// - Parameter attachmentID: the unique id of the attachment

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -972,7 +972,7 @@ open class TextView: UITextView {
         return storage.attachment(withId: id)
     }
 
-    /// Removes the attachment that match the attachment identifier provided from the storage
+    /// Removes the attachment that matches the attachment identifier provided from the storage
     ///
     /// - Parameter attachmentID: the unique id of the attachment
     ///

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -972,18 +972,28 @@ open class TextView: UITextView {
         return storage.attachment(withId: id)
     }
 
-    /// Removes the attachments that match the attachament identifier provided from the storage
+    /// Removes the attachment that match the attachment identifier provided from the storage
     ///
     /// - Parameter attachmentID: the unique id of the attachment
     ///
     open func remove(attachmentID: String) {
-        storage.remove(attachmentID: attachmentID)
+        guard let range = storage.rangeFor(attachmentID: attachmentID) else {
+            return
+        }
+        let originalText = storage.attributedSubstring(from: range)
+        let finalRange = NSRange(location: range.location, length: 0)
+
+        undoManager?.registerUndo(withTarget: self, handler: { [weak self] target in
+            self?.undoTextReplacement(of: originalText, finalRange: finalRange)
+        })
+
+        storage.replaceCharacters(in: range, with: NSAttributedString(string: "", attributes: typingAttributes))
         delegate?.textViewDidChange?(self)
     }
 
     /// Removes all of the text attachments contained within the storage
     ///
-    open func removeTextAttachments() {
+    open func removeMediaAttachments() {
         storage.removeMediaAttachments()
         delegate?.textViewDidChange?(self)
     }

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -126,20 +126,7 @@ class TextStorageTests: XCTestCase
         func storage(_ storage: TextStorage, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
             return UIImage()
         }
-    }
-
-    func testRemovalOfAttachment() {
-        let storage = TextStorage()
-        let mockDelegate = MockAttachmentsDelegate()
-        storage.attachmentsDelegate = mockDelegate
-
-        let attachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"test://")!)
-        storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
-
-        storage.remove(attachmentID: attachment.identifier)
-
-        XCTAssertTrue(mockDelegate.deletedAttachmendIDCalledWithString == attachment.identifier)
-    }
+    }    
 
     func testInsertImage() {
         let storage = TextStorage()

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1441,4 +1441,20 @@ class TextViewTests: XCTestCase {
         }
         XCTAssertEqual(font, textView.defaultFont)
     }
+
+    func testRemovalOfAttachment() {
+        let textView = createEmptyTextView()
+
+        let attachment = textView.replaceWithImage(at: .zero, sourceURL: URL(string:"https://wordpress.com")!, placeHolderImage: nil)
+
+        var html = textView.getHTML()
+
+        XCTAssertEqual(html, "<img src=\"https://wordpress.com\">")
+
+        textView.remove(attachmentID: attachment.identifier)
+
+        html = textView.getHTML()
+
+        XCTAssertEqual(html, "")
+    }
 }


### PR DESCRIPTION
This PR implements the capability of undo redo when removing an attachment by pressing on it and select the option remove.

To test:
 - Start the demo app
 - open the demo with content
 - scroll to the coyote image
 - Tap on it
 - Tap again
 - Select Remove Media
 - Check if image was removed
 - Tap Undo 
 - Check if image comes back again.
