### PR TITLE
Fix: InNodeConverter Missing Switch Case

### DIFF
--- a/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
@@ -16,6 +16,8 @@ class InNodeConverter: SafeConverter {
         switch rawNode.type {
         case XML_TEXT_NODE:
             node = createTextNode(rawNode)
+        case XML_CDATA_SECTION_NODE:
+            node = createTextNode(rawNode)
         case XML_COMMENT_NODE:
             node = createCommentNode(rawNode)
         default:

--- a/AztecTests/Importer/HTMLToAttributedStringTests.swift
+++ b/AztecTests/Importer/HTMLToAttributedStringTests.swift
@@ -3,6 +3,9 @@ import XCTest
 
 class HTMLToAttributedStringTests: XCTestCase {
 
+    let defaultFontDescriptor = UIFont.systemFont(ofSize: 12).fontDescriptor
+
+
     /// Test the conversion of a single tag at the root level to `NSAttributedString`.
     ///
     /// Example: <bold>Hello</bold>
@@ -12,7 +15,7 @@ class HTMLToAttributedStringTests: XCTestCase {
         let tagNames = ["bold", "italic", "customTag", "div", "p", "a"]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor)
 
             let nodeText = "Hello"
             let html = "<\(tagName)>\(nodeText)</\(tagName)>"
@@ -51,7 +54,7 @@ class HTMLToAttributedStringTests: XCTestCase {
         let tagNames = ["bold", "italic", "customTag", "div", "p", "a"]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor)
 
             let firstText = "Hello "
             let secondText = "world"
@@ -100,7 +103,7 @@ class HTMLToAttributedStringTests: XCTestCase {
                         ("a", "bold")]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor)
 
             let text = "Hello"
             let html = "<\(tagName.0)><\(tagName.1)>\(text)</\(tagName.1)></\(tagName.0)>"
@@ -153,7 +156,7 @@ class HTMLToAttributedStringTests: XCTestCase {
                         ("a", "bold")]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor)
 
             let firstText = "Hello "
             let secondText = "world"
@@ -227,7 +230,7 @@ class HTMLToAttributedStringTests: XCTestCase {
                         ("a", "bold", "italic")]
 
         for (index, tagName) in tagNames.enumerated() {
-            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: UIFont.systemFont(ofSize: 12).fontDescriptor)
+            let parser = HTMLToAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor)
 
             let firstText = "Hello "
             let secondText = "world"
@@ -292,5 +295,16 @@ class HTMLToAttributedStringTests: XCTestCase {
             XCTAssertEqual(thirdTextNode.parent, firstNode)
             XCTAssertEqual(thirdTextNode.text(), thirdText)
         }
+    }
+
+    /// Test that text contained within script tags, parsed by libxml as CData, does not trigger a crash.
+    ///
+    /// Example: <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+    ///
+    func testScriptTagWithCDataDoesNotTriggerACrash() {
+        let parser = HTMLToAttributedString(usingDefaultFontDescriptor: defaultFontDescriptor)
+        let html = "<script>(adsbygoogle = window.adsbygoogle || []).push({});</script>"
+
+        XCTAssertNoThrow(parser.convert(html))
     }
 }


### PR DESCRIPTION
### Details:
I've managed to reproduce Crash #655 with the following snippet:

```
<script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
```

Libxml is parsing all of the text inside `<script>` tags as CData nodes (which lack the **name** field, cause of the crash). In this PR we're adding a switch case, so that CData nodes are handled as Text Nodes.

Fixes #655

### To test:
- Verify the unit tests are green!


*P.s.:* I've added the **NeXT** milestone, as discussed. Feel free to rename it, if you manage to come up with a cooler name.

cc @diegoreymendez 
