### PR TITLE
TextViewAttachmentDelegate: Cleanup

### DIFF
--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -6,15 +6,15 @@ protocol MediaAttachmentDelegate: class {
         _ mediaAttachment: MediaAttachment,
         imageForURL url: URL,
         onSuccess success: @escaping (UIImage) -> (),
-        onFailure failure: @escaping () -> ()) -> UIImage
+        onFailure failure: @escaping () -> ())
 
     func mediaAttachmentPlaceholderImageFor(attachment: MediaAttachment) -> UIImage
 }
 
 /// Custom text attachment.
 ///
-open class MediaAttachment: NSTextAttachment
-{
+open class MediaAttachment: NSTextAttachment {
+
     /// Attributes accessible by the user, for general purposes.
     ///
     public var extraAttributes = [String: String]()
@@ -333,8 +333,10 @@ open class MediaAttachment: NSTextAttachment
         }
         
         isFetchingImage = true
-        
-        let image = delegate.mediaAttachment(self, imageForURL: url, onSuccess: { [weak self] image in
+
+        self.image = delegate.mediaAttachmentPlaceholderImageFor(attachment: self)
+
+        delegate.mediaAttachment(self, imageForURL: url, onSuccess: { [weak self] image in
                 guard let strongSelf = self else {
                     return
                 }
@@ -353,8 +355,6 @@ open class MediaAttachment: NSTextAttachment
                 strongSelf.image = nil
                 strongSelf.invalidateLayout(inTextContainer: textContainer)
             })
-
-        self.image = image
     }
     
     fileprivate func invalidateLayout(inTextContainer textContainer: NSTextContainer?) {

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -15,16 +15,22 @@ protocol TextStorageAttachmentsDelegate {
     ///     - success: Callback block to be invoked with the image fetched from the url.
     ///     - failure: Callback block to be invoked when an error occurs when fetching the image.
     ///
-    /// - Returns: returns a temporary UIImage to be used while the request is happening
-    ///
     func storage(
         _ storage: TextStorage,
         attachment: NSTextAttachment,
         imageFor url: URL,
         onSuccess success: @escaping (UIImage) -> (),
-        onFailure failure: @escaping () -> ()) -> UIImage
-    
-    func storage(_ storage: TextStorage, missingImageFor attachment: NSTextAttachment) -> UIImage
+        onFailure failure: @escaping () -> ())
+
+    /// Provides an image placeholder for a specified attachment.
+    ///
+    /// - Parameters:
+    ///     - storage: The storage that is requesting the image.
+    ///     - attachment: The attachment that is requesting the image.
+    ///
+    /// - Returns: An Image placeholder to be rendered onscreen.
+    ///
+    func storage(_ storage: TextStorage, placeholderFor attachment: NSTextAttachment) -> UIImage
     
     /// Called when an image is about to be added to the storage as an attachment, so that the
     /// delegate can specify an URL where that image is available.
@@ -363,39 +369,45 @@ open class TextStorage: NSTextStorage {
 }
 
 
-// MARK: - TextStorage: TextAttachmentDelegate Methods
+// MARK: - TextStorage: MediaAttachmentDelegate Methods
 //
 extension TextStorage: MediaAttachmentDelegate {
 
     func mediaAttachmentPlaceholderImageFor(attachment: MediaAttachment) -> UIImage {
         assert(attachmentsDelegate != nil)
-        return attachmentsDelegate.storage(self, missingImageFor: attachment)
+        return attachmentsDelegate.storage(self, placeholderFor: attachment)
     }
-
 
     func mediaAttachment(
         _ mediaAttachment: MediaAttachment,
         imageForURL url: URL,
         onSuccess success: @escaping (UIImage) -> (),
-        onFailure failure: @escaping () -> ()) -> UIImage
+        onFailure failure: @escaping () -> ())
     {
         assert(attachmentsDelegate != nil)
-        return attachmentsDelegate.storage(self, attachment: mediaAttachment, imageFor: url, onSuccess: success, onFailure: failure)
+        attachmentsDelegate.storage(self, attachment: mediaAttachment, imageFor: url, onSuccess: success, onFailure: failure)
     }
 }
 
+
+// MARK: - TextStorage: VideoAttachmentDelegate Methods
+//
 extension TextStorage: VideoAttachmentDelegate {
+
+    func videoAttachmentPlaceholderImageFor(attachment: VideoAttachment) -> UIImage {
+        assert(attachmentsDelegate != nil)
+        return attachmentsDelegate.storage(self, placeholderFor: attachment)
+    }
 
     func videoAttachment(
         _ videoAttachment: VideoAttachment,
         imageForURL url: URL,
         onSuccess success: @escaping (UIImage) -> (),
-        onFailure failure: @escaping () -> ()) -> UIImage
+        onFailure failure: @escaping () -> ())
     {
         assert(attachmentsDelegate != nil)
-        return attachmentsDelegate.storage(self, attachment: videoAttachment, imageFor: url, onSuccess: success, onFailure: failure)
+        attachmentsDelegate.storage(self, attachment: videoAttachment, imageFor: url, onSuccess: success, onFailure: failure)
     }
-    
 }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -15,14 +15,11 @@ public protocol TextViewAttachmentDelegate: class {
     ///     - success: when the image is obtained, this closure should be executed.
     ///     - failure: if the image cannot be obtained, this closure should be executed.
     ///
-    /// - Returns: the placeholder for the requested image.  Also useful if showing low-res versions
-    ///         of the images.
-    ///
     func textView(_ textView: TextView,
                   attachment: NSTextAttachment,
                   imageAt url: URL,
                   onSuccess success: @escaping (UIImage) -> Void,
-                  onFailure failure: @escaping () -> Void) -> UIImage
+                  onFailure failure: @escaping () -> Void)
 
     /// Called when an attachment is about to be added to the storage as an attachment (copy/paste), so that the
     /// delegate can specify an URL where that attachment is available.
@@ -40,9 +37,10 @@ public protocol TextViewAttachmentDelegate: class {
     /// - Parameters:
     ///   - textView: the textview that is requesting the image
     ///   - attachment: the attachment that does not an have image source
+    ///
     /// - Returns: an UIImage to represent the attachment graphically
-    func textView(_ textView: TextView,
-                  placeholderForAttachment attachment: NSTextAttachment) -> UIImage
+    ///
+    func textView(_ textView: TextView, placeholderFor attachment: NSTextAttachment) -> UIImage
 
     /// Called after a attachment is removed from the storage.
     ///
@@ -1458,20 +1456,21 @@ extension TextView: TextStorageAttachmentsDelegate {
         attachment: NSTextAttachment,
         imageFor url: URL,
         onSuccess success: @escaping (UIImage) -> (),
-        onFailure failure: @escaping () -> ()) -> UIImage {
+        onFailure failure: @escaping () -> ()) {
         
         guard let textAttachmentDelegate = textAttachmentDelegate else {
             fatalError("This class requires a text attachment delegate to be set.")
         }
         
-        return textAttachmentDelegate.textView(self, attachment: attachment, imageAt: url, onSuccess: success, onFailure: failure)
+        textAttachmentDelegate.textView(self, attachment: attachment, imageAt: url, onSuccess: success, onFailure: failure)
     }
 
-    func storage(_ storage: TextStorage, missingImageFor attachment: NSTextAttachment) -> UIImage {
+    func storage(_ storage: TextStorage, placeholderFor attachment: NSTextAttachment) -> UIImage {
         guard let textAttachmentDelegate = textAttachmentDelegate else {
             fatalError("This class requires a text attachment delegate to be set.")
         }
-        return textAttachmentDelegate.textView(self, placeholderForAttachment: attachment)
+
+        return textAttachmentDelegate.textView(self, placeholderFor: attachment)
     }
     
     func storage(_ storage: TextStorage, urlFor imageAttachment: ImageAttachment) -> URL {

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -6,7 +6,9 @@ protocol VideoAttachmentDelegate: class {
         _ videoAttachment: VideoAttachment,
         imageForURL url: URL,
         onSuccess success: @escaping (UIImage) -> (),
-        onFailure failure: @escaping () -> ()) -> UIImage
+        onFailure failure: @escaping () -> ())
+
+    func videoAttachmentPlaceholderImageFor(attachment: VideoAttachment) -> UIImage
 }
 
 /// Custom text attachment.

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -111,12 +111,12 @@ class TextStorageTests: XCTestCase
             return URL(string:"test://")!
         }
 
-        func storage(_ storage: TextStorage, missingImageFor attachment: NSTextAttachment) -> UIImage {
+        func storage(_ storage: TextStorage, placeholderFor attachment: NSTextAttachment) -> UIImage {
             return UIImage()
         }
 
-        func storage(_ storage: TextStorage, attachment: NSTextAttachment, imageFor url: URL, onSuccess success: @escaping (UIImage) -> (), onFailure failure: @escaping () -> ()) -> UIImage {
-            return UIImage()
+        func storage(_ storage: TextStorage, attachment: NSTextAttachment, imageFor url: URL, onSuccess success: @escaping (UIImage) -> (), onFailure failure: @escaping () -> ()) {
+            // NO OP
         }
 
         func storage(_ storage: TextStorage, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {

--- a/AztecTests/TextViewStubAttachmentDelegate.swift
+++ b/AztecTests/TextViewStubAttachmentDelegate.swift
@@ -4,11 +4,11 @@ import UIKit
 
 class TextViewStubAttachmentDelegate: TextViewAttachmentDelegate, TextViewAttachmentImageProvider {
 
-    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) -> UIImage {
-        return placeholderImage(for: attachment)
+    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) {
+        // NO OP!
     }
 
-    func textView(_ textView: TextView, placeholderForAttachment attachment: NSTextAttachment) -> UIImage {
+    func textView(_ textView: TextView, placeholderFor attachment: NSTextAttachment) -> UIImage {
         return placeholderImage(for: attachment)
     }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -994,14 +994,13 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
 
 extension EditorDemoController: TextViewAttachmentDelegate {
 
-    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) -> UIImage {
+    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) {
 
-        let task = URLSession.shared.dataTask(with: url, completionHandler: { (data, urlResponse, error) in
+        let task = URLSession.shared.dataTask(with: url, completionHandler: { (data, _, error) in
             DispatchQueue.main.async(execute: {
-                    guard
-                        error == nil,
+                    guard error == nil,
                         let data = data,
-                        let image = UIImage(data: data, scale:UIScreen.main.scale)
+                        let image = UIImage(data: data, scale: UIScreen.main.scale)
                     else {
                         failure()
                         return
@@ -1010,11 +1009,9 @@ extension EditorDemoController: TextViewAttachmentDelegate {
             })
         }) 
         task.resume()
-
-        return placeholderImage(for: attachment)
     }
 
-    func textView(_ textView: TextView, placeholderForAttachment attachment: NSTextAttachment) -> UIImage {
+    func textView(_ textView: TextView, placeholderFor attachment: NSTextAttachment) -> UIImage {
         return placeholderImage(for: attachment)
     }
 
@@ -1028,7 +1025,6 @@ extension EditorDemoController: TextViewAttachmentDelegate {
             placeholderImage = Gridicon.iconOfType(.video, withSize: imageSize)
         default:
             placeholderImage = Gridicon.iconOfType(.attachment, withSize: imageSize)
-
         }
 
         return placeholderImage


### PR DESCRIPTION
### Description:
This is the first PR in a series of (upcoming) Attachment-Y updates. We're doing a bit of a cleanup in the `TextViewAttachmentDelegate`:

- The method `textView:attachment:imageAtURL:onSuccess:onFailure:` was returning an *image placeholder*
- We also had a specific method to retrieve the placeholder: `textView:placeholderForAttachment`

The `-> UIImage` placeholder has been removed from the first method, and thus, we're routing all of the placeholder-Y requirements via it's specific method.

### Testing:
- Ensure the Unit Tests run correctly
- Verify that the Editor Demo properly displays the Video / Image placeholders

cc @diegoreymendez @SergioEstevao 
Thanks in advance!