### PR TITLE
Attachments: Interface Cleanup

### DIFF
--- a/Aztec/Classes/TextKit/HTMLAttachment.swift
+++ b/Aztec/Classes/TextKit/HTMLAttachment.swift
@@ -26,7 +26,7 @@ open class HTMLAttachment: NSTextAttachment {
     ///
     open var rawHTML: String = "" {
         didSet {
-            glyphImage = nil
+            rootTagName = extractRootTagName(from: rawHTML)
         }
     }
 
@@ -48,6 +48,16 @@ open class HTMLAttachment: NSTextAttachment {
 
         self.rootTagName = rootTagName
         self.rawHTML = rawHTML
+    }
+
+
+    /// Extracts the root tag name from a given HTML string
+    ///
+    private func extractRootTagName(from html: String) -> String {
+        let root = InHTMLConverter().convert(html)
+        let firstChildren = root.children.first
+
+        return firstChildren?.name ?? NSLocalizedString("Unknown", comment: "Unknown Tag Name")
     }
 
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -268,38 +268,6 @@ open class TextStorage: NSTextStorage {
         return foundAttachment
     }
 
-
-    /// Updates the attachment attributes to the values provided.
-    ///
-    /// - Parameters:
-    ///   - attachment: the attachment to update
-    ///   - alignment: the alignment value
-    ///   - size: the size to use
-    ///   - url: the image URL for the image
-    ///
-    func update(attachment: ImageAttachment,
-                alignment: ImageAttachment.Alignment,
-                size: ImageAttachment.Size,
-                url: URL) {
-        attachment.alignment = alignment
-        attachment.size = size
-        attachment.url = url
-    }
-
-    /// Updates the specified HTMLAttachment with new HTML contents
-    ///
-    func update(attachment: HTMLAttachment, html: String) {
-        guard let range = range(for: attachment) else {
-            assertionFailure("Couldn't determine the range for an Attachment")
-            return
-        }
-
-        attachment.rawHTML = html
-
-        let stringWithAttachment = NSAttributedString(attachment: attachment)
-        replaceCharacters(in: range, with: stringWithAttachment)
-    }
-
     /// Return the range of an attachment with the specified identifier if any
     ///
     /// - Parameter attachmentID: the id of the attachment

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1181,48 +1181,12 @@ open class TextView: UITextView {
 
     // MARK: - Attachments
 
-    /// Updates the attachment properties to the new values
-    ///
-    /// - Parameters:
-    ///     - attachment: the attachment to update
-    ///     - alignment: the alignment value
-    ///     - size: the size value
-    ///     - url: the attachment url
-    ///
-    open func update(attachment: ImageAttachment,
-                     alignment: ImageAttachment.Alignment,
-                     size: ImageAttachment.Size,
-                     url: URL) {
-        storage.update(attachment: attachment, alignment: alignment, size: size, url: url)
-        layoutManager.invalidateLayout(for: attachment)
-        layoutManager.ensureLayoutForContainers()
-        delegate?.textViewDidChange?(self)
-    }
-
-    open func update(attachment: VideoAttachment) {        
-        layoutManager.invalidateLayout(for: attachment)
-        layoutManager.ensureLayoutForContainers()
-        delegate?.textViewDidChange?(self)
-    }
-
-
-    /// Updates the Attachment's HTML contents to the new specified value.
-    ///
-    /// - Parameters:
-    ///     - attachment: The attachment to be updated
-    ///     - html: New *VALID* HTML to be set
-    ///
-    open func update(attachment: HTMLAttachment, html: String) {
-        storage.update(attachment: attachment, html: html)
-        delegate?.textViewDidChange?(self)
-    }
-
     /// Invalidates the layout of the attachment and marks it to be refresh on the next update
     ///
     /// - Parameters:
     ///   - attachment: the attachment to update
     ///
-    open func refreshLayout(for attachment: MediaAttachment) {
+    open func refreshLayout(for attachment: NSTextAttachment) {
         layoutManager.invalidateLayout(for: attachment)
         layoutManager.ensureLayoutForContainers()
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1190,7 +1190,7 @@ open class TextView: UITextView {
     /// - Parameters:
     ///   - attachment: the attachment to update
     ///
-    open func edited(_ attachment: NSTextAttachment) {
+    open func refresh(_ attachment: NSTextAttachment) {
         guard let range = storage.range(for: attachment) else {
             return
         }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1179,16 +1179,23 @@ open class TextView: UITextView {
         return max(0, index - 1)
     }
 
+
     // MARK: - Attachments
 
-    /// Invalidates the layout of the attachment and marks it to be refresh on the next update
+    /// Invalidates the layout of the attachment and marks it to be refresh on the next update cycle.
+    /// This method should be called after editing any kind of *Attachment, since, whenever its bounds
+    /// do change, we'll need to perform a layout pass. Otherwise, TextKit's inner map won't match with
+    /// what's actually onscreen.
     ///
     /// - Parameters:
     ///   - attachment: the attachment to update
     ///
-    open func refreshLayout(for attachment: NSTextAttachment) {
-        layoutManager.invalidateLayout(for: attachment)
-        layoutManager.ensureLayoutForContainers()
+    open func edited(_ attachment: NSTextAttachment) {
+        guard let range = storage.range(for: attachment) else {
+            return
+        }
+
+        storage.edited(.editedAttributes, range: range, changeInLength: 0)
     }
 
 

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -142,6 +142,9 @@ class TextStorageTests: XCTestCase
         XCTAssertEqual(html, "<img src=\"https://wordpress.com\">")
     }
 
+    /// Verifies that any edition performed on ImageAttachment attributes is properly serialized back during
+    /// the HTML generation step.
+    ///
     func testEditingImageAttachmentAfterItHasBeenInsertedCausesItsAttributesToProperlySerialize() {
         let storage = TextStorage()
         let mockDelegate = MockAttachmentsDelegate()
@@ -160,6 +163,9 @@ class TextStorageTests: XCTestCase
         XCTAssertEqual(html, "<img src=\"https://wordpress.com\" class=\"alignleft size-medium\">")
     }
 
+    /// Verifies that any edition performed on HTMLttachment attributes is properly serialized back during
+    /// the HTML generation step.
+    ///
     func testUpdatingHtmlAttachmentEffectivelyUpdatesTheDom() {
         let initialHTML = "<unknown>html</unknown>"
         let updatedHTML = "<updated>NEW HTML</updated>"

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -157,7 +157,7 @@ class TextStorageTests: XCTestCase
         XCTAssertEqual(html, "<img src=\"https://wordpress.com\" class=\"alignleft size-medium\">")
     }
 
-    func testUpdateHtmlAttachmentEffectivelyUpdatesTheDom() {
+    func testUpdatingHtmlAttachmentEffectivelyUpdatesTheDom() {
         let initialHTML = "<unknown>html</unknown>"
         let updatedHTML = "<updated>NEW HTML</updated>"
 
@@ -176,7 +176,7 @@ class TextStorageTests: XCTestCase
 
         // Update
         XCTAssertNotNil(theAttachment)
-        storage.update(attachment: theAttachment, html: updatedHTML)
+        theAttachment.rawHTML = updatedHTML
 
         // Verify
         XCTAssertEqual(storage.getHTML(), updatedHTML)

--- a/AztecTests/TextStorageTests.swift
+++ b/AztecTests/TextStorageTests.swift
@@ -142,17 +142,20 @@ class TextStorageTests: XCTestCase
         XCTAssertEqual(html, "<img src=\"https://wordpress.com\">")
     }
 
-    func testUpdateImage() {
+    func testEditingImageAttachmentAfterItHasBeenInsertedCausesItsAttributesToProperlySerialize() {
         let storage = TextStorage()
         let mockDelegate = MockAttachmentsDelegate()
         storage.attachmentsDelegate = mockDelegate
+
         let url = URL(string: "https://wordpress.com")!
         let attachment = ImageAttachment(identifier: UUID().uuidString, url: url)
+
         storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
 
-        storage.update(attachment: attachment, alignment: .left, size: .medium, url: url)
-        let html = storage.getHTML()
+        attachment.alignment = .left
+        attachment.size = .medium
 
+        let html = storage.getHTML()
         XCTAssertEqual(attachment.url, url)
         XCTAssertEqual(html, "<img src=\"https://wordpress.com\" class=\"alignleft size-medium\">")
     }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1396,7 +1396,7 @@ class TextViewTests: XCTestCase {
         }
 
         videoAttachment.srcURL = URL(string:"newVideo.mp4")!
-        textView.edited(videoAttachment)
+        textView.refresh(videoAttachment)
 
         XCTAssertEqual(textView.getHTML(), "<video src=\"newVideo.mp4\" poster=\"video.jpg\" alt=\"The video\"></video>")
     }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1389,11 +1389,10 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(textView.getHTML(), "<video src=\"video.mp4\" poster=\"video.jpg\"></video>")
     }
 
-    func testUpdateVideo() {
+    func testEditingVideoAttachmentAttributesCausesAttributesToProperlySerializeBack() {
         let textView = createTextView(withHTML: "<video src=\"video.mp4\" poster=\"video.jpg\" alt=\"The video\"></video>")
         let videoAttachment = textView.storage.mediaAttachments.first! as! VideoAttachment
         videoAttachment.srcURL = URL(string:"newVideo.mp4")!
-        let _ = textView.update(attachment: videoAttachment)
 
         XCTAssertEqual(textView.getHTML(), "<video src=\"newVideo.mp4\" poster=\"video.jpg\" alt=\"The video\"></video>")
     }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1389,6 +1389,9 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(textView.getHTML(), "<video src=\"video.mp4\" poster=\"video.jpg\"></video>")
     }
 
+    /// Verifies that any edition performed on VideoAttachment's srcURL attribute is properly serialized back,
+    /// during the HTML generation step.
+    ///
     func testEditingVideoAttachmentAttributesCausesAttributesToProperlySerializeBack() {
         let textView = createTextView(withHTML: "<video src=\"video.mp4\" poster=\"video.jpg\" alt=\"The video\"></video>")
         guard let videoAttachment = textView.storage.mediaAttachments.first! as? VideoAttachment else {

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1391,8 +1391,13 @@ class TextViewTests: XCTestCase {
 
     func testEditingVideoAttachmentAttributesCausesAttributesToProperlySerializeBack() {
         let textView = createTextView(withHTML: "<video src=\"video.mp4\" poster=\"video.jpg\" alt=\"The video\"></video>")
-        let videoAttachment = textView.storage.mediaAttachments.first! as! VideoAttachment
+        guard let videoAttachment = textView.storage.mediaAttachments.first! as? VideoAttachment else {
+            fatalError()
+            return
+        }
+
         videoAttachment.srcURL = URL(string:"newVideo.mp4")!
+        textView.edited(videoAttachment)
 
         XCTAssertEqual(textView.getHTML(), "<video src=\"newVideo.mp4\" poster=\"video.jpg\" alt=\"The video\"></video>")
     }

--- a/AztecTests/TextViewTests.swift
+++ b/AztecTests/TextViewTests.swift
@@ -1393,7 +1393,6 @@ class TextViewTests: XCTestCase {
         let textView = createTextView(withHTML: "<video src=\"video.mp4\" poster=\"video.jpg\" alt=\"The video\"></video>")
         guard let videoAttachment = textView.storage.mediaAttachments.first! as? VideoAttachment else {
             fatalError()
-            return
         }
 
         videoAttachment.srcURL = URL(string:"newVideo.mp4")!

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1330,7 +1330,7 @@ private extension EditorDemoController
 
             attachment.alignment = alignment
             attachment.size = size
-            attachment».url = url
+            attachment.url = url
 
             self.richTextView.edited(attachment)
         }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1147,7 +1147,8 @@ private extension EditorDemoController {
     func displayUnknownHtmlEditor(for attachment: HTMLAttachment) {
         let targetVC = UnknownEditorViewController(attachment: attachment)
         targetVC.onDidSave = { [weak self] html in
-            self?.richTextView.update(attachment: attachment, html: html)
+            attachment.rawHTML = html
+            self?.richTextView.refreshLayout(for: attachment)
             self?.dismiss(animated: true, completion: nil)
         }
 
@@ -1258,7 +1259,7 @@ private extension EditorDemoController
             attachment.progress = nil
             if let videoAttachment = attachment as? VideoAttachment, let videoURL = progress.userInfo[MediaProgressKey.videoURL] as? URL {
                 videoAttachment.srcURL = videoURL                
-                richTextView.update(attachment: videoAttachment)
+                richTextView.refreshLayout(for: videoAttachment)
             }
         }
         richTextView.refreshLayout(for: attachment)
@@ -1322,18 +1323,16 @@ private extension EditorDemoController
     func displayDetailsForAttachment(_ attachment: ImageAttachment, position:CGPoint) {
         let detailsViewController = AttachmentDetailsViewController.controller()
         detailsViewController.attachment = attachment
-        detailsViewController.onUpdate = { [weak self] (alignment, size, url, alt) in
-
-            guard let strongSelf = self else {
-                return
-            }
+        detailsViewController.onUpdate = { (alignment, size, url, alt) in
             if let alt = alt {
                 attachment.extraAttributes["alt"] = alt
             }
-            strongSelf.richTextView.update(attachment: attachment,
-                                           alignment: alignment,
-                                           size: size,
-                                           url: url)
+
+            attachment.alignment = alignment
+            attachment.size = size
+            attachment.url = url
+
+            self.richTextView.refreshLayout(for: attachment)
         }
 
         let navigationController = UINavigationController(rootViewController: detailsViewController)        

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1068,7 +1068,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
                 if selectedAttachment is ImageAttachment {
                     selectedAttachment.overlayImage = nil
                 }
-                richTextView.refreshLayout(for: selectedAttachment)
+                richTextView.edited(selectedAttachment)
             }
 
             // and mark the newly tapped attachment
@@ -1077,7 +1077,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
             if attachment.overlayImage == nil {
                 attachment.overlayImage = Gridicon.iconOfType(.pencil).withRenderingMode(.alwaysTemplate)
             }
-            richTextView.refreshLayout(for: attachment)
+            richTextView.edited(attachment)
             currentSelectedAttachment = attachment
         }
     }
@@ -1086,7 +1086,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
         currentSelectedAttachment = nil
         if let mediaAttachment = attachment as? MediaAttachment {
             mediaAttachment.message = nil
-            richTextView.refreshLayout(for: mediaAttachment)
+            richTextView.edited(mediaAttachment)
         }
     }
 
@@ -1148,7 +1148,8 @@ private extension EditorDemoController {
         let targetVC = UnknownEditorViewController(attachment: attachment)
         targetVC.onDidSave = { [weak self] html in
             attachment.rawHTML = html
-            self?.richTextView.refreshLayout(for: attachment)
+            self?.richTextView.edited(attachment)
+
             self?.dismiss(animated: true, completion: nil)
         }
 
@@ -1258,11 +1259,10 @@ private extension EditorDemoController
             timer.invalidate()
             attachment.progress = nil
             if let videoAttachment = attachment as? VideoAttachment, let videoURL = progress.userInfo[MediaProgressKey.videoURL] as? URL {
-                videoAttachment.srcURL = videoURL                
-                richTextView.refreshLayout(for: videoAttachment)
+                videoAttachment.srcURL = videoURL
             }
         }
-        richTextView.refreshLayout(for: attachment)
+        richTextView.edited(attachment)
     }
 
     var mediaMessageAttributes: [String: Any] {
@@ -1330,9 +1330,9 @@ private extension EditorDemoController
 
             attachment.alignment = alignment
             attachment.size = size
-            attachment.url = url
+            attachment».url = url
 
-            self.richTextView.refreshLayout(for: attachment)
+            self.richTextView.edited(attachment)
         }
 
         let navigationController = UINavigationController(rootViewController: detailsViewController)        

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1068,7 +1068,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
                 if selectedAttachment is ImageAttachment {
                     selectedAttachment.overlayImage = nil
                 }
-                richTextView.edited(selectedAttachment)
+                richTextView.refresh(selectedAttachment)
             }
 
             // and mark the newly tapped attachment
@@ -1077,7 +1077,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
             if attachment.overlayImage == nil {
                 attachment.overlayImage = Gridicon.iconOfType(.pencil).withRenderingMode(.alwaysTemplate)
             }
-            richTextView.edited(attachment)
+            richTextView.refresh(attachment)
             currentSelectedAttachment = attachment
         }
     }
@@ -1086,7 +1086,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
         currentSelectedAttachment = nil
         if let mediaAttachment = attachment as? MediaAttachment {
             mediaAttachment.message = nil
-            richTextView.edited(mediaAttachment)
+            richTextView.refresh(mediaAttachment)
         }
     }
 
@@ -1148,7 +1148,7 @@ private extension EditorDemoController {
         let targetVC = UnknownEditorViewController(attachment: attachment)
         targetVC.onDidSave = { [weak self] html in
             attachment.rawHTML = html
-            self?.richTextView.edited(attachment)
+            self?.richTextView.refresh(attachment)
 
             self?.dismiss(animated: true, completion: nil)
         }
@@ -1262,7 +1262,7 @@ private extension EditorDemoController
                 videoAttachment.srcURL = videoURL
             }
         }
-        richTextView.edited(attachment)
+        richTextView.refresh(attachment)
     }
 
     var mediaMessageAttributes: [String: Any] {
@@ -1332,7 +1332,7 @@ private extension EditorDemoController
             attachment.size = size
             attachment.url = url
 
-            self.richTextView.edited(attachment)
+            self.richTextView.refresh(attachment)
         }
 
         let navigationController = UINavigationController(rootViewController: detailsViewController)        


### PR DESCRIPTION
### Details:
In this PR we're simplifying the Attachments API. Attachment Edition + Undo is coming up in another PR, for simplicity's sake.


### Scenario: HTML Attachment
1. Launch the Empty Editor
2. Switch to HTML Mode
3. Enter `Test <table>Something</table> Test`
4. Switch to Rich Mode
5. Press the `[TABLE]` legend
6. Verify that the Unknown HTML Editor is onscreen
7. Update the HTML so it reads as `<testtest>Something</testtest>`
8. Verify that the document properly displays `[TESTTEST]` instead of `TABLE`.

### Scenario: Image Attachment
1. Launch the Empty Editor
2. Insert an image
3. Press over the image and edit it's properties
4. Verify the image properly reflects the new properties

