### PR TITLE
Backport: Support for Tab + Shift Tab

### DIFF
--- a/Aztec/Classes/Extensions/Character+Name.swift
+++ b/Aztec/Classes/Extensions/Character+Name.swift
@@ -11,6 +11,7 @@ extension Character {
         case objectReplacement = "\u{FFFC}"
         case paragraphSeparator = "\u{2029}"
         case space = " "
+        case tab = "\t"
         case zeroWidthSpace = "\u{200B}"
     }
     

--- a/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
@@ -64,19 +64,20 @@ class TextListFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func present(in attributes: [String : Any]) -> Bool {
-        guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle, let list = style.lists.last else {
-            return false
-        }
-
-        return list.style == listStyle
+    func present(in attributes: [String: Any]) -> Bool {
+        return TextListFormatter.lastListPresent(in: attributes)?.style == listStyle
     }
 
+
+    // MARK: - Static Helpers
+
     static func listsOfAnyKindPresent(in attributes: [String: Any]) -> Bool {
-        guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle else {
-            return false
-        }
-        return !(style.lists.isEmpty)
+        return lastListPresent(in: attributes) != nil
+    }
+
+    static func lastListPresent(in attributes: [String: Any]) -> TextList? {
+        let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle
+        return style?.lists.last
     }
 }
 

--- a/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
@@ -65,19 +65,19 @@ class TextListFormatter: ParagraphAttributeFormatter {
     }
 
     func present(in attributes: [String: Any]) -> Bool {
-        return TextListFormatter.lastListPresent(in: attributes)?.style == listStyle
+        return TextListFormatter.lists(in: attributes).last?.style == listStyle
     }
 
 
     // MARK: - Static Helpers
 
     static func listsOfAnyKindPresent(in attributes: [String: Any]) -> Bool {
-        return lastListPresent(in: attributes) != nil
+        return lists(in: attributes).isEmpty == false
     }
 
-    static func lastListPresent(in attributes: [String: Any]) -> TextList? {
+    static func lists(in attributes: [String: Any]) -> [TextList] {
         let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle
-        return style?.lists.last
+        return style?.lists ?? []
     }
 }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -292,13 +292,37 @@ open class TextView: UITextView {
             // When the keyboard "enter" key is pressed, the keycode corresponds to .carriageReturn,
             // even if it's later converted to .lineFeed by default.
             //
-            return [UIKeyCommand(input: String(.carriageReturn), modifierFlags: .shift , action: #selector(handleShiftEnter(command:)))]
+            return [
+                UIKeyCommand(input: String(.carriageReturn), modifierFlags: .shift, action: #selector(handleShiftEnter(command:))),
+                UIKeyCommand(input: String(.tab), modifierFlags: .shift, action: #selector(handleShiftTab(command:))),
+                UIKeyCommand(input: String(.tab), modifierFlags: [], action: #selector(handleTab(command:)))
+            ]
         }
     }
 
     func handleShiftEnter(command: UIKeyCommand) {
         insertText(String(.lineSeparator))
     }
+
+    func handleShiftTab(command: UIKeyCommand) {
+        guard let list = TextListFormatter.lastListPresent(in: typingAttributes) else {
+            return
+        }
+
+        let formatter = TextListFormatter(style: list.style, placeholderAttributes: nil, increaseDepth: true)
+        formatter.removeAttributes(from: storage, at: selectedRange)
+    }
+
+    func handleTab(command: UIKeyCommand) {
+        guard let list = TextListFormatter.lastListPresent(in: typingAttributes) else {
+            insertText(String(.tab))
+            return
+        }
+
+        let formatter = TextListFormatter(style: list.style, placeholderAttributes: nil, increaseDepth: true)
+        formatter.applyAttributes(to: storage, at: selectedRange)
+    }
+
 
     // MARK: - Pasteboard Helpers
 


### PR DESCRIPTION
Backports #584 into Beta 6

### To test:
1. Launch an Empty Document
2. Add an Ordered / Unordered List
3. Hit `Tab` and verify a new indentation level is added
4. Repeat and verify up to `7` indentation levels are added
5. Try `Shift Tab` and verify an indentation level is removed
6. Try the Shake gesture, and verify the Undo OP works as expected

cc @diegoreymendez 
Thanks in advance!!
