### PR TITLE
Add an extra check for alternative emoji font.

### DIFF
--- a/Aztec/Classes/Extensions/UIFont+Emoji.swift
+++ b/Aztec/Classes/Extensions/UIFont+Emoji.swift
@@ -9,6 +9,6 @@ extension UIFont {
     /// Indicates if the current font instance matches with iOS's Internal Emoji Font, or not.
     ///
     var isAppleEmojiFont: Bool {
-        return fontName == ".AppleColorEmojiUI"
+        return fontName == ".AppleColorEmojiUI" || fontName == "AppleColorEmoji"
     }
 }

--- a/AztecTests/TextViewStubAttachmentDelegate.swift
+++ b/AztecTests/TextViewStubAttachmentDelegate.swift
@@ -13,7 +13,6 @@ class TextViewStubAttachmentDelegate: TextViewAttachmentDelegate, TextViewAttach
     }
 
     func placeholderImage(for attachment: NSTextAttachment) -> UIImage {
-        let imageSize = CGSize(width:32, height:32)
         let placeholderImage: UIImage
         switch attachment {
         case _ as ImageAttachment:

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -38,10 +38,10 @@ class TextViewTests: XCTestCase {
         return richTextView
     }
 
-    let anotherFont = UIFont(name:"HelveticaNeue", size: 14)!
+    let nonStandardSystemFont = UIFont(name:"HelveticaNeue", size: 14)!
 
-    func createEmptyTextViewWithAnotherFont() -> Aztec.TextView {
-        let richTextView = Aztec.TextView(defaultFont: anotherFont, defaultMissingImage: UIImage())
+    func createEmptyTextViewWithNonStandardSystemFont() -> Aztec.TextView {
+        let richTextView = Aztec.TextView(defaultFont: nonStandardSystemFont, defaultMissingImage: UIImage())
         richTextView.textAttachmentDelegate = attachmentDelegate
         richTextView.registerAttachmentImageProvider(attachmentDelegate)
         return richTextView
@@ -1452,11 +1452,11 @@ class TextViewTests: XCTestCase {
     }
 
     func testInsertEmojiKeepsDefaultFont() {
-        let textView = createEmptyTextViewWithAnotherFont()
+        let textView = createEmptyTextViewWithNonStandardSystemFont()
 
         textView.insertText("😘")
         let currentTypingFont = textView.typingAttributes[NSFontAttributeName] as! UIFont
-        XCTAssertEqual(currentTypingFont, anotherFont, "Font should be set to default")
+        XCTAssertEqual(currentTypingFont, nonStandardSystemFont, "Font should be set to default")
     }
 
 

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -38,6 +38,15 @@ class TextViewTests: XCTestCase {
         return richTextView
     }
 
+    let anotherFont = UIFont(name:"HelveticaNeue", size: 14)!
+
+    func createEmptyTextViewWithAnotherFont() -> Aztec.TextView {
+        let richTextView = Aztec.TextView(defaultFont: anotherFont, defaultMissingImage: UIImage())
+        richTextView.textAttachmentDelegate = attachmentDelegate
+        richTextView.registerAttachmentImageProvider(attachmentDelegate)
+        return richTextView
+    }
+
     func createTextViewWithContent() -> Aztec.TextView {
         let paragraph = "Lorem ipsum dolar sit amet.\n"
         let richTextView = Aztec.TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: UIImage())
@@ -1441,4 +1450,14 @@ class TextViewTests: XCTestCase {
         }
         XCTAssertEqual(font, textView.defaultFont)
     }
+
+    func testInsertEmojiKeepsDefaultFont() {
+        let textView = createEmptyTextViewWithAnotherFont()
+
+        textView.insertText("😘")
+        let currentTypingFont = textView.typingAttributes[NSFontAttributeName] as! UIFont
+        XCTAssertEqual(currentTypingFont, anotherFont, "Font should be set to default")
+    }
+
+
 }


### PR DESCRIPTION
Refs #485 

This PR adds another check for alternative emoji font when not using the standard system font (San Francisco UI)

To test:
 - Make sure unit tests are ok
 - Run the demo app
 - Insert an emoji anywhere in the text
 - Make sure that characters written after have the correct style

