### PR TITLE
Fixing div partitioning

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -26,7 +26,7 @@ class ElementNode: Node {
     }
 
     private static let knownElements: [StandardElementType] = [.a, .b, .br, .blockquote, .del, .div, .em, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .i, .img, .li, .ol, .p, .pre, .s, .span, .strike, .strong, .u, .ul, .video]
-    private static let mergeableBlocklevelElements: [StandardElementType] = [.p, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .ol, .ul, .li, .blockquote]
+    private static let mergeableBlocklevelElements: [StandardElementType] = [.p, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .ol, .ul, .li, .blockquote, .div]
     private static let mergeableStyleElements: [StandardElementType] = [.i, .em, .b, .strong, .strike, .u]
 
     internal var standardName: StandardElementType? {

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -105,7 +105,7 @@ class ElementNode: Node {
             return true
         }
 
-        return isBlockLevelElement() && !isLastInTree()
+        return !isLastInTree() && isLastInAncestorEndingInBlockLevelSeparation()
     }
 
     // MARK: - Node Queries

--- a/AztecTests/Converters/HTMLNodeToNSAttributedStringTests.swift
+++ b/AztecTests/Converters/HTMLNodeToNSAttributedStringTests.swift
@@ -24,9 +24,10 @@ class HTMLNodeToNSAttributedStringTests: XCTestCase {
         let headerNode = ElementNode(type: .h1, attributes: [], children: [spanNode1])
         let rootNode = RootNode(children: [headerNode])
 
-        // Convert + Test
+        // Convert
         let output = attributedString(from: rootNode)
 
+        // Test
         var range = NSRange()
         guard let unsupportedHTML = output.attribute(UnsupportedHTMLAttributeName, at: 0, effectiveRange: &range) as? UnsupportedHTML else {
             XCTFail()
@@ -131,6 +132,28 @@ class HTMLNodeToNSAttributedStringTests: XCTestCase {
         let outHtml = OutHTMLConverter().convert(outNode)
 
         XCTAssertEqual(outHtml, expectedHtml)
+    }
+
+
+    /// Verifies that nested Unsupported HTML snippets get applied to *their own* UnsupportedHTML container.
+    /// Ref. #658
+    ///
+    func testMultipleUnrelatedUnsupportedHTMLSnippetsDoNotGetAppliedToTheEntireStringRange() {
+        let inHtml = "<div>" +
+            "<p><span>One</span></p>" +
+            "<p><span><br></span></p>" +
+            "<p><span>Two</span></p>" +
+            "<p><br></p>" +
+            "<p><span>Three</span><span>Four</span><span>Five</span></p>" +
+        "</div>"
+
+        let inNode = InHTMLConverter().convert(inHtml)
+        let attrString = attributedString(from: inNode)
+
+        let outNode = NSAttributedStringToNodes().convert(attrString)
+        let outHtml = OutHTMLConverter().convert(outNode)
+
+        XCTAssertEqual(outHtml, inHtml)
     }
 }
 


### PR DESCRIPTION
### Details:
The DIV element is considered non mergeable. As a result, Aztec currently has the following behavior:

Input: `<div><p>Hello</p><p>World</p></div>`
Output: `<div><p>Hello</p></div><div><p>World</p></div>`

In this PR we're marking the **div** element as mergeable, and thus, preventing such partitioning.

Ref #658

### To test:
Run the unit tests!

cc @diegoreymendez 

