### PR TITLE
FormatBar: Customise left and right items

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -70,6 +70,8 @@ open class FormatBar: UIView {
     ///
     open var trailingItem: UIButton? = nil {
         didSet {
+            updateScrollViewInsets()
+
             trailingItemContainer.arrangedSubviews.forEach({ $0.removeFromSuperview() })
 
             if let item = trailingItem {
@@ -81,6 +83,8 @@ open class FormatBar: UIView {
                 item.addTarget(self, action: #selector(handleButtonTouch), for: .touchDown)
 
                 trailingItemContainer.addArrangedSubview(item)
+
+                setOverflowItemsVisible(false)
             }
 
             updateOverflowToggleItemVisibility()
@@ -109,7 +113,7 @@ open class FormatBar: UIView {
             populateItems()
 
             let overflowVisible = UserDefaults.standard.bool(forKey: Constants.overflowExpandedUserDefaultsKey)
-            setOverflowItemsVisible(overflowVisible, animated: false)
+            setOverflowItemsVisible(overflowVisible && trailingItem == nil, animated: false)
             
             if overflowVisible {
                 rotateOverflowToggleItem(.vertical, animated: false)
@@ -192,6 +196,14 @@ open class FormatBar: UIView {
         return frame.width - scrollView.contentInset.left - scrollView.contentInset.right
     }
 
+    fileprivate var trailingInset: CGFloat {
+        if let trailingItem = trailingItem {
+            trailingItem.sizeToFit()
+            return trailingItem.bounds.size.width + Constants.trailingButtonMargin
+        } else {
+            return Constants.stackButtonWidth
+        }
+    }
 
     /// Returns true if any of the overflow items in the bar are currently hidden
     ///
@@ -504,13 +516,17 @@ private extension FormatBar {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.delegate = self
 
+        updateScrollViewInsets()
+    }
+
+    func updateScrollViewInsets() {
         // Add padding at the end to account for overflow button
         let layoutDirection = UIView.userInterfaceLayoutDirection(for: semanticContentAttribute)
         switch layoutDirection {
         case .leftToRight:
-            scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: Constants.stackButtonWidth)
+            scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: trailingInset)
         case .rightToLeft:
-            scrollView.contentInset = UIEdgeInsets(top: 0, left: Constants.stackButtonWidth, bottom: 0, right: 0)
+            scrollView.contentInset = UIEdgeInsets(top: 0, left: trailingInset, bottom: 0, right: 0)
         }
     }
 

--- a/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarDelegate.swift
@@ -7,11 +7,6 @@ public enum FormatBarOverflowState {
 }
 
 public protocol FormatBarDelegate : NSObjectProtocol {
-    /// Prompts the delegate that the specified bar item was tapped,
-    /// and it should take appropriate action.
-    ///
-    func handleAction(for barItem: FormatBarItem)
-
     /// Informs the delegate that a touch down event was received on the format bar.
     ///
     func formatBarTouchesBegan(_ formatBar: FormatBar)

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -549,7 +549,10 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
             print("Format bar expanded")
         }
     }
+}
 
+// MARK: - Format Bar Actions
+extension EditorDemoController {
     func handleAction(for barItem: FormatBarItem) {
         guard let identifier = barItem.identifier,
             let formattingIdentifier = FormattingIdentifier(rawValue: identifier) else {
@@ -572,7 +575,7 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
         case .link:
             toggleLink()
         case .media:
-            showImagePicker()
+            break
         case .sourcecode:
             toggleEditingMode()
         case .p, .header1, .header2, .header3, .header4, .header5, .header6:
@@ -958,6 +961,14 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
         toolbar.overflowToggleIcon = Gridicon.iconOfType(.ellipsis)
         toolbar.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 44.0)
         toolbar.formatter = self
+
+        toolbar.barItemHandler = { [weak self] item in
+            self?.handleAction(for: item)
+        }
+
+        toolbar.leadingItemHandler = { [weak self] item in
+            self?.showImagePicker()
+        }
 
         return toolbar
     }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -947,7 +947,8 @@ extension EditorDemoController : Aztec.FormatBarDelegate {
         let overflowItems = overflowItemsForToolbar
 
         let toolbar = Aztec.FormatBar()
-        toolbar.defaultItems = [[mediaItem], scrollableItems]
+        toolbar.leadingItem = mediaItem
+        toolbar.defaultItems = scrollableItems
         toolbar.overflowItems = overflowItems
         toolbar.tintColor = .gray
         toolbar.highlightedTintColor = .blue


### PR DESCRIPTION
Implements #699

Our designs for the new media picker toolbar in WordPress for iOS require us to set a custom button on the trailing end of the format bar:

<img src="https://user-images.githubusercontent.com/4780/29455178-125e2a22-8408-11e7-8e0b-c44e7313e0a3.png" />

This PR adds a new `trailingItem` property that can be used to set a custom item on the right end of the bar. It also changes the way the leftmost item is set to use a similar `leadingItem` property instead of a subarray of bar items.

To test:

* Ensure that the toolbar behaves as it did before.
* In the demo app, you can add a custom trailing button in the `createToolbar` method of `EditorDemoController.swift`, by adding the following code just before the `return`:

```
        let trailingItem = UIButton(type: .custom)
        trailingItem.setTitle("Testing", for: .normal)
        trailingItem.setTitleColor(.black, for: .normal)
        trailingItem.titleLabel?.font = UIFont.systemFont(ofSize: 13.0, weight: UIFontWeightMedium)
        toolbar.trailingItem = trailingItem

        toolbar.trailingItemHandler = { item in
            print("Trailing item tapped")
        }
```
* Check that the trailing item looks correct and sticks to the right edge of the toolbar. It should look like this:

<img width="340" alt="screen shot 2017-08-21 at 12 05 02" src="https://user-images.githubusercontent.com/4780/29516629-fd0886fa-8668-11e7-85ef-ca3157c11f70.png">

Needs review: @SergioEstevao 
