### PR TITLE
Add resources to pod spec file.

### DIFF
--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -31,6 +31,7 @@ Pod::Spec.new do |s|
 
   s.module_name = "Aztec"
   s.source_files = 'Aztec/Classes/**/*'
+  s.resources = 'Aztec/Assets/**/*'
 
   # For more info about these, see: https://medium.com/swift-and-ios-writing/using-a-c-library-inside-a-swift-framework-d041d7b701d9#.wohyiwj5e
   # For this to work on local/development pods and outside projects we added two paths one for each scenario. See here: https://github.com/CocoaPods/CocoaPods/issues/5375


### PR DESCRIPTION
Closes #577 

This issue resulted from the Removal of Gridicons done here: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/559

The resources where not added to the pod, so this made application that used the pod crash when trying to access a resource.

To test:
 - The easiest way to test this is to try this version directly on the main WPiOS app.

Note: @diegoreymendez because we are using CocoaPods should convert the Example app to use CocoaPods instead of Carthage? This will make it easier to find this kind of issue.