### PR TITLE
Fix format bar colors

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -144,7 +144,7 @@ open class FormatBar: UIView {
     ///
     override open var tintColor: UIColor? {
         didSet {
-            for item in items {
+            for item in items + [overflowToggleItem] {
                 item.normalTintColor = tintColor
             }
         }
@@ -155,7 +155,7 @@ open class FormatBar: UIView {
     ///
     open var selectedTintColor: UIColor? {
         didSet {
-            for item in items {
+            for item in items + [overflowToggleItem] {
                 item.selectedTintColor = selectedTintColor
             }
         }
@@ -166,7 +166,7 @@ open class FormatBar: UIView {
     ///
     open var highlightedTintColor: UIColor? {
         didSet {
-            for item in items {
+            for item in items + [overflowToggleItem] {
                 item.highlightedTintColor = highlightedTintColor
             }
         }
@@ -177,7 +177,7 @@ open class FormatBar: UIView {
     ///
     open var disabledTintColor: UIColor? {
         didSet {
-            for item in items {
+            for item in items + [overflowToggleItem] {
                 item.disabledTintColor = disabledTintColor
             }
         }

--- a/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
@@ -114,8 +114,8 @@ open class FormatBarItem: UIButton {
 
         super.init(frame: frame)
         self.setImage(image, for: UIControlState())
-        self.adjustsImageWhenDisabled = true
-        self.adjustsImageWhenHighlighted = true
+        self.adjustsImageWhenDisabled = false
+        self.adjustsImageWhenHighlighted = false
     }
 
 


### PR DESCRIPTION
I hope this is okay coming into the release branch, but it's just a tiny fix to the colours of the format bar items. Previously disabled items had the wrong tint colour (iOS was adding its own adjustments), and we weren't including the overflow toggle button when setting colors.

![formatbar-fix](https://user-images.githubusercontent.com/4780/27744447-781e09da-5db7-11e7-8e8b-249e21e54a10.png)

To test:

* Build and run, open Aztec. Enter HTML mode, and check:
  * The disabled items and the overflow toggle (`...`) should match in color
  * They should match the 'after' color in the screenshot above.

Needs review: @SergioEstevao 
cc @diegoreymendez 