### PR TITLE
Links over images

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -943,6 +943,20 @@ open class TextView: UITextView {
         delegate?.textViewDidChange?(self)
     }
 
+    /// Adds a link to the designated url on the specified range.
+    ///
+    /// - Parameters:
+    ///     - url: the NSURL to link to.
+    ///     - range: The NSRange to edit.
+    ///
+    open func setLink(_ url: URL, inRange range: NSRange) {
+        let formatter = LinkFormatter()
+        formatter.attributeValue = url
+        toggle(formatter: formatter, atRange: range)
+    }
+
+
+
 
     /// Removes the link, if any, at the specified range
     ///

--- a/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
+++ b/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
@@ -49,7 +49,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CC400F161E9EC04200859AB4"

--- a/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
+++ b/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
@@ -49,7 +49,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CC400F161E9EC04200859AB4"


### PR DESCRIPTION
Fixes #641 

To test:
 - Start the demo app.
 - Select a range of text where an image or video exists.
 - Tap on the link button on the toolbar
 - Check that the link text option doesn't show
 - Change the url or write a new url
 - Tap on Insert Link
 - Switch to HTML mode and see if link is applied around the image/video

