### PR TITLE
Attachments: Undo Support

### DIFF
--- a/Aztec/Classes/TextKit/HTMLAttachment.swift
+++ b/Aztec/Classes/TextKit/HTMLAttachment.swift
@@ -71,6 +71,7 @@ open class HTMLAttachment: NSTextAttachment {
         return outParser.convert(inNode)
     }
 
+
     // MARK: - NSCoder Methods
 
     open override func encode(with aCoder: NSCoder) {
@@ -79,7 +80,6 @@ open class HTMLAttachment: NSTextAttachment {
         aCoder.encode(rootTagName, forKey: Keys.rootTagName)
         aCoder.encode(rawHTML, forKey: Keys.rawHTML)
     }
-
 
 
     // MARK: - NSTextAttachmentContainer
@@ -101,6 +101,19 @@ open class HTMLAttachment: NSTextAttachment {
         }
 
         return bounds
+    }
+}
+
+
+// MARK: - NSCopying
+//
+extension HTMLAttachment: NSCopying {
+
+    public func copy(with zone: NSZone? = nil) -> Any {
+        let clone = HTMLAttachment()
+        clone.rawHTML = rawHTML
+        clone.delegate = delegate
+        return clone
     }
 }
 

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -3,8 +3,8 @@ import UIKit
 
 /// Custom text attachment.
 ///
-open class ImageAttachment: MediaAttachment
-{
+open class ImageAttachment: MediaAttachment {
+
     /// Attachment Alignment
     ///
     open var alignment: Alignment = .center {
@@ -25,6 +25,7 @@ open class ImageAttachment: MediaAttachment
         }
     }
 
+
     /// Creates a new attachment
     ///
     /// - Parameters:
@@ -34,6 +35,7 @@ open class ImageAttachment: MediaAttachment
     required public init(identifier: String, url: URL? = nil) {
         super.init(identifier: identifier, url: url)
     }
+
 
     /// Required Initializer
     ///
@@ -53,6 +55,9 @@ open class ImageAttachment: MediaAttachment
             }
         }
     }
+
+
+    // MARK: - Overriden Methods
 
     override open func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
@@ -105,11 +110,27 @@ open class ImageAttachment: MediaAttachment
 }
 
 
+// MARK: - NSCopying
+//
+extension ImageAttachment {
 
-/// Nested Types
-///
-extension ImageAttachment
-{
+    override public func copy(with zone: NSZone? = nil) -> Any {
+        guard let clone = super.copy() as? ImageAttachment else {
+            fatalError()
+        }
+
+        clone.size = size
+        clone.alignment = alignment
+
+        return clone
+    }
+}
+
+
+// MARL: - Nested Types
+//
+extension ImageAttachment {
+
     /// Alignment
     ///
     public enum Alignment: Int {

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -115,7 +115,7 @@ open class ImageAttachment: MediaAttachment {
 extension ImageAttachment {
 
     override public func copy(with zone: NSZone? = nil) -> Any {
-        guard let clone = super.copy() as? ImageAttachment else {
+        guard let clone = super.copy(with: nil) as? ImageAttachment else {
             fatalError()
         }
 

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -369,6 +369,7 @@ extension MediaAttachment: NSCopying {
 
     public func copy(with zone: NSZone? = nil) -> Any {
         let clone = type(of: self).init(identifier: identifier, url: url)
+        clone.image = image
         clone.extraAttributes = extraAttributes
         clone.url = url
         clone.lastRequestedURL = lastRequestedURL

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -361,3 +361,19 @@ open class MediaAttachment: NSTextAttachment {
         textContainer?.layoutManager?.invalidateLayout(for: self)
     }
 }
+
+
+// MARK: - NSCopying
+//
+extension MediaAttachment: NSCopying {
+
+    public func copy(with zone: NSZone? = nil) -> Any {
+        let clone = type(of: self).init(identifier: identifier, url: url)
+        clone.extraAttributes = extraAttributes
+        clone.url = url
+        clone.lastRequestedURL = lastRequestedURL
+        clone.imageMargin = imageMargin
+        clone.delegate = delegate
+        return clone
+    }
+}

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1199,6 +1199,21 @@ open class TextView: UITextView {
         storage.edited(.editedAttributes, range: range, changeInLength: 0)
     }
 
+    ///
+    ///
+    open func edit<T>(_ attachment: T, block: (T) -> ()) where T:NSTextAttachment {
+        guard let range = storage.range(for: attachment), let copy = attachment.copy() as? T else {
+            return
+        }
+
+        block(copy)
+
+        performUndoable(at: range) {
+            storage.setAttributes([NSAttachmentAttributeName: copy], range: range)
+            return range
+        }
+    }
+
 
     // MARK: - More
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1202,7 +1202,11 @@ open class TextView: UITextView {
     ///
     ///
     open func edit<T>(_ attachment: T, block: (T) -> ()) where T:NSTextAttachment {
-        guard let range = storage.range(for: attachment), let copy = attachment.copy() as? T else {
+        guard let copying = attachment as? NSCopying else {
+            fatalError("Attachments must implement NSCopying in order to quality for Undo Support")
+        }
+
+        guard let range = storage.range(for: attachment), let copy = copying.copy() as? T else {
             return
         }
 

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -68,6 +68,8 @@ open class VideoAttachment: MediaAttachment {
     fileprivate enum EncodeKeys: String {
         case srcURL
     }
+
+
     // MARK: - Origin calculation
 
     override func xPosition(forContainerWidth containerWidth: CGFloat) -> CGFloat {
@@ -93,5 +95,22 @@ open class VideoAttachment: MediaAttachment {
         } else {
             return 0
         }
+    }
+}
+
+
+// MARK: - NSCopying
+//
+extension VideoAttachment {
+
+    override public func copy(with zone: NSZone? = nil) -> Any {
+        guard let clone = super.copy() as? VideoAttachment else {
+            fatalError()
+        }
+
+        clone.srcURL = srcURL
+        clone.posterURL = posterURL
+
+        return clone
     }
 }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1147,8 +1147,9 @@ private extension EditorDemoController {
     func displayUnknownHtmlEditor(for attachment: HTMLAttachment) {
         let targetVC = UnknownEditorViewController(attachment: attachment)
         targetVC.onDidSave = { [weak self] html in
-            attachment.rawHTML = html
-            self?.richTextView.refresh(attachment)
+            self?.richTextView.edit(attachment) { updated in
+                updated.rawHTML = html
+            }
 
             self?.dismiss(animated: true, completion: nil)
         }
@@ -1324,15 +1325,15 @@ private extension EditorDemoController
         let detailsViewController = AttachmentDetailsViewController.controller()
         detailsViewController.attachment = attachment
         detailsViewController.onUpdate = { (alignment, size, url, alt) in
-            if let alt = alt {
-                attachment.extraAttributes["alt"] = alt
+            self.richTextView.edit(attachment) { updated in
+                if let alt = alt {
+                    updated.extraAttributes["alt"] = alt
+                }
+
+                updated.alignment = alignment
+                updated.size = size
+                updated.url = url
             }
-
-            attachment.alignment = alignment
-            attachment.size = size
-            attachment.url = url
-
-            self.richTextView.refresh(attachment)
         }
 
         let navigationController = UINavigationController(rootViewController: detailsViewController)        


### PR DESCRIPTION
### Details:
In this PR we're implementing a (hopefully) cool API that will allow us to edit attachments, while getting Undo Support + Re-Layout after edition, for free.

```
textView.edit(attachment) { updated in
   updated.property = newValue
}
```

Needs Review: @SergioEstevao 
Thanks in advance!!

Closes #630

--

### Testing: HTMLAttachment
1. Launch the Editor Demo (with Sample Text)
2. Scroll all the way down
3. Tap and edit the `[TABLE]` Attachment
4. Make sure the `[TABLE]` tag gets renamed, if you happen to change the root tag
5. Verify the generated HTML looks as expected.
6. Perform the Shake Gesture and hit Undo
7. Verify everything got to it's former state

### Testing: ImageAttachment
1. Launch the Editor Demo (with Sample Text)
2. Edit few Image Properties (alignment / size)
3. Verify the generated HTML looks as expected
4. Peform the Shake Gesture and hit Undo
5. Verify everything got to it's former state
