### PR TITLE
Shift + ENTER no longer breaks lists at EoF.

### DIFF
--- a/Aztec/Classes/Extensions/String+EndOfLine.swift
+++ b/Aztec/Classes/Extensions/String+EndOfLine.swift
@@ -45,7 +45,8 @@ extension String {
     /// - Returns: `true` if the receiver is an end-of-line character.
     ///
     func isEndOfLine() -> Bool {
-        return self == String(.lineSeparator)
+        return self == String(.carriageReturn)
+            || self == String(.lineSeparator)
             || self == String(.lineFeed)
             || self == String(.paragraphSeparator)
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -836,12 +836,10 @@ open class TextView: UITextView {
     /// Blockquote's background.
     ///
     private func ensureInsertionOfEndOfLine(beforeInserting text: String) {
-        guard text == String(.lineFeed) else {
-            return
-        }
 
-        guard selectedRange.location == storage.length else {
-            return
+        guard text.isEndOfLine(),
+            selectedRange.location == storage.length else {
+                return
         }
 
         let formatters: [AttributeFormatter] = [
@@ -1409,9 +1407,7 @@ private extension TextView {
 
     // MARK: - WORKAROUND: removing styles at EOF due to selection change
 
-    /// Removes paragraph attributes after a selection change.  The logic that defines if the
-    /// attributes must be removed is located in
-    /// `mustRemoveSingleLineParagraphAttributesAfterSelectionChange()`.
+    /// Removes paragraph attributes after a selection change.
     ///
     func ensureRemovalOfParagraphAttributesAfterSelectionChange() {
         guard mustRemoveParagraphAttributesAfterSelectionChange() else {


### PR DESCRIPTION
Fixes #594 

### Testing:

**Test 1:**

Build and run the unit tests.

**Test 2:**

- Run the empty demo.
- Create a list.
- Press shift + enter while the carete is both at end-of-file and end-of-list.
- Make sure the list style is not removed.

