### PR TITLE
Fix link formatter

### DIFF
--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -602,7 +602,12 @@ private extension NSAttributedStringToNodes {
     /// Extracts all of the Link Elements contained within a collection of Attributes.
     ///
     private func processLinkStyle(in attributes: [String: Any]) -> ElementNode? {
-        guard let url = attributes[NSLinkAttributeName] as? URL else {
+        var urlString = ""
+        if let url = attributes[NSLinkAttributeName] as? URL {
+            urlString = url.absoluteString
+        } else if let link = attributes[NSLinkAttributeName] as? String {
+            urlString = link
+        } else {
             return nil
         }
 
@@ -616,7 +621,7 @@ private extension NSAttributedStringToNodes {
             element = ElementNode(type: .a)
         }
 
-        element.updateAttribute(named: "href", value: .string(url.absoluteString))
+        element.updateAttribute(named: "href", value: .string(urlString))
 
         return element
     }

--- a/Aztec/Classes/Formatters/Implementations/LinkFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/LinkFormatter.swift
@@ -14,15 +14,15 @@ class LinkFormatter: StandardAttributeFormatter {
         if let representation = representation,
             case let .element(element) = representation.kind {
 
-            let linkURL: NSURL
-
-            if let elementUrl = element.attribute(named: HTMLLinkAttribute.Href.rawValue)?.value.toString() {
-                linkURL = NSURL(string: elementUrl)!
+            if let elementURL = element.attribute(named: HTMLLinkAttribute.Href.rawValue)?.value.toString() {
+               if let url = NSURL(string: elementURL) {
+                   attributeValue = url
+               } else {
+                   attributeValue = elementURL
+               }
             } else {
-                linkURL = NSURL(string: "")!
-            }
-
-            attributeValue = linkURL
+                attributeValue = NSURL(string: "")!
+            }            
         } else {
 
             // There's no support fora link representation that's not an HTML element, so this

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -671,6 +671,13 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(textView.getHTML(), "<a href=\"\(linkUrl)\">\(linkTitle)</a>")
     }
 
+    func testParsingOfInvalidLink() {
+        let html = "<a href=\"\\http:\\badlink&?\">link</a>"
+        let textView = createTextView(withHTML: html)
+
+        XCTAssertEqual(textView.getHTML(), html)
+    }
+
     func testToggleBlockquoteWriteOneCharAndDelete() {
         let textView = createEmptyTextView()
 


### PR DESCRIPTION
Fixes #654 

To test:
 - Open the empty demo app
 - Switch to HTML mode and write this: `<a href=\"\\http:\\badlink&?\">link</a>`
 - Switch to visual mode and see if the app doesn't crash.
