### PR TITLE
Draw block quotes inside lists

### DIFF
--- a/Aztec/Classes/Constants/Metrics.swift
+++ b/Aztec/Classes/Constants/Metrics.swift
@@ -7,9 +7,8 @@ import Foundation
 enum Metrics {
 
     static let defaultIndentation = CGFloat(12)
-    static let maxIndentation = CGFloat(200)
-    static let listBulletIndentation = CGFloat(20)
-    static let listTextIndentation = CGFloat(24)
+    static let maxIndentation = CGFloat(200)    
+    static let listTextIndentation = CGFloat(16)
     static let tabStepInterval = 8
     static let tabStepCount = 12
     static let paragraphSpacing = CGFloat(6)

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -53,17 +53,13 @@ private extension LayoutManager {
             guard let paragraphStyle = object as? ParagraphStyle, !paragraphStyle.blockquotes.isEmpty else {
                 return
             }
-            let blockquoteDepth = CGFloat(paragraphStyle.properties.filter({ (property) -> Bool in
-                return property is Blockquote || property is TextList
-                }).index(where: { (property) -> Bool in
-                return property is Blockquote
-            }) ?? 0)
+            let blockquoteIndent = paragraphStyle.blockquoteIndent
 
             let blockquoteGlyphRange = glyphRange(forCharacterRange: range, actualCharacterRange: nil)
 
             enumerateLineFragments(forGlyphRange: blockquoteGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
-                let paddingWidth = (blockquoteDepth == 0 ? 0: blockquoteDepth + 1) * Metrics.defaultIndentation
-                var paddingHeight: CGFloat = blockquoteDepth == 0 ? 0 : (Metrics.paragraphSpacing / 2)
+                let paddingWidth = blockquoteIndent
+                var paddingHeight: CGFloat = blockquoteIndent == 0 ? 0 : (Metrics.paragraphSpacing / 2)
                 //cheking if we this a middle line inside a blockquote paragraph
                 let lineRange = self.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
                 let lineCharacters = textStorage.attributedSubstring(from: lineRange).string

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -58,7 +58,7 @@ private extension LayoutManager {
             let blockquoteGlyphRange = glyphRange(forCharacterRange: range, actualCharacterRange: nil)
 
             enumerateLineFragments(forGlyphRange: blockquoteGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
-                let paddingWidth = blockquoteIndent
+                let paddingWidth = blockquoteIndent + (blockquoteIndent == 0 ? 0 : (Metrics.listTextIndentation / 2))
                 var paddingHeight: CGFloat = blockquoteIndent == 0 ? 0 : (Metrics.paragraphSpacing / 2)
                 //cheking if we this a middle line inside a blockquote paragraph
                 let lineRange = self.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
@@ -202,8 +202,8 @@ private extension LayoutManager {
     private func markerAttributesBasedOnParagraph(attributes: [String: Any]) -> [String: Any] {
         var resultAttributes = attributes
         var indent: CGFloat = 0
-        if let style = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
-            indent = style.headIndent
+        if let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle {
+            indent = style.listIndent + Metrics.listTextIndentation
         }
 
         resultAttributes[NSParagraphStyleAttributeName] = markerParagraphStyle(indent: indent)

--- a/Aztec/Classes/TextKit/ParagraphProperty/TextList.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/TextList.swift
@@ -16,8 +16,8 @@ open class TextList: ParagraphProperty {
 
         func markerText(forItemNumber number: Int) -> String {
             switch self {
-            case .ordered:      return "\t\(number).\t"
-            case .unordered:    return "\t\u{2022}\t\t"
+            case .ordered:      return "\t\(number)."
+            case .unordered:    return "\t\u{2022}"
             }
         }
     }

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -121,7 +121,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
     open override var headIndent: CGFloat {
         get {
-            let extra: CGFloat = (CGFloat(lists.count) * Metrics.listTextIndentation)
+            let extra: CGFloat = (CGFloat(lists.count + blockquotes.count) * Metrics.listTextIndentation)
 
             return baseHeadIndent + extra
         }
@@ -133,7 +133,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
     open override var firstLineHeadIndent: CGFloat {
         get {
-            let extra: CGFloat = (CGFloat(lists.count) * Metrics.listTextIndentation)
+            let extra: CGFloat = (CGFloat(lists.count + blockquotes.count) * Metrics.listTextIndentation)
 
             return baseFirstLineHeadIndent + extra
         }
@@ -192,11 +192,28 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
             return property is Blockquote
         })
 
-        guard let depth = blockquoteIndex, depth > 0 else {
+        guard let depth = blockquoteIndex else {
             return 0
         }
 
-        return CGFloat(depth + 1) * Metrics.defaultIndentation
+        return CGFloat(depth) * Metrics.listTextIndentation
+    }
+
+    /// The amount of indent for the list of the paragraph if any.
+    ///
+    public var listIndent: CGFloat {
+        let listAndBlockquotes = self.properties.filter({ (property) -> Bool in
+            return property is Blockquote || property is TextList
+        })
+        var depth = 0
+        for position in (0..<listAndBlockquotes.count).reversed() {
+            if listAndBlockquotes[position] is TextList {
+                depth = position
+                break
+            }
+        }
+
+        return CGFloat(depth) * Metrics.listTextIndentation
     }
 
     var baseHeadIndent: CGFloat = 0

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -183,6 +183,22 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         }
     }
 
+    /// The amount of indent for the blockquote of the paragraph if any.
+    ///
+    public var blockquoteIndent: CGFloat {
+        let blockquoteIndex = self.properties.filter({ (property) -> Bool in
+            return property is Blockquote || property is TextList
+        }).index(where: { (property) -> Bool in
+            return property is Blockquote
+        })
+
+        guard let depth = blockquoteIndex, depth > 0 else {
+            return 0
+        }
+
+        return CGFloat(depth + 1) * Metrics.defaultIndentation
+    }
+
     var baseHeadIndent: CGFloat = 0
     var baseFirstLineHeadIndent: CGFloat = 0
     var baseTailIndent: CGFloat = 0

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -186,9 +186,9 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     /// The amount of indent for the blockquote of the paragraph if any.
     ///
     public var blockquoteIndent: CGFloat {
-        let blockquoteIndex = self.properties.filter({ (property) -> Bool in
+        let blockquoteIndex = properties.filter({ property in
             return property is Blockquote || property is TextList
-        }).index(where: { (property) -> Bool in
+        }).index(where: { property in
             return property is Blockquote
         })
 
@@ -202,7 +202,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     /// The amount of indent for the list of the paragraph if any.
     ///
     public var listIndent: CGFloat {
-        let listAndBlockquotes = self.properties.filter({ (property) -> Bool in
+        let listAndBlockquotes = properties.filter({ property in
             return property is Blockquote || property is TextList
         })
         var depth = 0

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -86,6 +86,14 @@ Blockquote and Ordered List:
 </ol>
 </blockquote>
 </p>
+<p>
+List with Blockquotes inside:
+    <ol>
+        <li><blockquote>One</blockquote></li>
+        <li><blockquote>Two</blockquote></li>
+        <li><blockquote>Three</blockquote></li>
+    </ol>
+</p>
 
 <p>
 Master cleanse Intelligentsia butcher Brooklyn Tumblr. Etsy lo-fi Marfa bicycle rights. Intelligentsia Helvetica fanny pack, normcore Odd Future fixie brunch mustache aesthetic kitsch artisan cardigan mlkshk. Pour-over hashtag selfies pug Tumblr mlkshk. Food truck small batch McSweeney's trust fund, Intelligentsia bitters Brooklyn twee meh authentic. Normcore distillery American Apparel single-origin coffee artisan try-hard, stumptown XOXO tote bag fanny pack Blue Bottle Shoreditch food truck Banksy. Church-key American Apparel Blue Bottle, swag try-hard Odd Future mustache chia iPhone.


### PR DESCRIPTION
Fixes #449 

This PR adds support for drawing block quotes inside lists.

To test:
 - Run the demo app with sample content
 - Scroll to the place where lists are mixed with block quotes and see if the presentation is done correctly
 - Open the empty demo app
 - write something
 - Tap on list formatting
 - Tap on block quote formatting
 - Check if presentation is correct.
