### PR TITLE
Implements HTMLDiv Formatter

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		59FEA07A1D8BDFA700D138DF /* InHTMLConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FEA06C1D8BDFA700D138DF /* InHTMLConverterTests.swift */; };
 		B50CE7321F1FA6260018CAA1 /* NSAttributedString+Strip.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50CE7311F1FA6260018CAA1 /* NSAttributedString+Strip.swift */; };
 		B50CE7341F1FABA00018CAA1 /* content.html in Resources */ = {isa = PBXBuildFile; fileRef = B50CE7331F1FABA00018CAA1 /* content.html */; };
+		B524228D1F30C039002E7C6C /* HTMLDiv.swift in Sources */ = {isa = PBXBuildFile; fileRef = B524228C1F30C039002E7C6C /* HTMLDiv.swift */; };
+		B524228F1F30C098002E7C6C /* HTMLDivFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B524228E1F30C098002E7C6C /* HTMLDivFormatter.swift */; };
 		B5375F471EC2566200F5D7EC /* String+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5375F461EC2566200F5D7EC /* String+HTML.swift */; };
 		B5375F491EC2569500F5D7EC /* StringHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5375F481EC2569500F5D7EC /* StringHTMLTests.swift */; };
 		B542D6421E9EB122009D12D3 /* PreFormaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B542D6411E9EB122009D12D3 /* PreFormaterTests.swift */; };
@@ -199,6 +201,8 @@
 		59FEA06D1D8BDFA700D138DF /* InNodeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InNodeConverterTests.swift; sourceTree = "<group>"; };
 		B50CE7311F1FA6260018CAA1 /* NSAttributedString+Strip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Strip.swift"; sourceTree = "<group>"; };
 		B50CE7331F1FABA00018CAA1 /* content.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = content.html; path = Example/Example/SampleContent/content.html; sourceTree = SOURCE_ROOT; };
+		B524228C1F30C039002E7C6C /* HTMLDiv.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLDiv.swift; sourceTree = "<group>"; };
+		B524228E1F30C098002E7C6C /* HTMLDivFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLDivFormatter.swift; sourceTree = "<group>"; };
 		B5375F461EC2566200F5D7EC /* String+HTML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+HTML.swift"; sourceTree = "<group>"; };
 		B5375F481EC2569500F5D7EC /* StringHTMLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringHTMLTests.swift; path = Extensions/StringHTMLTests.swift; sourceTree = "<group>"; };
 		B542D6411E9EB122009D12D3 /* PreFormaterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreFormaterTests.swift; sourceTree = "<group>"; };
@@ -658,6 +662,7 @@
 			children = (
 				F11326A91EF1AA91007FEE9A /* Blockquote.swift */,
 				F11326AA1EF1AA91007FEE9A /* Header.swift */,
+				B524228C1F30C039002E7C6C /* HTMLDiv.swift */,
 				F11326AB1EF1AA91007FEE9A /* HTMLParagraph.swift */,
 				F11326AC1EF1AA91007FEE9A /* HTMLPre.swift */,
 				F11326AD1EF1AA91007FEE9A /* ParagraphProperty.swift */,
@@ -695,6 +700,7 @@
 				F12F58571EF20394008AE298 /* ColorFormatter.swift */,
 				F12F58591EF20394008AE298 /* HeaderFormatter.swift */,
 				F12F585A1EF20394008AE298 /* HRFormatter.swift */,
+				B524228E1F30C098002E7C6C /* HTMLDivFormatter.swift */,
 				F12F585B1EF20394008AE298 /* HTMLParagraphFormatter.swift */,
 				F12F585C1EF20394008AE298 /* ImageFormatter.swift */,
 				F18986E41EF2043E0060EDBA /* ItalicFormatter.swift */,
@@ -959,6 +965,7 @@
 				F1FA0E831E6EF514009D98EE /* ElementNode.swift in Sources */,
 				FFD0FEB71DAE59A700430586 /* NSLayoutManager+Attachments.swift in Sources */,
 				599F25541D8BC9A1002871D6 /* TextView.swift in Sources */,
+				B524228D1F30C039002E7C6C /* HTMLDiv.swift in Sources */,
 				599F254A1D8BC9A1002871D6 /* NSAttributedString+Attachments.swift in Sources */,
 				F1DE83D51EF20493009269E6 /* UIColor+Parsers.swift in Sources */,
 				B5B96DAB1E01B2F300791315 /* UIPasteboard+Helpers.swift in Sources */,
@@ -998,6 +1005,7 @@
 				B50CE7321F1FA6260018CAA1 /* NSAttributedString+Strip.swift in Sources */,
 				B5B86D371DA3EC250083DB3F /* NSRange+Helpers.swift in Sources */,
 				599F25501D8BC9A1002871D6 /* FormattingIdentifier.swift in Sources */,
+				B524228F1F30C098002E7C6C /* HTMLDivFormatter.swift in Sources */,
 				599F25341D8BC9A1002871D6 /* ArrayConverter.swift in Sources */,
 				F1FA0E811E6EF514009D98EE /* Attribute.swift in Sources */,
 			);

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -190,6 +190,7 @@ class HTMLNodeToNSAttributedString: SafeConverter {
         .ol: TextListFormatter(style: .ordered, increaseDepth: true),
         .ul: TextListFormatter(style: .unordered, increaseDepth: true),
         .blockquote: BlockquoteFormatter(),
+        .div: HTMLDivFormatter(),
         .strong: BoldFormatter(),
         .em: ItalicFormatter(),
         .u: UnderlineFormatter(),

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -419,6 +419,10 @@ private extension NSAttributedStringToNodes {
                 let elements = processListStyle(list: list)
                 paragraphNodes += elements
 
+            case let div as HTMLDiv:
+                let element = processDivStyle(div: div)
+                paragraphNodes.append(element)
+
             case let paragraph as HTMLParagraph:
                 let element = processParagraphStyle(paragraph: paragraph)
                 paragraphNodes.append(element)
@@ -447,6 +451,20 @@ private extension NSAttributedStringToNodes {
         }
 
         return element.toElementNode()
+    }
+
+
+    /// Extracts all of the Div Elements contained within a collection of Attributes.
+    ///
+    private func processDivStyle(div: HTMLDiv) -> ElementNode {
+
+        guard let representation = div.representation,
+            case let .element(representationElement) = representation.kind
+        else {
+            return ElementNode(type: .div)
+        }
+
+        return representationElement.toElementNode()
     }
 
 

--- a/Aztec/Classes/Formatters/Implementations/HTMLDivFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HTMLDivFormatter.swift
@@ -1,0 +1,58 @@
+import Foundation
+import UIKit
+
+
+// MARK: - HTMLDivFormatter Formatter
+//
+class HTMLDivFormatter: ParagraphAttributeFormatter {
+
+    /// Attributes to be added by default
+    ///
+    let placeholderAttributes: [String: Any]?
+
+
+    /// Designated Initializer
+    ///
+    init(placeholderAttributes: [String: Any]? = nil) {
+        self.placeholderAttributes = placeholderAttributes
+    }
+
+
+    // MARK: - Overwriten Methods
+
+    func apply(to attributes: [String: Any], andStore representation: HTMLRepresentation?) -> [String: Any] {
+        let newParagraphStyle = ParagraphStyle()
+
+        if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
+            newParagraphStyle.setParagraphStyle(paragraphStyle)
+        }
+
+        let newProperty = HTMLDiv(with: representation)
+        newParagraphStyle.appendProperty(newProperty)
+
+        var resultingAttributes = attributes
+        resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
+        return resultingAttributes
+    }
+
+    func remove(from attributes:[String: Any]) -> [String: Any] {
+        guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
+            !paragraphStyle.htmlDiv.isEmpty
+        else {
+            return attributes
+        }
+
+        let newParagraphStyle = ParagraphStyle()
+        newParagraphStyle.setParagraphStyle(paragraphStyle)
+        newParagraphStyle.removeProperty(ofType: HTMLDiv.self)
+
+        var resultingAttributes = attributes
+        resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
+        return resultingAttributes
+    }
+
+    func present(in attributes: [String: Any]) -> Bool {
+        let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle
+        return style?.htmlDiv.isEmpty == false
+    }
+}

--- a/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 
-// MARK: - Blockquote Formatter
+// MARK: - HTMLParagraph Formatter
 //
 class HTMLParagraphFormatter: ParagraphAttributeFormatter {
 

--- a/Aztec/Classes/TextKit/ParagraphProperty/HTMLDiv.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/HTMLDiv.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+
+// MARK: - HTMLDiv
+//
+class HTMLDiv: ParagraphProperty {
+
+    override public func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+    }
+
+    override public init(with representation: HTMLRepresentation? = nil) {
+        super.init(with: representation)
+    }
+
+    required public init?(coder aDecoder: NSCoder){
+        super.init(coder: aDecoder)
+    }
+
+    static func ==(lhs: HTMLDiv, rhs: HTMLDiv) -> Bool {
+        return lhs === rhs
+    }
+}

--- a/Aztec/Classes/TextKit/ParagraphProperty/HTMLParagraph.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/HTMLParagraph.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+
+// MARK: - HTMLParagraph
+//
 class HTMLParagraph: ParagraphProperty {
     
     override public func encode(with aCoder: NSCoder) {

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -10,7 +10,11 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
     public var customMirror: Mirror {
         get {
-            return Mirror(self, children: ["blockquotes": blockquotes as Any, "headerLevel": headerLevel, "htmlParagraph": htmlParagraph as Any, "textList": lists as Any])
+            return Mirror(self, children: ["blockquotes": blockquotes,
+                                           "headerLevel": headerLevel,
+                                           "htmlDiv": htmlDiv,
+                                           "htmlParagraph": htmlParagraph,
+                                           "textList": lists])
         }
     }
 
@@ -278,7 +282,12 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     }
 
     open override var description: String {
-        return super.description + " Blockquotes: \(String(describing:blockquotes)),\n HeaderLevel: \(headerLevel),\n HTMLParagraph: \(String(describing: htmlParagraph)),\n TextLists: \(lists)"
+        return super.description +
+            " Blockquotes: \(String(describing:blockquotes)),\n" +
+            " HeaderLevel: \(headerLevel),\n" +
+            " HTMLDiv: \(String(describing: htmlDiv)),\n" +
+            " HTMLParagraph: \(String(describing: htmlParagraph)),\n" +
+            " TextLists: \(lists)"
     }
 }
 

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -21,42 +21,27 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     var properties = [ParagraphProperty]()
 
     var blockquotes: [Blockquote] {
-        return properties.flatMap { (property) -> Blockquote? in
-            if let blockquote = property as? Blockquote {
-                return blockquote
-            } else {
-                return nil
-            }
+        return properties.flatMap { property in
+            return property as? Blockquote
+        }
         }
     }
 
     var htmlParagraph: [HTMLParagraph] {
-        return properties.flatMap { (property) -> HTMLParagraph? in
-            if let paragraph = property as? HTMLParagraph {
-                return paragraph
-            } else {
-                return nil
-            }
+        return properties.flatMap { property in
+            return property as? HTMLParagraph
         }
     }
 
     var lists : [TextList] {
-        return properties.flatMap { (property) -> TextList? in
-            if let textList = property as? TextList {
-                return textList
-            } else {
-                return nil
-            }
+        return properties.flatMap { property in
+            return property as? TextList
         }
     }
 
     var headers: [Header] {
-        return properties.flatMap { (property) -> Header? in
-            if let header = property as? Header {
-                return header
-            } else {
-                return nil
-            }
+        return properties.flatMap { property in
+            return property as? Header
         }
     }
 
@@ -70,12 +55,8 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     }
 
     var htmlPre: HTMLPre? {
-        let htmlPres = properties.flatMap { (property) -> HTMLPre? in
-            if let htmlPre = property as? HTMLPre {
-                return htmlPre
-            } else {
-                return nil
-            }
+        let htmlPres = properties.flatMap { property in
+            return property as? HTMLPre
         }
         return htmlPres.first
     }

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -24,6 +24,11 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         return properties.flatMap { property in
             return property as? Blockquote
         }
+    }
+
+    var htmlDiv: [HTMLDiv] {
+        return properties.flatMap { property in
+            return property as? HTMLDiv
         }
     }
 

--- a/AztecTests/Converters/HTMLNodeToNSAttributedStringTests.swift
+++ b/AztecTests/Converters/HTMLNodeToNSAttributedStringTests.swift
@@ -50,6 +50,51 @@ class HTMLNodeToNSAttributedStringTests: XCTestCase {
         XCTAssertEqual(restoredSpanAttribute1?.name, "class")
         XCTAssertEqual(restoredSpanAttribute1?.value.toString(), "first")
     }
+
+    /// Verifies that the DivFormatter effectively appends the DIV Element Representation, to the properties collection.
+    ///
+    func testHtmlDivFormatterEffectivelyAppendsNewDivProperty() {
+        let textNode = TextNode(text: "Ehlo World!")
+
+        let divAttr3 = Attribute(name: "class", value: .string("third"))
+        let divNode3 = ElementNode(type: .div, attributes: [divAttr3], children: [textNode])
+
+        let divAttr2 = Attribute(name: "class", value: .string("second"))
+        let divNode2 = ElementNode(type: .div, attributes: [divAttr2], children: [divNode3])
+
+        let divAttr1 = Attribute(name: "class", value: .string("first"))
+        let divNode1 = ElementNode(type: .div, attributes: [divAttr1], children: [divNode2])
+
+        // Convert
+        let output = attributedString(from: divNode1)
+
+        // Test!
+        var range = NSRange()
+        guard let paragraphStyle = output.attribute(NSParagraphStyleAttributeName, at: 0, effectiveRange: &range) as? ParagraphStyle else {
+            XCTFail()
+            return
+        }
+
+        XCTAssert(range.length == textNode.length())
+        XCTAssert(paragraphStyle.htmlDiv.count == 3)
+
+        guard case let .element(restoredDiv1) = paragraphStyle.htmlDiv[0].representation!.kind,
+            case let .element(restoredDiv2) = paragraphStyle.htmlDiv[1].representation!.kind,
+            case let .element(restoredDiv3) = paragraphStyle.htmlDiv[2].representation!.kind
+        else {
+            XCTFail()
+            return
+        }
+
+        XCTAssert(restoredDiv1.name == divNode1.name)
+        XCTAssert(restoredDiv1.attributes == [divAttr1])
+
+        XCTAssert(restoredDiv2.name == divNode2.name)
+        XCTAssert(restoredDiv2.attributes == [divAttr2])
+
+        XCTAssert(restoredDiv3.name == divNode3.name)
+        XCTAssert(restoredDiv3.attributes == [divAttr3])
+    }
 }
 
 

--- a/AztecTests/Converters/NSAttributedStringToNodesTests.swift
+++ b/AztecTests/Converters/NSAttributedStringToNodesTests.swift
@@ -703,6 +703,39 @@ class NSAttributedStringToNodesTests: XCTestCase {
         let restoredTextNode = restoredSpanNode?.children.first as? TextNode
         XCTAssert(restoredTextNode?.contents == text)
     }
+
+
+    /// Verifies that the Div Element is effectively converted into an ElementNode.
+    ///
+    /// - Input: <div><div>Ehlo World!</div></div>
+    ///
+    /// - Output: Same as above!
+    ///
+    func testDivIsEffectivelySerializedIntoDivElement() {
+        let text = "Ehlo World!"
+        let testingString = NSMutableAttributedString(string: text)
+
+        let range = testingString.rangeOfEntireString
+
+        let formatter = HTMLDivFormatter()
+        formatter.applyAttributes(to: testingString, at: range)
+        formatter.applyAttributes(to: testingString, at: range)
+
+        // Convert + Verify
+        let node = NSAttributedStringToNodes().convert(testingString)
+        XCTAssert(node.children.count == 1)
+
+        let restoredDiv1Node = node.children.first as? ElementNode
+        XCTAssert(restoredDiv1Node?.name == "div")
+        XCTAssert(restoredDiv1Node?.children.count == 1)
+
+        let restoredDiv2Node = restoredDiv1Node?.children.first as? ElementNode
+        XCTAssert(restoredDiv2Node?.name == "div")
+        XCTAssert(restoredDiv2Node?.children.count == 1)
+
+        let restoredTextNode = restoredDiv2Node?.children.first as? TextNode
+        XCTAssert(restoredTextNode?.contents == text)
+    }
 }
 
 


### PR DESCRIPTION
### Details:
In this PR we're implementing both, HTMLDiv and HTMLDivFormatter, plus, adding new unit tests.
From now on, DIV elements will no longer be stored by means of UnsupportedHTML instances.

Ref. #658

### To test:
Run the unit tests!

cc @diegoreymendez 


