### PR TITLE
Fixing Blockquote within Nested List Indentation

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		B5657C151EE99A8600579FE1 /* NSAttributedStringToNodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5657C141EE99A8600579FE1 /* NSAttributedStringToNodes.swift */; };
 		B5657C181EE99AF500579FE1 /* NSAttributedStringToNodesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5657C171EE99AF500579FE1 /* NSAttributedStringToNodesTests.swift */; };
 		B572AC281E817CFE008948C2 /* CommentAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B572AC271E817CFE008948C2 /* CommentAttachment.swift */; };
+		B57534501F267D0B009D4904 /* Array+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B575344F1F267D0B009D4904 /* Array+Helpers.swift */; };
+		B57534521F267D63009D4904 /* ArrayHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57534511F267D63009D4904 /* ArrayHelperTests.swift */; };
 		B57D1C3D1E92C38000EA4B16 /* HTMLAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */; };
 		B59C9F9F1DF74BB80073B1D6 /* UIFont+Traits.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */; };
 		B5A5277C1EF1B44800E7D2FD /* UnsupportedHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A5277B1EF1B44800E7D2FD /* UnsupportedHTML.swift */; };
@@ -204,6 +206,8 @@
 		B5657C141EE99A8600579FE1 /* NSAttributedStringToNodes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAttributedStringToNodes.swift; sourceTree = "<group>"; };
 		B5657C171EE99AF500579FE1 /* NSAttributedStringToNodesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAttributedStringToNodesTests.swift; sourceTree = "<group>"; };
 		B572AC271E817CFE008948C2 /* CommentAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentAttachment.swift; sourceTree = "<group>"; };
+		B575344F1F267D0B009D4904 /* Array+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+Helpers.swift"; sourceTree = "<group>"; };
+		B57534511F267D63009D4904 /* ArrayHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArrayHelperTests.swift; path = Extensions/ArrayHelperTests.swift; sourceTree = "<group>"; };
 		B57D1C3C1E92C38000EA4B16 /* HTMLAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachment.swift; sourceTree = "<group>"; };
 		B59C9F9E1DF74BB80073B1D6 /* UIFont+Traits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Traits.swift"; sourceTree = "<group>"; };
 		B5A5277B1EF1B44800E7D2FD /* UnsupportedHTML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnsupportedHTML.swift; sourceTree = "<group>"; };
@@ -460,6 +464,7 @@
 		599F25241D8BC9A1002871D6 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B575344F1F267D0B009D4904 /* Array+Helpers.swift */,
 				F1C05B981E37F99D007510EA /* Character+Name.swift */,
 				B5F84B601E70595B0089A76C /* NSAttributedString+Analyzers.swift */,
 				FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */,
@@ -729,6 +734,7 @@
 		F18733C61DA0970E005AEB80 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B57534511F267D63009D4904 /* ArrayHelperTests.swift */,
 				B5F84B621E706B720089A76C /* NSAttributedStringAnalyzerTests.swift */,
 				B5BC4FF11DA2D17000614582 /* NSAttributedStringListsTests.swift */,
 				F10BE61B1EA7B1DB002E4625 /* NSAttributedStringReplaceOcurrencesTests.swift */,
@@ -905,6 +911,7 @@
 				B5A99D841EBA073D00DED081 /* HTMLStorage.swift in Sources */,
 				599F25471D8BC9A1002871D6 /* HTMLConstants.swift in Sources */,
 				599F25371D8BC9A1002871D6 /* InAttributeConverter.swift in Sources */,
+				B57534501F267D0B009D4904 /* Array+Helpers.swift in Sources */,
 				599F25531D8BC9A1002871D6 /* TextStorage.swift in Sources */,
 				B572AC281E817CFE008948C2 /* CommentAttachment.swift in Sources */,
 				F1FA0E861E6EF514009D98EE /* Node.swift in Sources */,
@@ -1007,6 +1014,7 @@
 				59FEA0751D8BDFA700D138DF /* NodeTests.swift in Sources */,
 				59FEA0781D8BDFA700D138DF /* HTMLToAttributedStringTests.swift in Sources */,
 				B5375F491EC2569500F5D7EC /* StringHTMLTests.swift in Sources */,
+				B57534521F267D63009D4904 /* ArrayHelperTests.swift in Sources */,
 				F14665451EA7C230008DE2B8 /* NSMutableAttributedStringReplaceOcurrencesTests.swift in Sources */,
 				F18733C81DA09737005AEB80 /* NSRangeComparisonTests.swift in Sources */,
 				B5E607331DA56EC700C8A389 /* TextListFormatterTests.swift in Sources */,

--- a/Aztec/Classes/Extensions/Array+Helpers.swift
+++ b/Aztec/Classes/Extensions/Array+Helpers.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+
+// MARK: - Array Helpers
+//
+extension Array {
+
+    /// Returns the last Element Index within the current collection, that satisfies the specified closure.
+    ///
+    func lastIndex(where block: ((Element) -> Bool)) -> Int? {
+        for (index, element) in enumerated().reversed() where block(element) {
+            return index
+        }
+
+        return nil
+    }
+}

--- a/Aztec/Classes/Formatters/Implementations/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/BlockquoteFormatter.swift
@@ -26,7 +26,7 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
 
-        newParagraphStyle.add(property: Blockquote(with: representation))
+        newParagraphStyle.append(property: Blockquote(with: representation))
 
         var resultingAttributes = attributes
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle

--- a/Aztec/Classes/Formatters/Implementations/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/BlockquoteFormatter.swift
@@ -26,7 +26,7 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
 
-        newParagraphStyle.append(property: Blockquote(with: representation))
+        newParagraphStyle.appendProperty(Blockquote(with: representation))
 
         var resultingAttributes = attributes
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle

--- a/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
@@ -27,7 +27,7 @@ class HTMLParagraphFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
 
-        newParagraphStyle.add(property: HTMLParagraph(with: representation))
+        newParagraphStyle.append(property: HTMLParagraph(with: representation))
 
         var resultingAttributes = attributes
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle

--- a/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
@@ -27,7 +27,7 @@ class HTMLParagraphFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
 
-        newParagraphStyle.append(property: HTMLParagraph(with: representation))
+        newParagraphStyle.appendProperty(HTMLParagraph(with: representation))
 
         var resultingAttributes = attributes
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle

--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -33,8 +33,8 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
 
-        if (newParagraphStyle.headerLevel == 0) {
-            newParagraphStyle.add(property: Header(level: headerLevel, with: representation))
+        if newParagraphStyle.headerLevel == 0 {
+            newParagraphStyle.append(property: Header(level: headerLevel, with: representation))
         } else {
             newParagraphStyle.replaceProperty(ofType: Header.self, with: Header(level: headerLevel))
         }

--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -34,7 +34,7 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         }
 
         if newParagraphStyle.headerLevel == 0 {
-            newParagraphStyle.append(property: Header(level: headerLevel, with: representation))
+            newParagraphStyle.appendProperty(Header(level: headerLevel, with: representation))
         } else {
             newParagraphStyle.replaceProperty(ofType: Header.self, with: Header(level: headerLevel))
         }

--- a/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
@@ -29,7 +29,7 @@ open class PreFormatter: ParagraphAttributeFormatter {
         var resultingAttributes = attributes
         let newParagraphStyle = ParagraphStyle()
 
-        newParagraphStyle.add(property: HTMLPre(with: representation))
+        newParagraphStyle.append(property: HTMLPre(with: representation))
 
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
         resultingAttributes[NSFontAttributeName] = monospaceFont

--- a/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
@@ -29,7 +29,7 @@ open class PreFormatter: ParagraphAttributeFormatter {
         var resultingAttributes = attributes
         let newParagraphStyle = ParagraphStyle()
 
-        newParagraphStyle.append(property: HTMLPre(with: representation))
+        newParagraphStyle.appendProperty(HTMLPre(with: representation))
 
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
         resultingAttributes[NSFontAttributeName] = monospaceFont

--- a/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
@@ -12,14 +12,14 @@ class TextListFormatter: ParagraphAttributeFormatter {
 
     /// Attributes to be added by default
     ///
-    let placeholderAttributes: [String : Any]?
+    let placeholderAttributes: [String: Any]?
 
     /// Tells if the formatter is increasing the depth of a list or simple changing the current one if any
     let increaseDepth: Bool
 
     /// Designated Initializer
     ///
-    init(style: TextList.Style, placeholderAttributes: [String : Any]? = nil, increaseDepth: Bool = false) {
+    init(style: TextList.Style, placeholderAttributes: [String: Any]? = nil, increaseDepth: Bool = false) {
         self.listStyle = style
         self.placeholderAttributes = placeholderAttributes
         self.increaseDepth = increaseDepth
@@ -34,8 +34,8 @@ class TextListFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
 
-        if  (increaseDepth || newParagraphStyle.lists.isEmpty) {
-            newParagraphStyle.add(property: TextList(style: self.listStyle, with: representation))
+        if increaseDepth || newParagraphStyle.lists.isEmpty {
+            newParagraphStyle.append(property: TextList(style: self.listStyle, with: representation))
         } else {
             newParagraphStyle.replaceProperty(ofType: TextList.self, with: TextList(style: self.listStyle))
         }

--- a/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
@@ -34,10 +34,11 @@ class TextListFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
 
-        if increaseDepth || newParagraphStyle.lists.isEmpty {
-            newParagraphStyle.append(property: TextList(style: self.listStyle, with: representation))
+        let newList = TextList(style: self.listStyle, with: representation)
+        if newParagraphStyle.lists.isEmpty || increaseDepth {
+            newParagraphStyle.insertProperty(newList, afterLastOfType: TextList.self)
         } else {
-            newParagraphStyle.replaceProperty(ofType: TextList.self, with: TextList(style: self.listStyle))
+            newParagraphStyle.replaceProperty(ofType: TextList.self, with: newList)
         }
 
         var resultingAttributes = attributes

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -60,7 +60,7 @@ private extension LayoutManager {
             enumerateLineFragments(forGlyphRange: blockquoteGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
                 let paddingWidth = blockquoteIndent + (blockquoteIndent == 0 ? 0 : (Metrics.listTextIndentation / 2))
                 var paddingHeight: CGFloat = blockquoteIndent == 0 ? 0 : (Metrics.paragraphSpacing / 2)
-                //cheking if we this a middle line inside a blockquote paragraph
+                // Cheking if we this a middle line inside a blockquote paragraph
                 let lineRange = self.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
                 let lineCharacters = textStorage.attributedSubstring(from: lineRange).string
                 if !lineCharacters.isEndOfLine(before: lineCharacters.endIndex) {

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -1,6 +1,9 @@
 import Foundation
 import UIKit
 
+
+// MARK: - ParagraphStyle
+//
 open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
     // MARK: - CustomReflectable
@@ -95,28 +98,29 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     override open func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
 
-        aCoder.encode(properties, forKey: String(describing: ParagraphProperty.self))        
-
+        aCoder.encode(properties, forKey: String(describing: ParagraphProperty.self))
         aCoder.encode(headerLevel, forKey: EncodingKeys.headerLevel.rawValue)
     }
 
     override open func setParagraphStyle(_ obj: NSParagraphStyle) {
         super.setParagraphStyle(obj)
-        if let paragrahStyle = obj as? ParagraphStyle {
-            headIndent = 0
-            firstLineHeadIndent = 0
-            tailIndent = 0
-            paragraphSpacing = 0
-            paragraphSpacingBefore = 0
-
-            baseHeadIndent = paragrahStyle.baseHeadIndent
-            baseFirstLineHeadIndent = paragrahStyle.baseFirstLineHeadIndent
-            baseTailIndent = paragrahStyle.baseTailIndent
-            baseParagraphSpacing = paragrahStyle.baseParagraphSpacing
-            baseParagraphSpacingBefore = paragrahStyle.baseParagraphSpacingBefore
-
-            properties = paragrahStyle.properties
+        guard let paragrahStyle = obj as? ParagraphStyle else {
+            return
         }
+
+        headIndent = 0
+        firstLineHeadIndent = 0
+        tailIndent = 0
+        paragraphSpacing = 0
+        paragraphSpacingBefore = 0
+
+        baseHeadIndent = paragrahStyle.baseHeadIndent
+        baseFirstLineHeadIndent = paragrahStyle.baseFirstLineHeadIndent
+        baseTailIndent = paragrahStyle.baseTailIndent
+        baseParagraphSpacing = paragrahStyle.baseParagraphSpacing
+        baseParagraphSpacingBefore = paragrahStyle.baseParagraphSpacingBefore
+
+        properties = paragrahStyle.properties
     }
 
     open override var headIndent: CGFloat {
@@ -292,8 +296,9 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     }
 }
 
-// MARK: - Add method to manipulate properties array
 
+// MARK: - Add method to manipulate properties array
+//
 extension ParagraphStyle {
 
     func append(property: ParagraphProperty) {

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -296,7 +296,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
 extension ParagraphStyle {
 
-    func add(property: ParagraphProperty) {
+    func append(property: ParagraphProperty) {
         properties.append(property)
     }
 

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -301,10 +301,35 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 //
 extension ParagraphStyle {
 
-    func append(property: ParagraphProperty) {
+    /// Inserts the specified ParagraphProperty at the very end of the Properties array
+    ///
+    func appendProperty(_ property: ParagraphProperty) {
         properties.append(property)
     }
 
+    /// Inserts the specified ParagraphProperty at the specified index
+    ///
+    func insertProperty(_ property: ParagraphProperty, at index: Int) {
+        properties.insert(property, at: index)
+    }
+
+    /// Inserts the specified ParagraphProperty after the last Property of the specified kind. If none,
+    /// this method will simply append the given ParagraphProperty at the very end of the Properties array.
+    ///
+    /// *Note*: This is specially useful when adding a nested List Nested Level, where 'New Lists' should be
+    /// clustered at the 'Right Hand Side' of the currently existant list.
+    ///
+    func insertProperty(_ property: ParagraphProperty, afterLastOfType type: AnyClass) {
+        guard let targetIndex = properties.lastIndex(where: { type(of: $0) == type }) else {
+            properties.append(property)
+            return
+        }
+
+        properties.insert(property, at: targetIndex + 1)
+    }
+
+    /// Removes the first ParagraphProperty present in the Properties collection that matches the specified kind.
+    ///
     func removeProperty(ofType type: AnyClass) {
         for index in (0..<properties.count).reversed() {
             if type(of: properties[index]) == type {
@@ -314,6 +339,8 @@ extension ParagraphStyle {
         }
     }
 
+    /// Removes the first ParagraphProperty present in the Properties collection with a given instance
+    ///
     func replaceProperty(ofType type: AnyClass, with newProperty: ParagraphProperty) {
         for index in (0..<properties.count).reversed() {
             if type(of: properties[index]) == type {

--- a/AztecTests/Extensions/ArrayHelperTests.swift
+++ b/AztecTests/Extensions/ArrayHelperTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import Aztec
+
+
+// MARK: - Array Helper Tests
+//
+class ArrayHelperTests: XCTestCase {
+
+    /// Verifies that the `lastIndex` helper effectively returns the position of the last satisfying
+    /// element within the collection.
+    ///
+    func testLastIndexEffectivelyReturnsTheLastSatisfyingElementIndex() {
+        let collection = [9,8,7,6,5,4,3,2,1,9,0,9,0]
+
+        guard let index = collection.lastIndex(where: { $0 == 9 }) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssert(index == (collection.count - 2))
+    }
+
+    /// Verifies that the `lastIndex` helper effectively returns nil whenever there is just no single
+    /// element within the collection that would satisfy the specified condition.
+    ///
+    func testLastIndexEffectivelyReturnsNilWheneverThereIsNoSatisfyingElement() {
+        let collection = [9,8,7,6,5,4,3,2,1,9,0,9,0]
+
+        guard let _ = collection.lastIndex(where: { $0 == 15 }) else {
+            return
+        }
+
+        XCTFail()
+    }
+}

--- a/AztecTests/Extensions/NSAttributedStringListsTests.swift
+++ b/AztecTests/Extensions/NSAttributedStringListsTests.swift
@@ -254,7 +254,7 @@ extension NSAttributedStringListsTests
 
         let range = (sample.string as NSString).range(of: sampleListContents)
         let listParagraphStyle = ParagraphStyle()
-        listParagraphStyle.add(property: TextList(style: .ordered))
+        listParagraphStyle.appendProperty(TextList(style: .ordered))
         let attributes = [NSParagraphStyleAttributeName: listParagraphStyle]
         sample.addAttributes(attributes, range: range)
 

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1610,4 +1610,37 @@ class TextViewTests: XCTestCase {
         textView.selectedRange = textView.storage.rangeOfEntireString
         textView.cut(nil)
     }
+
+    /// This test verifies that Nested Text Lists are 'Grouped Together', and not simply appended at the end of
+    /// the Properties collection. For instance, a 'broken' behavior would produce the following HTML:
+    ///
+    ///     <ol><li><blockquote><ol><li><ol><li>First Item</li></ol></li></ol></blockquote></li></ol>
+    ///
+    /// Ref. Issue #633: Hitting Tab causes the bullet to indent, but the blockquote is not moving
+    ///
+    func testNestedTextListsAreProperlyGroupedTogether() {
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleOrderedList(range: .zero)
+        textView.toggleBlockquote(range: .zero)
+        textView.insertText("First Item")
+
+        // Simulate TAB Event
+        let command = textView.keyCommands?.first { command in
+            return command.input == String(.tab) && command.modifierFlags.isEmpty
+        }
+
+        guard let tab = command else {
+            XCTFail()
+            return
+        }
+
+        // Insert Two Nested Levels
+        textView.handleTab(command: tab)
+        textView.handleTab(command: tab)
+
+        // Verify!
+        let expected = "<ol><li><ol><li><ol><li><blockquote>First Item</blockquote></li></ol></li></ol></li></ol>"
+        XCTAssert(textView.getHTML() == expected)
+    }
 }


### PR DESCRIPTION
### Details:
In this PR we're adding logic so that **Nested Text Lists** get grouped together. Instead of producing:

```
OL > LI > Blockquote > OL > LI
```

We should produce:

```
OL > LI > OL > LI > Blockquote
```

Fixes #633 

### To test:
1. Verify that the Unit Tests are happy
2. Launch the Empty Editor
2.1. Toggle Ordered List
2.2. Toggle Blockquote
2.3. Hit Tab
3. Verify that the produced HTML looks as expected.
