### PR TITLE
Adds CAPTION shortcode processing to the Example app.

### DIFF
--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -108,6 +108,10 @@ Image:<br/><br/>
 <img src="https://httpbin.org/image/jpeg" alt="Coyote" />
 </p>
 <p>
+Image with caption:<br/><br/>
+
+[caption id="attachment_6" align="alignright" width="300"]<img src="https://httpbin.org/image/jpeg" alt="Coyote" />Ahoi![/caption]
+<p>
 Video:<br/><br/>
 
 <video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://i2.wp.com/videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg?ssl=1" alt="Video about bunnies" />


### PR DESCRIPTION
First part of providing a solution for #281.

The truth is that shortcodes support is not very relevant for Aztec, as shortcodes are not standard HTML.

That said, this PR offers an example solution to handle WordPress' `[caption]` shortcode.