### PR TITLE
Update FormatBar to use Strings as identifiers

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -303,9 +303,7 @@ open class FormatBar: UIView {
     }
 
     @IBAction func handleButtonAction(_ sender: FormatBarItem) {
-        guard let identifier = sender.identifier else { return }
-
-        formatter?.handleActionForIdentifier(identifier, barItem: sender)
+        formatter?.handleAction(for: sender)
     }
 
     @IBAction func handleToggleButtonAction(_ sender: FormatBarItem) {

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -271,9 +271,9 @@ open class FormatBar: UIView {
 
     // MARK: - Styles
 
-    /// Selects all of the FormatBarItems matching a collection of Identifiers
+    /// Selects all of the FormatBarItems matching a collection of identifiers
     ///
-    open func selectItemsMatchingIdentifiers(_ identifiers: [FormattingIdentifier]) {
+    open func selectItemsMatchingIdentifiers(_ identifiers: [String]) {
         let identifiers = Set(identifiers)
 
         for item in items {

--- a/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
@@ -7,10 +7,10 @@ public enum FormatBarOverflowState {
 }
 
 public protocol FormatBarDelegate : NSObjectProtocol {
-    /// Prompts the delegate that the bar item with the specified identifier was tapped,
+    /// Prompts the delegate that the specified bar item was tapped,
     /// and it should take appropriate action.
     ///
-    func handleActionForIdentifier(_ identifier: String, barItem: FormatBarItem)
+    func handleAction(for barItem: FormatBarItem)
 
     /// Informs the delegate that a touch down event was received on the format bar.
     ///

--- a/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
@@ -10,7 +10,7 @@ public protocol FormatBarDelegate : NSObjectProtocol {
     /// Prompts the delegate that the bar item with the specified identifier was tapped,
     /// and it should take appropriate action.
     ///
-    func handleActionForIdentifier(_ identifier: FormattingIdentifier, barItem: FormatBarItem)
+    func handleActionForIdentifier(_ identifier: String, barItem: FormatBarItem)
 
     /// Informs the delegate that a touch down event was received on the format bar.
     ///

--- a/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
@@ -6,9 +6,10 @@ import UIKit
 //
 open class FormatBarItem: UIButton {
 
-    /// Formatting Identifier
+    /// Identifier for this item. It's recommended to use a custom String enum
+    /// to encapsulate the values used here.
     ///
-    open var identifier: FormattingIdentifier?
+    open var identifier: String?
 
 
     /// Tint Color to be applied whenever the button is selected
@@ -77,13 +78,13 @@ open class FormatBarItem: UIButton {
     // MARK: - Icons
 
     /// A list of alternative icons that can be switched out for
-    /// this item's default icon if their formatting identifiers are detected
+    /// this item's default icon if their identifiers are detected
     ///
-    public var alternativeIcons: [FormattingIdentifier: UIImage]? = nil
+    public var alternativeIcons: [String: UIImage]? = nil
 
     /// Switch out this item's icon for the icon that matches the specified identifier
     ///
-    public func useAlternativeIconForIdentifier(_ identifier: FormattingIdentifier) {
+    public func useAlternativeIconForIdentifier(_ identifier: String) {
         if let icon = alternativeIcons?[identifier] {
             setImage(icon, for: .normal)
         }
@@ -99,7 +100,7 @@ open class FormatBarItem: UIButton {
 
     // MARK: - Lifecycle
 
-    public convenience init(image: UIImage, identifier: FormattingIdentifier? = nil) {
+    public convenience init(image: UIImage, identifier: String? = nil) {
         let defaultFrame = CGRect(x: 0, y: 0, width: 44, height: 44)
         self.init(image: image, frame: defaultFrame)
         self.identifier = identifier

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -550,8 +550,11 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
         }
     }
 
-    func handleActionForIdentifier(_ identifier: String, barItem: FormatBarItem) {
-        guard let formattingIdentifier = FormattingIdentifier(rawValue: identifier) else { return }
+    func handleAction(for barItem: FormatBarItem) {
+        guard let identifier = barItem.identifier,
+            let formattingIdentifier = FormattingIdentifier(rawValue: identifier) else {
+                return
+        }
 
         switch formattingIdentifier {
         case .bold:

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -409,7 +409,7 @@ class EditorDemoController: UIViewController {
             identifiers = richTextView.formatIdentifiersForTypingAttributes()
         }
 
-        toolbar.selectItemsMatchingIdentifiers(identifiers)
+        toolbar.selectItemsMatchingIdentifiers(identifiers.map({ $0.rawValue }))
     }
 
     override var keyCommands: [UIKeyCommand] {
@@ -492,7 +492,7 @@ extension EditorDemoController : UITextViewDelegate {
             formatBar.enabled = false
 
             // Disable the bar, except for the source code button
-            let htmlButton = formatBar.overflowItems.first(where: { $0.identifier == FormattingIdentifier.sourcecode })
+            let htmlButton = formatBar.overflowItems.first(where: { $0.identifier == FormattingIdentifier.sourcecode.rawValue })
             htmlButton?.isEnabled = true
         default: break
         }
@@ -550,8 +550,10 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
         }
     }
 
-    func handleActionForIdentifier(_ identifier: FormattingIdentifier, barItem: FormatBarItem) {
-        switch identifier {
+    func handleActionForIdentifier(_ identifier: String, barItem: FormatBarItem) {
+        guard let formattingIdentifier = FormattingIdentifier(rawValue: identifier) else { return }
+
+        switch formattingIdentifier {
         case .bold:
             toggleBold()
         case .italic:
@@ -930,7 +932,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
     // MARK: -
 
     func makeToolbarButton(identifier: FormattingIdentifier) -> FormatBarItem {
-        let button = FormatBarItem(image: identifier.iconImage, identifier: identifier)
+        let button = FormatBarItem(image: identifier.iconImage, identifier: identifier.rawValue)
         button.accessibilityLabel = identifier.accessibilityLabel
         button.accessibilityIdentifier = identifier.accessibilityIdentifier
         return button
@@ -959,19 +961,19 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
     var scrollableItemsForToolbar: [FormatBarItem] {
         let headerButton = makeToolbarButton(identifier: .p)
 
-        var alternativeIcons = [FormattingIdentifier: UIImage]()
+        var alternativeIcons = [String: UIImage]()
         let headings = Constants.headers.suffix(from: 1) // Remove paragraph style
         for heading in headings {
-            alternativeIcons[heading.formattingIdentifier] = heading.iconImage
+            alternativeIcons[heading.formattingIdentifier.rawValue] = heading.iconImage
         }
 
         headerButton.alternativeIcons = alternativeIcons
 
 
         let listButton = makeToolbarButton(identifier: .unorderedlist)
-        var listIcons = [FormattingIdentifier: UIImage]()
+        var listIcons = [String: UIImage]()
         for list in Constants.lists {
-            listIcons[list.formattingIdentifier] = list.iconImage
+            listIcons[list.formattingIdentifier.rawValue] = list.iconImage
         }
 
         listButton.alternativeIcons = listIcons


### PR DESCRIPTION
This PR is part of the format bar updates required for https://github.com/wordpress-mobile/WordPress-iOS/issues/7703.

In particular, it updates the format bar to use plain `String`s for bar item identifiers instead of `FormattingIdentifier`s specifically. This allows us to support a wider range of options for format bar
buttons – the buttons required for media insertion don't have associated formatting identifiers, so instead we can just provide strings.

The format bar itself never really made use of the fact that the identifiers were `FormattingIdentifier`s, only the code outside of the bar did. We can still use `FormattingIdentifier`s to manage the formatting items, but the bar doesn't need to care that we're doing so.

I'll have a PR coming up for WPiOS so that it'll work correctly with this update.

To test:

* Run the demo app and check the bar still works as intended. In particular, check that formatting of text works, and that the items become enabled correctly to show the format of the currently selected text.

Needs review: @SergioEstevao 
