### PR TITLE
Code cleanup before enforcing paragraphs.

### DIFF
--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -112,7 +112,7 @@ class HTMLNodeToNSAttributedString: SafeConverter {
         let childAttributes = self.attributes(for: element, inheriting: attributes)
         let content = NSMutableAttributedString()
 
-        if let representation = implicitRepresentation(for: element, inheriting: attributes) {
+        if let representation = implicitRepresentation(for: element, inheriting: childAttributes) {
             content.append(representation)
         } else {
             for child in element.children {

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -309,7 +309,7 @@ extension HTMLNodeToNSAttributedString {
     }
 }
 
-extension HTMLNodeToNSAttributedString {
+private extension HTMLNodeToNSAttributedString {
 
     // MARK: - Implicit Representations
 

--- a/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
+++ b/Aztec/Classes/Converters/HTMLNodeToNSAttributedString.swift
@@ -152,36 +152,6 @@ class HTMLNodeToNSAttributedString: SafeConverter {
 
     // MARK: - Node Styling
 
-    /// Returns an attributed string representing the specified node.
-    ///
-    /// - Parameters:
-    ///     - node: the element node to generate a representation string of.
-    ///     - attributes: the inherited attributes from parent nodes.
-    ///
-    /// - Returns: the attributed string representing the specified element node.
-    ///
-    ///
-    fileprivate func string(for element: ElementNode, inheriting attributes: [String:Any]) -> NSAttributedString {
-        
-        let childAttributes = self.attributes(for: element, inheriting: attributes)
-        let content = NSMutableAttributedString()
-
-        if let representation = implicitRepresentation(for: element, inheriting: childAttributes) {
-            content.append(representation)
-        } else {
-            for child in element.children {
-                let childContent = convert(child, inheriting: childAttributes)
-                content.append(childContent)
-            }
-        }
-
-        guard !element.needsClosingParagraphSeparator() else {
-            return appendParagraphSeparator(to: content, inheriting: attributes)
-        }
-        
-        return content
-    }
-
     public let elementToFormattersMap: [StandardElementType: AttributeFormatter] = [
         .ol: TextListFormatter(style: .ordered, increaseDepth: true),
         .ul: TextListFormatter(style: .unordered, increaseDepth: true),

--- a/Aztec/Classes/Libxml2/DOM/Data/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/StandardElementType.swift
@@ -78,35 +78,5 @@ enum StandardElementType: String {
                 return [self.rawValue]
             }
         }
-    }
-
-    func implicitRepresentation() -> NSAttributedString? {
-        return implicitRepresentation(withAttributes: [:])
-    }
-
-    func implicitRepresentation(withAttributes attributes: [String:Any]) -> NSAttributedString? {
-        switch self {
-        case .img:
-            return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
-        case .video:
-            return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
-        case .br:
-            // Since the user can type outside of paragraphs (or any block level element) we
-            // must ensure that when that happens, each line is treated as a separate paragraph.
-            // Otherwise the styles applied to each line will be overridden constantly
-            // by the lack of paragraph delimiters.
-            //
-            if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
-                paragraphStyle.properties.count > 0 {
-                return NSAttributedString(.lineSeparator, attributes: attributes)
-            } else {
-                return NSAttributedString(.lineFeed, attributes: attributes)
-            }
-        case .hr:
-            return NSAttributedString(string:String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
-        default:
-            return nil
-        }
-    }
-    
+    }    
 }


### PR DESCRIPTION
### Description:

This PR does some code cleanup that'll be useful for #667.

- Removes an unused and duplicated method.
- Moves some conversion code to `HTMLNodeToNSAttributedString`.
- Documents the methods that were moved.

### Testing:

Just run the unit tests.