### PR TITLE
Media: Preventing Infinite Loop (Just the retry, we love Cupertino though)

### DIFF
--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -49,7 +49,7 @@ open class MediaAttachment: NSTextAttachment {
     
     /// Attachment URL
     ///
-    open var url: URL? {
+    public var url: URL? {
         didSet {
             retryCount = 0
         }
@@ -215,7 +215,7 @@ open class MediaAttachment: NSTextAttachment {
         updateImage(inTextContainer: textContainer)
 
         guard let image = image else {
-            return nil
+            return delegate?.mediaAttachmentPlaceholderImageFor(attachment: self)
         }
 
         if let cachedImage = glyphImage, imageBounds.size.equalTo(cachedImage.size) {
@@ -368,7 +368,6 @@ open class MediaAttachment: NSTextAttachment {
                 
                 strongSelf.isFetchingImage = false
                 strongSelf.lastRequestedURL = nil
-                strongSelf.image = nil
                 strongSelf.invalidateLayout(inTextContainer: textContainer)
             })
     }

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -49,8 +49,23 @@ open class MediaAttachment: NSTextAttachment {
     
     /// Attachment URL
     ///
-    open var url: URL?
+    open var url: URL? {
+        didSet {
+            retryCount = 0
+        }
+    }
+
+    /// URL of the last successfully acquired asset
+    ///
     fileprivate var lastRequestedURL: URL?
+
+    /// Number of times we've tried to download the remote asset
+    ///
+    fileprivate var retryCount = 0
+
+    /// Maximum number of times to retry downloading the asset, upon error
+    ///
+    private let maxRetryCount = 3
 
     /// A progress value that indicates the progress of an attachment. It can be set between values 0 and 1
     ///
@@ -324,17 +339,18 @@ open class MediaAttachment: NSTextAttachment {
             assertionFailure("This class doesn't really support not having an updater set.")
             return
         }
-        
-        guard let url = url, !isFetchingImage && url != lastRequestedURL else {
-            if self.url == nil {
-                self.image = delegate.mediaAttachmentPlaceholderImageFor(attachment: self)                
-            }
+
+        guard !isFetchingImage && url != lastRequestedURL && retryCount < maxRetryCount else {
             return
         }
-        
-        isFetchingImage = true
 
         self.image = delegate.mediaAttachmentPlaceholderImageFor(attachment: self)
+
+        guard let url = url else {
+            return
+        }
+        isFetchingImage = true
+        retryCount += 1
 
         delegate.mediaAttachment(self, imageForURL: url, onSuccess: { [weak self] image in
                 guard let strongSelf = self else {

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -215,7 +215,7 @@ open class MediaAttachment: NSTextAttachment {
         updateImage(inTextContainer: textContainer)
 
         guard let image = image else {
-            return delegate?.mediaAttachmentPlaceholderImageFor(attachment: self)
+            return delegate!.mediaAttachmentPlaceholderImageFor(attachment: self)
         }
 
         if let cachedImage = glyphImage, imageBounds.size.equalTo(cachedImage.size) {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -996,18 +996,21 @@ extension EditorDemoController: TextViewAttachmentDelegate {
 
     func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) {
 
-        let task = URLSession.shared.dataTask(with: url, completionHandler: { (data, _, error) in
-            DispatchQueue.main.async(execute: {
-                    guard error == nil,
-                        let data = data,
-                        let image = UIImage(data: data, scale: UIScreen.main.scale)
-                    else {
-                        failure()
-                        return
-                    }
-                    success(image)
-            })
-        }) 
+        let task = URLSession.shared.dataTask(with: url) { [weak self] (data, _, error) in
+            DispatchQueue.main.async {
+                guard self != nil else {
+                    return
+                }
+
+                guard error == nil, let data = data, let image = UIImage(data: data, scale: UIScreen.main.scale) else {
+                    failure()
+                    return
+                }
+
+                success(image)
+            }
+        }
+
         task.resume()
     }
 


### PR DESCRIPTION
### Details:
In this PR we're implementing a limit to the Image Download Retry Mechanism. After 3 failed attempts, we shall no longer retry (we were previously retrying an infinite number of times).

Fixes #675

### To test:
1. Add an invalid image (`<img src="https://someinvalid.url/with-an-invalid-resource">`
2. Verify the image disappears shortly after
3. Add a valid image (`<img src="https://kurzee.files.wordpress.com/2017/07/img_3287.jpg"">`
4. Verify the image remains onscreen

cc @diegoreymendez  @SergioEstevao 

P.s: YES Brent's blog was the first image that showed up.

Thanks in advance!
