### PR TITLE
Fix: Stop encoding non-latin characters

### DIFF
--- a/Aztec/Classes/Extensions/String+HTML.swift
+++ b/Aztec/Classes/Extensions/String+HTML.swift
@@ -19,11 +19,25 @@ extension String {
 
     /// Escapes the following HTML entities: [&, <, >, ', "]
     ///
-    private func escapeHtmlNamedEntities() -> String {
-        return replacingOccurrences(of: "&", with: "&amp;")
-                .replacingOccurrences(of: "<", with: "&lt;")
-                .replacingOccurrences(of: ">", with: "&gt;")
-                .replacingOccurrences(of: "\"", with: "&quot;")
-                .replacingOccurrences(of: "\'", with: "&apos;")
+    public func escapeHtmlNamedEntities() -> String {
+        return entities.reduce(self) { (out, entity: Entity) in
+            return out.replacingOccurrences(of: entity.raw, with: entity.encoded)
+        }
+    }
+
+    /// Entity Typealias Helper
+    ///
+    private typealias Entity = (raw: String, encoded: String)
+
+    /// Named HTML Entities
+    ///
+    private var entities: [Entity] {
+        return [
+            ("&", "&amp;"),
+            ("<", "&lt;"),
+            (">", "&gt;"),
+            ("\"", "&quot;"),
+            ("\'", "&apos;")
+        ]
     }
 }

--- a/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/Out/OutHTMLConverter.swift
@@ -93,7 +93,7 @@ private extension OutHTMLConverter {
     /// Serializes a TextNode into it's HTML String Representation
     ///
     private func convert(text node: TextNode) -> String {
-        return node.text().encodeHtmlEntities()
+        return node.text().escapeHtmlNamedEntities()
     }
 }
 

--- a/AztecTests/Extensions/StringHTMLTests.swift
+++ b/AztecTests/Extensions/StringHTMLTests.swift
@@ -43,4 +43,13 @@ class StringHTMLTests: XCTestCase {
 
         XCTAssertEqual(original.encodeHtmlEntities(), original)
     }
+
+    /// Verifies that HTML Entities get properly escaped.
+    ///
+    func testEscapeNamedEntitiesEffectivelyEscapedSupportedNamedEntities() {
+        let original = "&<>\"' Some Text Here"
+        let expected = "&amp;&lt;&gt;&quot;&apos; Some Text Here"
+
+        XCTAssertEqual(original.escapeHtmlNamedEntities(), expected)
+    }
 }

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -224,7 +224,7 @@ class TextStorageTests: XCTestCase
 
         let html = storage.getHTML()
 
-        XCTAssertEqual(html, "Hello &#x1F30E;!<blockquote>Apply a blockquote!</blockquote>")
+        XCTAssertEqual(html, "Hello 🌎!<blockquote>Apply a blockquote!</blockquote>")
     }
 
     func testLinkInsert() {

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1590,7 +1590,7 @@ class TextViewTests: XCTestCase {
         let html = "<img src=\"image.jpg\" class=\"wp-image-test\" alt=\"Alt\" title=\"Title\">"
         let textView = createTextView(withHTML: html)
 
-        XCTAssertEqual(textView.getHTML(), html)        
+        XCTAssertEqual(textView.getHTML(), html)
     }
 
     /// This test verifies that copying the Sample HTML Document does not trigger a crash.
@@ -1609,5 +1609,17 @@ class TextViewTests: XCTestCase {
         let textView = createTextViewWithSampleHTML()
         textView.selectedRange = textView.storage.rangeOfEntireString
         textView.cut(nil)
+    }
+
+    /// This test verifies that Japanese Characters do not get hexa encoded anymore, since we actually support UTF8!
+    /// Ref. Issue #632: Stop encoding non-latin characters
+    ///
+    func testJapaneseCharactersWillNotGetEscaped() {
+        let pristineJapanese = "国ドぼゆ九会以つまにの市賛済ツ聞数ナシ私35奨9企め全談ヱマヨワ全竹スレフヨ積済イナ続害ホテ" +
+            "ソト聞長津装げ。16北夢みは殻容ク洋意能緯ざた投記ぐだもみ学徳局みそイし済更離ラレミネ展至察畑しのわぴ。航リむは" +
+            "素希ホソ元不サト国十リ産望イげ地年ニヲネ将広ぴん器学サナチ者一か新米だしず災9識じざい総台男みのちフ。"
+
+        let textView = createTextView(withHTML: pristineJapanese)
+        XCTAssertEqual(textView.getHTML(), pristineJapanese)
     }
 }


### PR DESCRIPTION
Fixes #632

### To test:
1. Run the Unit Tests!
2. Verify that Japanese / Non Latin characters don't get encoded anymore

cc @SergioEstevao 
Thanks in advance sir!!

