### PR TITLE
Extracting Elements from Empty Paragraphs html within empty paragraphs

### DIFF
--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -458,11 +458,12 @@ private extension NSAttributedStringToNodes {
     /// - Returns: ElementNode representing the specified Paragraph.
     ///
     func createParagraphNodes(from attributes: [String: Any]) -> [ElementNode] {
-        guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle else {
-            return [ElementNode(type: .p)]
+        guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
+            paragraphStyle.properties.count > 0 else {
+                return [ElementNode(type: .p)]
         }
 
-        return createParagraphNodes(from: style)
+        return createParagraphNodes(from: paragraphStyle)
     }
 
 

--- a/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
+++ b/Aztec/Classes/Converters/NSAttributedStringToNodes.swift
@@ -459,7 +459,7 @@ private extension NSAttributedStringToNodes {
     ///
     func createParagraphNodes(from attributes: [String: Any]) -> [ElementNode] {
         guard let style = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle else {
-            return []
+            return [ElementNode(type: .p)]
         }
 
         return createParagraphNodes(from: style)

--- a/AztecTests/Converters/HTMLNodeToNSAttributedStringTests.swift
+++ b/AztecTests/Converters/HTMLNodeToNSAttributedStringTests.swift
@@ -120,9 +120,7 @@ class HTMLNodeToNSAttributedStringTests: XCTestCase {
     ///
     func testLineBreakTagWithinUnsupportedHTMLDoesNotCauseDataLoss() {
         let inHtml = "<span><br>Aztec, don't forget me!</span>"
-        let expectedHtml = "<br><span>Aztec, don't forget me!</span>"
-// TODO: The actual expected html should wrap the BR within a span tag. To be addressed in another PR!
-//        let expectedHtml = "<span><br></span><span>Aztec, don't forget me!</span>"
+        let expectedHtml = "<span><br></span><span>Aztec, don't forget me!</span>"
 
         let inNode = InHTMLConverter().convert(inHtml)
         let attrString = attributedString(from: inNode)


### PR DESCRIPTION
### Details:
This PR extracts attributes associated to empty paragraphs, which, otherwise, would be lost.

Fixes #673

### To test:
Run the unit tests!

cc @diegoreymendez 

