### PR TITLE
Fix: Missing Cursor after Inserting Blockquote

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -887,9 +887,13 @@ open class TextView: UITextView {
         let delay = 0.05
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             let pristine = self.selectedRange
-            let updated = NSMakeRange(max(pristine.location - 1, 0), 0)
+            var location = max(pristine.location - 1, 0)
+            if pristine.location == location {
+                location = min(pristine.location + 1, self.storage.length)
+            }
+
             let beforeTypingAttributes = self.typingAttributes
-            self.selectedRange = updated
+            self.selectedRange = NSMakeRange(location, 0)
             self.selectedRange = pristine
             self.typingAttributes = beforeTypingAttributes
         }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -883,6 +883,9 @@ open class TextView: UITextView {
     /// Force the SDK to Redraw the cursor, asynchronously, after a delay. This method was meant as a workaround
     /// for Issue #144: the Caret might end up redrawn below the Blockquote's custom background.
     ///
+    /// Workaround: By changing the selectedRange back and forth, we're forcing UITextView to effectively re-render
+    /// the caret.
+    ///
     func forceRedrawCursorAfterDelay() {
         let delay = 0.05
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -889,14 +889,23 @@ open class TextView: UITextView {
     func forceRedrawCursorAfterDelay() {
         let delay = 0.05
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            let pristine = self.selectedRange
-            var location = max(pristine.location - 1, 0)
-            if pristine.location == location {
-                location = min(pristine.location + 1, self.storage.length)
-            }
-
             let beforeTypingAttributes = self.typingAttributes
+            let pristine = self.selectedRange
+            let maxLength = self.storage.length
+
+            // Determine the Temporary Shift Location:
+            // - If we're at the end of the document, we'll move the caret minus one character
+            // - Otherwise, we'll move the caret plus one position
+            //
+            let delta = pristine.location == maxLength ? -1 : 1
+            let location = min(max(pristine.location + delta, 0), maxLength)
+
+            // Shift the SelectedRange to a nearby position: *FORCE* cursor redraw
+            //
             self.selectedRange = NSMakeRange(location, 0)
+
+            // Finally, restore the original SelectedRange and the typingAttributes we had before beginning
+            //
             self.selectedRange = pristine
             self.typingAttributes = beforeTypingAttributes
         }


### PR DESCRIPTION
Fixes #440

### To test:
1. Launch the empty editor
2. Insert a Blockquote
3. Verify that the Cursor is visible

cc @diegoreymendez 
Thanks in advance!
