### PR TITLE
Fixes some obscure issues when editing HTML outside of block-level elements.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -239,25 +239,6 @@ extension Libxml2 {
 
         // MARK: - DOM Queries
         
-        /// Returns the index of the specified child node.  This method should only be called when
-        /// there's 100% certainty that this node should contain the specified child node, as it
-        /// fails otherwise.
-        ///
-        /// Call `children.indexOf()` if you need to test the parent-child relationship instead.
-        ///
-        /// - Parameters:
-        ///     - childNode: the child node to find the index of.
-        ///
-        /// - Returns: the index of the specified child node.
-        ///
-        func indexOf(childNode: Node) -> Int {
-            guard let index = children.index(of: childNode) else {
-                fatalError("Broken parent-child relationship found.")
-            }
-            
-            return index
-        }
-
         typealias NodeMatchTest = (_ node: Node) -> Bool
         typealias NodeIntersectionReport = (_ node: Node, _ intersection: NSRange) -> Void
         typealias RangeReport = (_ range: NSRange) -> Void

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -238,7 +238,7 @@ extension Libxml2 {
 
 
         // MARK: - DOM Queries
-        
+
         typealias NodeMatchTest = (_ node: Node) -> Bool
         typealias NodeIntersectionReport = (_ node: Node, _ intersection: NSRange) -> Void
         typealias RangeReport = (_ range: NSRange) -> Void

--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -131,7 +131,9 @@ extension Libxml2 {
                 return nil
             }
 
-            let index = parent.indexOf(childNode: self)
+            let index = parent.children.index { node -> Bool in
+                return node === self
+            }!
 
             return parent.sibling(rightOf: index)
         }

--- a/Aztec/Classes/Libxml2/DOM/Data/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/StandardElementType.swift
@@ -91,7 +91,12 @@ extension Libxml2 {
             case .video:
                 return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
             case .br:
-                return NSAttributedString(.lineSeparator, attributes: attributes)
+                if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
+                    paragraphStyle.properties.count > 0 {
+                        return NSAttributedString(.lineSeparator, attributes: attributes)
+                } else {
+                    return NSAttributedString(.lineFeed, attributes: attributes)
+                }
             case .hr:
                 return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
             default:

--- a/Aztec/Classes/Libxml2/DOM/Data/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/StandardElementType.swift
@@ -91,6 +91,11 @@ extension Libxml2 {
             case .video:
                 return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
             case .br:
+                // Since the user can type outside of paragraphs (or any block level element) we
+                // must ensure that when that happens, each line is treated as a separate paragraph.
+                // Otherwise the styles applied to each line will be overridden constantly
+                // by the lack of paragraph delimiters.
+                //
                 if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
                     paragraphStyle.properties.count > 0 {
                         return NSAttributedString(.lineSeparator, attributes: attributes)

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -45,10 +45,22 @@ extension Libxml2 {
             return !isLastInTree() && isLastInAncestorEndingInBlockLevelSeparation()
         }
 
+        // MARK - Hashable
+
+        override public var hashValue: Int {
+            return name.hashValue ^ contents.hashValue
+        }
+
         // MARK: - LeafNode
         
         func text() -> String {
             return contents
+        }
+
+        // MARK: - Node Equatable
+
+        static func ==(lhs: Libxml2.TextNode, rhs: Libxml2.TextNode) -> Bool {
+            return lhs.name == rhs.name && lhs.contents == rhs.contents
         }
     }
 }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -585,7 +585,7 @@ class TextViewTests: XCTestCase {
 
         textView.replace(range, withText: "")
 
-        XCTAssertEqual(textView.getHTML(), "<ol><li>First</li><li>SecondAhoi<br>Arr!</li></ol>")
+        XCTAssertEqual(textView.getHTML(), "<ol><li>First</li><li>SecondAhoi</li></ol>Arr!")
     }
 
     /// Tests that deleting a newline works at the end of text with paragraph with header before works.

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1495,4 +1495,14 @@ class TextViewTests: XCTestCase {
 
         XCTAssertEqual(html, "")
     }
+
+    /// This test verifies that the H1 Header does not get lost during the Rich <> Raw transitioning.
+    ///
+    func testSetHtmlDoesNotLooseHeaderStyle() {
+        let pristineHTML = "<br><br><h1>Header</h1>"
+        let textView = createTextView(withHTML: pristineHTML)
+        let generatedHTML = textView.getHTML()
+
+        XCTAssertEqual(pristineHTML, generatedHTML)
+    }
 }


### PR DESCRIPTION
Fixes some obscure issues when editing HTML outside of block-level elements.

**To test:**

1. Using the HTML input:

```text
<br><br><h1>Test</h1>
```

2. Switch to visual mode and back.

Expected output: same as the input (no `<br>` nodes should be removed).