### PR TITLE
Removes some redundancy in the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@
 [![License](https://img.shields.io/cocoapods/l/WordPress-Aztec-iOS.svg?style=flat)](http://cocoapods.org/pods/WordPress-Aztec-iOS)
 [![Platform](https://img.shields.io/cocoapods/p/WordPress-Aztec-iOS.svg?style=flat)](http://cocoapods.org/pods/WordPress-Aztec-iOS)
 
-## Example
-
-To run the example project, clone the repo, and run `carthage update` from the Example directory first.
-
 ## Requirements
 
 - iOS 9 and above


### PR DESCRIPTION
Removes some redundancy in the documentation.

The removed section had information that's also present in section "Running the Example App".

Feel free to merge if approved.