### PR TITLE
Only strip non-standard attributes.

### DIFF
--- a/Aztec/Classes/Extensions/NSAttributedString+Strip.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Strip.swift
@@ -33,4 +33,24 @@ extension NSAttributedString {
     private func isObject<T>(_ object: Any, kindOf type: T) -> Bool {
         return type(of: object) is T
     }
+
+    /// Removes attributes that not the standard attribute type of NSAttributedString
+    ///
+    func stripNonStandardAttributes() -> NSAttributedString {
+        guard let clean = mutableCopy() as? NSMutableAttributedString else {
+            fatalError()
+        }
+
+        let range = clean.rangeOfEntireString
+        clean.enumerateAttributes(in: range, options: []) { (attributes, range, _) in
+            for (key, _) in attributes {
+                if !key.hasPrefix("NS") {
+                    clean.removeAttribute(key, range: range)
+                }
+            }
+        }
+
+        return clean
+    }
+    
 }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -239,7 +239,7 @@ open class TextView: UITextView {
 
     open override func cut(_ sender: Any?) {
         // FIXME: This is a temporary workaround for Issue #626
-        let substring = storage.attributedSubstring(from: selectedRange).stripAttributes(of: unsupportedCopyAttributes)
+        let substring = storage.attributedSubstring(from: selectedRange).stripNonStandardAttributes()
         let data = substring.archivedData()
         super.cut(sender)
 
@@ -248,7 +248,7 @@ open class TextView: UITextView {
 
     open override func copy(_ sender: Any?) {
         // FIXME: This is a temporary workaround for Issue #626
-        let substring = storage.attributedSubstring(from: selectedRange).stripAttributes(of: unsupportedCopyAttributes)
+        let substring = storage.attributedSubstring(from: selectedRange).stripNonStandardAttributes()
         let data = substring.archivedData()
         super.copy(sender)
 


### PR DESCRIPTION
Fixes #638

The current strip method is not working correctly in the sense that it strips all attributes and not only the specified in the kinds parameter.
I tried to fix that method but it looks there is no proper way to find if type is the type that belongs to the array.

This call `return self.isObject(value, kindOf: kind)`

for this method

```
private func isObject<T>(_ object: Any, kindOf type: T) -> Bool {
        return type(of: object) is T
    }
```

is testing that the value is of type Any.Type and because all classes are, they are all stripped.

In replacement I added a method that simple checks the name of the attributes is prefixed by `NS`

This method is a temporary fix, until we actually encode properly all our custom attribute classes.

To test:
 - On the demo app
 - Select a segment of text
 - Copy or Cut it
 - Paste across another part of the document
 - Check that styles and attachment are copied through
