### PR TITLE
Fixes an issue with shift + ENTER and adds a unit test.

### DIFF
--- a/Aztec/Classes/Extensions/String+EndOfLine.swift
+++ b/Aztec/Classes/Extensions/String+EndOfLine.swift
@@ -45,7 +45,8 @@ extension String {
     /// - Returns: `true` if the receiver is an end-of-line character.
     ///
     func isEndOfLine() -> Bool {
-        return self == String(.lineSeparator)
+        return self == String(.carriageReturn)
+            || self == String(.lineSeparator)
             || self == String(.lineFeed)
             || self == String(.paragraphSeparator)
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -836,12 +836,9 @@ open class TextView: UITextView {
     /// Blockquote's background.
     ///
     private func ensureInsertionOfEndOfLine(beforeInserting text: String) {
-        guard text == String(.lineFeed) else {
-            return
-        }
-
-        guard selectedRange.location == storage.length else {
-            return
+        guard text.isEndOfLine(),
+            selectedRange.location == storage.length else {
+                return
         }
 
         let formatters: [AttributeFormatter] = [
@@ -1435,9 +1432,7 @@ private extension TextView {
 
     // MARK: - WORKAROUND: removing styles at EOF due to selection change
 
-    /// Removes paragraph attributes after a selection change.  The logic that defines if the
-    /// attributes must be removed is located in
-    /// `mustRemoveSingleLineParagraphAttributesAfterSelectionChange()`.
+    /// Removes paragraph attributes after a selection change.
     ///
     func ensureRemovalOfParagraphAttributesAfterSelectionChange() {
         guard mustRemoveParagraphAttributesAfterSelectionChange() else {

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -971,6 +971,25 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.paragraphSeparator))
     }
 
+    /// When the caret is positioned at both EoF and EoL, inserting a line separator (in most
+    /// editors by pressing shift+enter) must not remove the list style.
+    ///
+    /// This test is to avoid regressions on:
+    /// https://github.com/wordpress-mobile/AztecEditor-iOS/issues/594
+    ///
+    func testShiftEnterAtEndOfListAndEndOfFile() {
+        let textView = createEmptyTextView()
+
+        textView.insertText("First line")
+        textView.toggleUnorderedList(range: textView.selectedRange)
+        textView.insertText(String(.lineSeparator))
+
+        let unorderedListFormatter = TextListFormatter(style: .unordered)
+
+        XCTAssertTrue(unorderedListFormatter.present(in: textView.storage, at: 0))
+        XCTAssertTrue(unorderedListFormatter.present(in: textView.storage, at: textView.selectedRange))
+    }
+
 
     // MARK: - Blockquotes
 

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -972,7 +972,7 @@ class TextViewTests: XCTestCase {
     }
 
     /// When the caret is positioned at both EoF and EoL, inserting a line separator (in most
-    /// editors by pressing shift+enter) must not remove the list style.
+    /// editors by pressing shift + enter) must not remove the list style.
     ///
     /// This test is to avoid regressions on:
     /// https://github.com/wordpress-mobile/AztecEditor-iOS/issues/594


### PR DESCRIPTION
Fixes #594.

It seems the previous fix was aimed at beta.7 and got lost at some point.  This PR brings the fix to beta.8.

Also adds a unit test to make sure there's no future regression with this issue.