### PR TITLE
Carthage Script: Nuking logfile

### DIFF
--- a/Scripts/carthage_script.sh
+++ b/Scripts/carthage_script.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 cd "${PROJECT_DIR}/Example"
 if [ -d "Carthage/Build/iOS" ]; then
-echo "`date +%Y-%m-%d:%H:%M:%S` -- found dependencies" >> script_logs.log
+	echo "Carthage: found dependencies!"
 else
-carthage update
-echo "`date +%Y-%m-%d:%H:%M:%S` -- carthage update" >> script_logs.log
+	carthage update
 fi


### PR DESCRIPTION
### Details:
This (brief) PR nukes the Carthage Logfile, which isn't really needed.

### To test:
- Nuke `Example/Carthage/*`
- Run the sample app from within Xcode
- Verify that the script still runs!

cc @diegoreymendez 


