### PR TITLE
Fixing Regular Attachment's Touch Detection (Non Media!)

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1050,22 +1050,19 @@ open class TextView: UITextView {
         bounds.origin.y += textContainerInset.top
 
         // Let's check if we have media attachment in place
-        var mediaBounds: CGRect = .zero
-        if let mediaAttachment = attachment as? MediaAttachment {
-            mediaBounds = mediaAttachment.mediaBounds(forBounds: bounds)
+        guard let mediaAttachment = attachment as? MediaAttachment else {
+            return bounds.contains(point) ? attachment : nil
         }
 
         // Correct the bounds taking in account the dimesion of the media image being used
+        let mediaBounds = mediaAttachment.mediaBounds(forBounds: bounds)
+
         bounds.origin.x += mediaBounds.origin.x
         bounds.origin.y += mediaBounds.origin.y
         bounds.size.width = mediaBounds.size.width
         bounds.size.height = mediaBounds.size.height
 
-        if bounds.contains(point) {
-            return attachment
-        }
-
-        return nil
+        return bounds.contains(point) ? attachment : nil
     }
 
     /// Move the selected range to the nearest character of the point specified in the textView


### PR DESCRIPTION
### Details:
Touch Detection for non MediaAttachment's is broken (since `attachmentAtPoint` is overriding the attachment's width/height with zero, and thus, incorrectly returning nil). In this brief PR we're patching this behavior!

Fixes #619

### To test:
1. Launch the empty editor
2. Switch to HTML Edition
3. Enter `<table>Here</table>`
4. Switch to Rich Mode
5. Press over the `[TABLE]` attachment

As a result, the Unknown HTML Editor should show up onscreen.

Needs Review: @SergioEstevao 

