### PR TITLE
Adds ProcessorPipeline to Aztec. Adds preProcessor and postProcessor …

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -105,7 +105,7 @@
 		F12F58711EF20394008AE298 /* TextListFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F58601EF20394008AE298 /* TextListFormatter.swift */; };
 		F12F58721EF20394008AE298 /* UnderlineFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F58611EF20394008AE298 /* UnderlineFormatter.swift */; };
 		F12F58731EF20394008AE298 /* VideoFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F58621EF20394008AE298 /* VideoFormatter.swift */; };
-		F13CE53E1F4DD05E0043368D /* ProcessorPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE53D1F4DD05E0043368D /* ProcessorPipeline.swift */; };
+		F13CE53E1F4DD05E0043368D /* PipelineProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE53D1F4DD05E0043368D /* PipelineProcessor.swift */; };
 		F13CE5401F4DD08E0043368D /* RegexProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE53F1F4DD08E0043368D /* RegexProcessor.swift */; };
 		F14665451EA7C230008DE2B8 /* NSMutableAttributedStringReplaceOcurrencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14665441EA7C230008DE2B8 /* NSMutableAttributedStringReplaceOcurrencesTests.swift */; };
 		F16DD2CB1EE99B850083A098 /* HTMLRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16DD2CA1EE99B850083A098 /* HTMLRepresentation.swift */; };
@@ -275,7 +275,7 @@
 		F12F58601EF20394008AE298 /* TextListFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextListFormatter.swift; sourceTree = "<group>"; };
 		F12F58611EF20394008AE298 /* UnderlineFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnderlineFormatter.swift; sourceTree = "<group>"; };
 		F12F58621EF20394008AE298 /* VideoFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoFormatter.swift; sourceTree = "<group>"; };
-		F13CE53D1F4DD05E0043368D /* ProcessorPipeline.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProcessorPipeline.swift; sourceTree = "<group>"; };
+		F13CE53D1F4DD05E0043368D /* PipelineProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PipelineProcessor.swift; sourceTree = "<group>"; };
 		F13CE53F1F4DD08E0043368D /* RegexProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexProcessor.swift; sourceTree = "<group>"; };
 		F14665441EA7C230008DE2B8 /* NSMutableAttributedStringReplaceOcurrencesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringReplaceOcurrencesTests.swift; sourceTree = "<group>"; };
 		F16DD2CA1EE99B850083A098 /* HTMLRepresentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLRepresentation.swift; sourceTree = "<group>"; };
@@ -796,7 +796,7 @@
 				FF20D63D1EDC389A00294B78 /* HTMLAttributes.swift */,
 				FF20D63E1EDC389A00294B78 /* HTMLProcessor.swift */,
 				FF20D63F1EDC389A00294B78 /* Processor.swift */,
-				F13CE53D1F4DD05E0043368D /* ProcessorPipeline.swift */,
+				F13CE53D1F4DD05E0043368D /* PipelineProcessor.swift */,
 				F13CE53F1F4DD08E0043368D /* RegexProcessor.swift */,
 			);
 			path = Processor;
@@ -953,7 +953,7 @@
 				F12F586C1EF20394008AE298 /* HTMLParagraphFormatter.swift in Sources */,
 				F12F58661EF20394008AE298 /* StandardAttributeFormatter.swift in Sources */,
 				B5A99D841EBA073D00DED081 /* HTMLStorage.swift in Sources */,
-				F13CE53E1F4DD05E0043368D /* ProcessorPipeline.swift in Sources */,
+				F13CE53E1F4DD05E0043368D /* PipelineProcessor.swift in Sources */,
 				599F25471D8BC9A1002871D6 /* HTMLConstants.swift in Sources */,
 				599F25371D8BC9A1002871D6 /* InAttributeConverter.swift in Sources */,
 				B57534501F267D0B009D4904 /* Array+Helpers.swift in Sources */,

--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -105,6 +105,8 @@
 		F12F58711EF20394008AE298 /* TextListFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F58601EF20394008AE298 /* TextListFormatter.swift */; };
 		F12F58721EF20394008AE298 /* UnderlineFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F58611EF20394008AE298 /* UnderlineFormatter.swift */; };
 		F12F58731EF20394008AE298 /* VideoFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F58621EF20394008AE298 /* VideoFormatter.swift */; };
+		F13CE53E1F4DD05E0043368D /* ProcessorPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE53D1F4DD05E0043368D /* ProcessorPipeline.swift */; };
+		F13CE5401F4DD08E0043368D /* RegexProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE53F1F4DD08E0043368D /* RegexProcessor.swift */; };
 		F14665451EA7C230008DE2B8 /* NSMutableAttributedStringReplaceOcurrencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14665441EA7C230008DE2B8 /* NSMutableAttributedStringReplaceOcurrencesTests.swift */; };
 		F16DD2CB1EE99B850083A098 /* HTMLRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16DD2CA1EE99B850083A098 /* HTMLRepresentation.swift */; };
 		F18733C81DA09737005AEB80 /* NSRangeComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C71DA09737005AEB80 /* NSRangeComparisonTests.swift */; };
@@ -273,6 +275,8 @@
 		F12F58601EF20394008AE298 /* TextListFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextListFormatter.swift; sourceTree = "<group>"; };
 		F12F58611EF20394008AE298 /* UnderlineFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnderlineFormatter.swift; sourceTree = "<group>"; };
 		F12F58621EF20394008AE298 /* VideoFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoFormatter.swift; sourceTree = "<group>"; };
+		F13CE53D1F4DD05E0043368D /* ProcessorPipeline.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProcessorPipeline.swift; sourceTree = "<group>"; };
+		F13CE53F1F4DD08E0043368D /* RegexProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexProcessor.swift; sourceTree = "<group>"; };
 		F14665441EA7C230008DE2B8 /* NSMutableAttributedStringReplaceOcurrencesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringReplaceOcurrencesTests.swift; sourceTree = "<group>"; };
 		F16DD2CA1EE99B850083A098 /* HTMLRepresentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLRepresentation.swift; sourceTree = "<group>"; };
 		F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRange+Helpers.swift"; sourceTree = "<group>"; };
@@ -792,6 +796,8 @@
 				FF20D63D1EDC389A00294B78 /* HTMLAttributes.swift */,
 				FF20D63E1EDC389A00294B78 /* HTMLProcessor.swift */,
 				FF20D63F1EDC389A00294B78 /* Processor.swift */,
+				F13CE53D1F4DD05E0043368D /* ProcessorPipeline.swift */,
+				F13CE53F1F4DD08E0043368D /* RegexProcessor.swift */,
 			);
 			path = Processor;
 			sourceTree = "<group>";
@@ -947,6 +953,7 @@
 				F12F586C1EF20394008AE298 /* HTMLParagraphFormatter.swift in Sources */,
 				F12F58661EF20394008AE298 /* StandardAttributeFormatter.swift in Sources */,
 				B5A99D841EBA073D00DED081 /* HTMLStorage.swift in Sources */,
+				F13CE53E1F4DD05E0043368D /* ProcessorPipeline.swift in Sources */,
 				599F25471D8BC9A1002871D6 /* HTMLConstants.swift in Sources */,
 				599F25371D8BC9A1002871D6 /* InAttributeConverter.swift in Sources */,
 				B57534501F267D0B009D4904 /* Array+Helpers.swift in Sources */,
@@ -1027,6 +1034,7 @@
 				B551A4A01E770B3800EE3A7F /* UIFont+Emoji.swift in Sources */,
 				F12F586E1EF20394008AE298 /* LinkFormatter.swift in Sources */,
 				F12F586A1EF20394008AE298 /* HeaderFormatter.swift in Sources */,
+				F13CE5401F4DD08E0043368D /* RegexProcessor.swift in Sources */,
 				FF24AC991F0146AF003CA91D /* Assets.swift in Sources */,
 				599F254D1D8BC9A1002871D6 /* FormatBar.swift in Sources */,
 				F1FA0E881E6EF514009D98EE /* TextNode.swift in Sources */,

--- a/Aztec/Classes/Processor/PipelineProcessor.swift
+++ b/Aztec/Classes/Processor/PipelineProcessor.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-open class ProcessorPipeline: Processor {
+open class PipelineProcessor: Processor {
     private let processors: [Processor]
 
     public init(_ processors: [Processor]) {

--- a/Aztec/Classes/Processor/Processor.swift
+++ b/Aztec/Classes/Processor/Processor.swift
@@ -1,43 +1,5 @@
 import Foundation
 
 public protocol Processor {
-    func process(text: String) -> String
-}
-
-open class RegexProcessor: Processor {
-
-    public typealias ReplaceRegex = (NSTextCheckingResult, String) -> String?
-
-    public let regex: NSRegularExpression
-    public let replacer: ReplaceRegex
-
-    public init(regex: NSRegularExpression, replacer: @escaping ReplaceRegex) {
-        self.regex = regex
-        self.replacer = replacer
-    }
-
-    public func process(text: String) -> String {
-        let matches = regex.matches(in: text, options: [], range: text.nsRange(from: text.startIndex..<text.endIndex))
-        var replacements = [(NSRange, String)]()
-        for match in matches {
-            if let replacement = replacer(match, text) {
-                replacements.append((match.range, replacement))
-            }
-        }
-        let resultText = replace(matches: replacements, in: text)
-        return resultText
-    }
-
-    func replace(matches: [(NSRange, String)], in text: String) -> String {
-        let mutableString = NSMutableString(string: text)
-        var offset = 0
-        for (range, replacement) in matches {
-            let lengthBefore = mutableString.length
-            let offsetRange = NSRange(location: range.location + offset, length: range.length)
-            mutableString.replaceCharacters(in: offsetRange, with: replacement)
-            let lengthAfter = mutableString.length
-            offset += (lengthAfter - lengthBefore)
-        }
-        return mutableString as String
-    }
+    func process(_ text: String) -> String
 }

--- a/Aztec/Classes/Processor/ProcessorPipeline.swift
+++ b/Aztec/Classes/Processor/ProcessorPipeline.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+open class ProcessorPipeline: Processor {
+    private let processors: [Processor]
+
+    public init(_ processors: [Processor]) {
+        self.processors = processors
+    }
+
+    open func process(_ text: String) -> String {
+        return processors.reduce(text, { (previousText, processor) -> String in
+            return processor.process(previousText)
+        })
+    }
+}

--- a/Aztec/Classes/Processor/RegexProcessor.swift
+++ b/Aztec/Classes/Processor/RegexProcessor.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+open class RegexProcessor: Processor {
+
+    public typealias ReplaceRegex = (NSTextCheckingResult, String) -> String?
+
+    public let regex: NSRegularExpression
+    public let replacer: ReplaceRegex
+
+    public init(regex: NSRegularExpression, replacer: @escaping ReplaceRegex) {
+        self.regex = regex
+        self.replacer = replacer
+    }
+
+    public func process(_ text: String) -> String {
+        let matches = regex.matches(in: text, options: [], range: text.nsRange(from: text.startIndex ..< text.endIndex))
+        var replacements = [(NSRange, String)]()
+        for match in matches {
+            if let replacement = replacer(match, text) {
+                replacements.append((match.range, replacement))
+            }
+        }
+        let resultText = replace(matches: replacements, in: text)
+        return resultText
+    }
+
+    func replace(matches: [(NSRange, String)], in text: String) -> String {
+        let mutableString = NSMutableString(string: text)
+        var offset = 0
+        for (range, replacement) in matches {
+            let lengthBefore = mutableString.length
+            let offsetRange = NSRange(location: range.location + offset, length: range.length)
+            mutableString.replaceCharacters(in: offsetRange, with: replacement)
+            let lengthAfter = mutableString.length
+            offset += (lengthAfter - lengthBefore)
+        }
+        return mutableString as String
+    }
+}

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -150,14 +150,14 @@ open class TextView: UITextView {
 
     // MARK: - Properties: Processors
 
-    /// These processors will be executed on any HTML you provide to the method `setHTML()` and
+    /// This processor will be executed on any HTML you provide to the method `setHTML()` and
     /// before Aztec attempts to parse it.
     ///
-    public var preProcessors: PipelineProcessor?
+    public var inputProcessor: Processor?
 
-    /// These processors will be executed right before returning the HTML in `getHTML()`.
+    /// This processor will be executed right before returning the HTML in `getHTML()`.
     ///
-    public var postProcessors: PipelineProcessor?
+    public var outputProcessor: Processor?
 
     // MARK: - Properties: Text Storage
 
@@ -463,7 +463,7 @@ open class TextView: UITextView {
     open func getHTML(prettyPrint: Bool = true) -> String {
 
         let html = storage.getHTML(prettyPrint: prettyPrint)
-        let processedHTML = postProcessors?.process(html) ?? html
+        let processedHTML = outputProcessor?.process(html) ?? html
 
         return processedHTML
     }
@@ -475,7 +475,7 @@ open class TextView: UITextView {
     ///
     open func setHTML(_ html: String) {
 
-        let processedHTML = preProcessors?.process(html) ?? html
+        let processedHTML = inputProcessor?.process(html) ?? html
         
         // NOTE: there's a bug in UIKit that causes the textView's font to be changed under certain
         //      conditions.  We are assigning the default font here again to avoid that issue.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -153,11 +153,11 @@ open class TextView: UITextView {
     /// These processors will be executed on any HTML you provide to the method `setHTML()` and
     /// before Aztec attempts to parse it.
     ///
-    public var preProcessors: ProcessorPipeline?
+    public var preProcessors: PipelineProcessor?
 
     /// These processors will be executed right before returning the HTML in `getHTML()`.
     ///
-    public var postProcessors: ProcessorPipeline?
+    public var postProcessors: PipelineProcessor?
 
     // MARK: - Properties: Text Storage
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -148,6 +148,17 @@ open class TextView: UITextView {
     let defaultFont: UIFont
     var defaultMissingImage: UIImage
 
+    // MARK: - Properties: Processors
+
+    /// These processors will be executed on any HTML you provide to the method `setHTML()` and
+    /// before Aztec attempts to parse it.
+    ///
+    public var preProcessors: ProcessorPipeline?
+
+    /// These processors will be executed right before returning the HTML in `getHTML()`.
+    ///
+    public var postProcessors: ProcessorPipeline?
+
     // MARK: - Properties: Text Storage
 
     var storage: TextStorage {
@@ -450,7 +461,11 @@ open class TextView: UITextView {
     /// - Returns: The HTML version of the current Attributed String.
     ///
     open func getHTML(prettyPrint: Bool = true) -> String {
-        return storage.getHTML(prettyPrint: prettyPrint)
+
+        let html = storage.getHTML(prettyPrint: prettyPrint)
+        let processedHTML = postProcessors?.process(html) ?? html
+
+        return processedHTML
     }
 
 
@@ -459,6 +474,8 @@ open class TextView: UITextView {
     /// - Parameter html: The raw HTML we'd be editing.
     ///
     open func setHTML(_ html: String) {
+
+        let processedHTML = preProcessors?.process(html) ?? html
         
         // NOTE: there's a bug in UIKit that causes the textView's font to be changed under certain
         //      conditions.  We are assigning the default font here again to avoid that issue.
@@ -468,7 +485,7 @@ open class TextView: UITextView {
         //
         font = defaultFont
         
-        storage.setHTML(html, withDefaultFontDescriptor: font!.fontDescriptor)
+        storage.setHTML(processedHTML, withDefaultFontDescriptor: font!.fontDescriptor)
         if storage.length > 0 && selectedRange.location < storage.length {
             typingAttributes = storage.attributes(at: selectedRange.location, effectiveRange: nil)
         }

--- a/AztecTests/Processor/HTMLProcessorTests.swift
+++ b/AztecTests/Processor/HTMLProcessorTests.swift
@@ -31,7 +31,7 @@ class HTMLProcessorTests: XCTestCase {
             return html
         })
         let sampleText = "<video src=\"videopress://OcobLTqC\" width=640 height=400 data-wpvideopress=\"OcobLTqC\" />"
-        let parsedText = processor.process(text: sampleText)
+        let parsedText = processor.process(sampleText)
         XCTAssertEqual(parsedText, "[wpvideo OcobLTqC height=\"400\" width=\"640\" /]")
     }
     

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -25,6 +25,11 @@
 		CC400F1A1E9EC04200859AB4 /* AztecUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC400F191E9EC04200859AB4 /* AztecUITests.swift */; };
 		CC400F251E9EC16900859AB4 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC400F241E9EC16900859AB4 /* XCTest+Extensions.swift */; };
 		E63EF92B1D36A60B00B5BA4B /* EditorDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E63EF92A1D36A60B00B5BA4B /* EditorDemoController.swift */; };
+		F13CE5421F4DD2520043368D /* CaptionShortcodePreProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE5411F4DD2520043368D /* CaptionShortcodePreProcessor.swift */; };
+		F13CE5461F4DD8930043368D /* CaptionShortcodePostProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE5451F4DD8930043368D /* CaptionShortcodePostProcessor.swift */; };
+		F13CE5481F4DD99D0043368D /* WPVideoShortcodePreProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE5471F4DD99D0043368D /* WPVideoShortcodePreProcessor.swift */; };
+		F13CE54A1F4DDA8B0043368D /* VideoShortcodePreProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE5491F4DDA8B0043368D /* VideoShortcodePreProcessor.swift */; };
+		F13CE54C1F4DDB3A0043368D /* VideoShortcodePostProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE54B1F4DDB3A0043368D /* VideoShortcodePostProcessor.swift */; };
 		FF6691C21E76CF9200C6A703 /* OptionsTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */; };
 		FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */; };
 		FFD06EA41EC3C5350072AD85 /* ShortcodeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD06EA31EC3C5350072AD85 /* ShortcodeProcessor.swift */; };
@@ -117,6 +122,11 @@
 		CC400F1B1E9EC04200859AB4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CC400F241E9EC16900859AB4 /* XCTest+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTest+Extensions.swift"; sourceTree = "<group>"; };
 		E63EF92A1D36A60B00B5BA4B /* EditorDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorDemoController.swift; sourceTree = "<group>"; };
+		F13CE5411F4DD2520043368D /* CaptionShortcodePreProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CaptionShortcodePreProcessor.swift; sourceTree = "<group>"; };
+		F13CE5451F4DD8930043368D /* CaptionShortcodePostProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CaptionShortcodePostProcessor.swift; sourceTree = "<group>"; };
+		F13CE5471F4DD99D0043368D /* WPVideoShortcodePreProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPVideoShortcodePreProcessor.swift; sourceTree = "<group>"; };
+		F13CE5491F4DDA8B0043368D /* VideoShortcodePreProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoShortcodePreProcessor.swift; sourceTree = "<group>"; };
+		F13CE54B1F4DDB3A0043368D /* VideoShortcodePostProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoShortcodePostProcessor.swift; sourceTree = "<group>"; };
 		FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionsTableView.swift; sourceTree = "<group>"; };
 		FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AttachmentDetailsViewController.storyboard; sourceTree = "<group>"; };
 		FFD06EA31EC3C5350072AD85 /* ShortcodeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcodeProcessor.swift; sourceTree = "<group>"; };
@@ -275,7 +285,12 @@
 		FF9D82941ED452340080ACAF /* Processors */ = {
 			isa = PBXGroup;
 			children = (
+				F13CE5411F4DD2520043368D /* CaptionShortcodePreProcessor.swift */,
+				F13CE5451F4DD8930043368D /* CaptionShortcodePostProcessor.swift */,
 				FFD06EA31EC3C5350072AD85 /* ShortcodeProcessor.swift */,
+				F13CE5491F4DDA8B0043368D /* VideoShortcodePreProcessor.swift */,
+				F13CE54B1F4DDB3A0043368D /* VideoShortcodePostProcessor.swift */,
+				F13CE5471F4DD99D0043368D /* WPVideoShortcodePreProcessor.swift */,
 			);
 			name = Processors;
 			sourceTree = "<group>";
@@ -447,7 +462,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				B5DB1C371EC630E10005E623 /* UnknownEditorViewController.swift in Sources */,
+				F13CE5461F4DD8930043368D /* CaptionShortcodePostProcessor.swift in Sources */,
+				F13CE5421F4DD2520043368D /* CaptionShortcodePreProcessor.swift in Sources */,
 				599F25701D8BCF57002871D6 /* AppDelegate.swift in Sources */,
+				F13CE54A1F4DDA8B0043368D /* VideoShortcodePreProcessor.swift in Sources */,
+				F13CE5481F4DD99D0043368D /* WPVideoShortcodePreProcessor.swift in Sources */,
 				FFD06EA41EC3C5350072AD85 /* ShortcodeProcessor.swift in Sources */,
 				59D2873B1D8C599B00B99C80 /* AttachmentDetailsViewController.swift in Sources */,
 				FF6691C21E76CF9200C6A703 /* OptionsTableView.swift in Sources */,
@@ -455,6 +474,7 @@
 				B5AF89341E93ECE60051EFDB /* HTMLAttachmentRenderer.swift in Sources */,
 				E63EF92B1D36A60B00B5BA4B /* EditorDemoController.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
+				F13CE54C1F4DDB3A0043368D /* VideoShortcodePostProcessor.swift in Sources */,
 				B570B1C91E82D332008CF41E /* MoreAttachmentRenderer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Example/CaptionShortcodePostProcessor.swift
+++ b/Example/Example/CaptionShortcodePostProcessor.swift
@@ -1,0 +1,36 @@
+import Aztec
+import Foundation
+
+class CaptionShortcodePostProcessor: Aztec.HTMLProcessor {
+
+    init() {
+        super.init(tag: "div") { (shortcode) in
+
+            let dataShortcodeAttributeKey = "data-shortcode"
+
+            guard let shortcodeType = shortcode.attributes.named[dataShortcodeAttributeKey],
+                shortcodeType.lowercased() == "caption" else {
+                    return nil
+            }
+
+            var html = "[caption "
+
+            for (key, value) in shortcode.attributes.named {
+
+                guard key != dataShortcodeAttributeKey else {
+                    continue
+                }
+
+                html += "\(key)=\"\(value)\" "
+            }
+
+            for value in shortcode.attributes.unamed {
+                html += "\(value) "
+            }
+
+            html += "]" + (shortcode.content ?? "") + "[/caption]"
+            
+            return html
+        }
+    }
+}

--- a/Example/Example/CaptionShortcodePostProcessor.swift
+++ b/Example/Example/CaptionShortcodePostProcessor.swift
@@ -15,12 +15,7 @@ class CaptionShortcodePostProcessor: Aztec.HTMLProcessor {
 
             var html = "[caption "
 
-            for (key, value) in shortcode.attributes.named {
-
-                guard key != dataShortcodeAttributeKey else {
-                    continue
-                }
-
+            for (key, value) in shortcode.attributes.named where key != dataShortcodeAttributeKey {
                 html += "\(key)=\"\(value)\" "
             }
 

--- a/Example/Example/CaptionShortcodePreProcessor.swift
+++ b/Example/Example/CaptionShortcodePreProcessor.swift
@@ -1,0 +1,27 @@
+import Aztec
+import Foundation
+
+class CaptionShortcodePreProcessor: ShortcodeProcessor {
+
+    init() {
+        super.init(tag: "caption") { shortcode -> String in
+            var html = "<div data-shortcode=\"caption\" "
+
+            for (key, value) in shortcode.attributes.named {
+                html += "\(key)=\"\(value)\" "
+            }
+
+            for value in shortcode.attributes.unamed {
+                html += "\(value) "
+            }
+
+            if let content = shortcode.content {
+                html += ">" + content + "</div>"
+            } else {
+                html += "/>"
+            }
+            
+            return html
+        }
+    }
+}

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -19,12 +19,12 @@ class EditorDemoController: UIViewController {
         let textView = Aztec.TextView(defaultFont: Constants.defaultContentFont, defaultMissingImage: Constants.defaultMissingImage)
 
         textView.preProcessors =
-            ProcessorPipeline([CaptionShortcodePreProcessor(),
+            PipelineProcessor([CaptionShortcodePreProcessor(),
                                VideoShortcodePreProcessor(),
                                WPVideoShortcodePreProcessor()])
 
         textView.postProcessors =
-            ProcessorPipeline([CaptionShortcodePostProcessor(),
+            PipelineProcessor([CaptionShortcodePostProcessor(),
                                VideoShortcodePostProcessor()])
 
         let accessibilityLabel = NSLocalizedString("Rich Content", comment: "Post Rich content")

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -18,12 +18,12 @@ class EditorDemoController: UIViewController {
     fileprivate(set) lazy var richTextView: Aztec.TextView = {
         let textView = Aztec.TextView(defaultFont: Constants.defaultContentFont, defaultMissingImage: Constants.defaultMissingImage)
 
-        textView.preProcessors =
+        textView.inputProcessor =
             PipelineProcessor([CaptionShortcodePreProcessor(),
                                VideoShortcodePreProcessor(),
                                WPVideoShortcodePreProcessor()])
 
-        textView.postProcessors =
+        textView.outputProcessor =
             PipelineProcessor([CaptionShortcodePostProcessor(),
                                VideoShortcodePostProcessor()])
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -126,9 +126,7 @@ class EditorDemoController: UIViewController {
     }
 
     func getHTML() -> String {
-        let html = richTextView.getHTML(prettyPrint: true)
-
-        return html
+        return richTextView.getHTML(prettyPrint: true)
     }
 
     fileprivate var optionsViewController: OptionsTableViewController!

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -18,6 +18,15 @@ class EditorDemoController: UIViewController {
     fileprivate(set) lazy var richTextView: Aztec.TextView = {
         let textView = Aztec.TextView(defaultFont: Constants.defaultContentFont, defaultMissingImage: Constants.defaultMissingImage)
 
+        textView.preProcessors =
+            ProcessorPipeline([CaptionShortcodePreProcessor(),
+                               VideoShortcodePreProcessor(),
+                               WPVideoShortcodePreProcessor()])
+
+        textView.postProcessors =
+            ProcessorPipeline([CaptionShortcodePostProcessor(),
+                               VideoShortcodePostProcessor()])
+
         let accessibilityLabel = NSLocalizedString("Rich Content", comment: "Post Rich content")
         self.configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
 
@@ -108,28 +117,18 @@ class EditorDemoController: UIViewController {
         }
     }
 
-
     fileprivate var currentSelectedAttachment: MediaAttachment?
 
     var loadSampleHTML = false
 
-    private var shortcodePreProcessors = [Processor]()
-    private var shortcodePostProcessors = [Processor]()
-
     func setHTML(_ html: String) {
-        var processedHTML = html
-        for shortcodeProcessor in shortcodePreProcessors {
-            processedHTML = shortcodeProcessor.process(text: processedHTML)
-        }
-        richTextView.setHTML(processedHTML)
+        richTextView.setHTML(html)
     }
 
     func getHTML() -> String {
-        var processedHTML = richTextView.getHTML(prettyPrint: true)
-        for shortcodeProcessor in shortcodePostProcessors {
-            processedHTML = shortcodeProcessor.process(text: processedHTML)
-        }
-        return processedHTML
+        let html = richTextView.getHTML(prettyPrint: true)
+
+        return html
     }
 
     fileprivate var optionsViewController: OptionsTableViewController!
@@ -157,7 +156,6 @@ class EditorDemoController: UIViewController {
         view.addSubview(separatorView)
         configureConstraints()
         registerAttachmentImageProviders()
-        registerShortcodeProcessors()
 
         let html: String
 
@@ -292,136 +290,6 @@ class EditorDemoController: UIViewController {
             richTextView.registerAttachmentImageProvider(provider)
         }
     }
-
-    // MARK: - Shortcode Processors: Main Registration Point
-
-    private func registerShortcodeProcessors() {
-
-        // This method should not be called more than once.
-        //
-        assert(shortcodePreProcessors.count == 0)
-        assert(shortcodePostProcessors.count == 0)
-
-        registerCaptionShortcodeProcessors()
-        registerVideoShortcodeProcessors()
-    }
-
-    // MARK: - Shortcode Processors: Captions
-
-    private func registerCaptionShortcodeProcessors() {
-        registerCaptionShortcodePreProcessors()
-        registerCaptionShortcodePostProcessors()
-    }
-
-    private func registerCaptionShortcodePreProcessors() {
-        let captionPreProcessor = ShortcodeProcessor(tag: "caption") { shortcode -> String in
-            var html = "<div data-shortcode=\"caption\" "
-
-            for (key, value) in shortcode.attributes.named {
-                html += "\(key)=\"\(value)\" "
-            }
-
-            for value in shortcode.attributes.unamed {
-                html += "\(value) "
-            }
-
-            if let content = shortcode.content {
-                html += ">" + content + "</div>"
-            } else {
-                html += "/>"
-            }
-
-            return html
-        }
-
-        shortcodePreProcessors.append(captionPreProcessor)
-    }
-
-    private func registerCaptionShortcodePostProcessors() {
-        let captionPostProcessor = HTMLProcessor(tag:"div", replacer: { (shortcode) in
-
-            guard let shortcodeType = shortcode.attributes.named["data-shortcode"],
-                shortcodeType.lowercased() == "caption" else {
-                    return nil
-            }
-
-            var html = "[caption "
-
-            for (key, value) in shortcode.attributes.named {
-                html += "\(key)=\"\(value)\" "
-            }
-
-            for value in shortcode.attributes.unamed {
-                html += "\(value) "
-            }
-
-            html += "]" + (shortcode.content ?? "") + "[/caption]"
-
-            return html
-        })
-
-        shortcodePostProcessors.append(captionPostProcessor)
-
-    }
-
-    // MARK: - Shortcode Processors: Video
-
-    private func registerVideoShortcodeProcessors() {
-        registerVideoShortcodePreProcessors()
-        registerVideoShortcodePostProcessors()
-    }
-
-    private func registerVideoShortcodePreProcessors() {
-        let wpVideoShortcodeProcessor = ShortcodeProcessor(tag:"wpvideo", replacer: { (shortcode) in
-            var html = "<video "
-            if let src = shortcode.attributes.unamed.first {
-                html += "src=\"videopress://\(src)\" "
-                html += "data-wpvideopress=\"\(src)\" "
-            }
-            if let width = shortcode.attributes.named["w"] {
-                html += "width=\(width) "
-            }
-            if let height = shortcode.attributes.named["h"] {
-                html += "height=\(height) "
-            }
-
-            html += "/>"
-            return html
-        })
-
-        let videoShortcodeProcessor = ShortcodeProcessor(tag:"video", replacer: { (shortcode) in
-            var html = "<video "
-            for (key, value) in shortcode.attributes.named {
-                html += "\(key)=\"\(value)\" "
-            }
-            for value in shortcode.attributes.unamed {
-                html += "\(value) "
-            }
-            html += "/>"
-            return html
-        })
-
-        shortcodePreProcessors.append(wpVideoShortcodeProcessor)
-        shortcodePreProcessors.append(videoShortcodeProcessor)
-    }
-
-    private func registerVideoShortcodePostProcessors() {
-
-        let videoShortcodeProcessor = HTMLProcessor(tag:"video", replacer: { (shortcode) in
-            var html = "[video "
-            for (key, value) in shortcode.attributes.named {
-                html += "\(key)=\"\(value)\" "
-            }
-            for value in shortcode.attributes.unamed {
-                html += "\(value) "
-            }
-            html += "/]"
-            return html
-        })
-
-        shortcodePostProcessors.append(videoShortcodeProcessor)
-    }
-
 
     // MARK: - Helpers
 

--- a/Example/Example/VideoShortcodePostProcessor.swift
+++ b/Example/Example/VideoShortcodePostProcessor.swift
@@ -1,0 +1,23 @@
+import Aztec
+import Foundation
+
+class VideoShortcodePostProcessor: Aztec.HTMLProcessor {
+
+    init() {
+        super.init(tag:"video") { (shortcode) in
+            var html = "[video "
+
+            for (key, value) in shortcode.attributes.named {
+                html += "\(key)=\"\(value)\" "
+            }
+
+            for value in shortcode.attributes.unamed {
+                html += "\(value) "
+            }
+
+            html += "/]"
+
+            return html
+        }
+    }
+}

--- a/Example/Example/VideoShortcodePreProcessor.swift
+++ b/Example/Example/VideoShortcodePreProcessor.swift
@@ -1,0 +1,19 @@
+import Aztec
+import Foundation
+
+class VideoShortcodePreProcessor: ShortcodeProcessor {
+
+    init() {
+        super.init(tag:"video") { (shortcode) in
+            var html = "<video "
+            for (key, value) in shortcode.attributes.named {
+                html += "\(key)=\"\(value)\" "
+            }
+            for value in shortcode.attributes.unamed {
+                html += "\(value) "
+            }
+            html += "/>"
+            return html
+        }
+    }
+}

--- a/Example/Example/WPVideoShortcodePreProcessor.swift
+++ b/Example/Example/WPVideoShortcodePreProcessor.swift
@@ -1,0 +1,25 @@
+import Aztec
+import Foundation
+
+class WPVideoShortcodePreProcessor: ShortcodeProcessor {
+
+    init() {
+        super.init(tag: "wpvideo") { (shortcode) in
+            var html = "<video "
+            if let src = shortcode.attributes.unamed.first {
+                html += "src=\"videopress://\(src)\" "
+                html += "data-wpvideopress=\"\(src)\" "
+            }
+            if let width = shortcode.attributes.named["w"] {
+                html += "width=\(width) "
+            }
+            if let height = shortcode.attributes.named["h"] {
+                html += "height=\(height) "
+            }
+
+            html += "/>"
+
+            return html
+        }
+    }
+}

--- a/Example/Tests/ShortcodeProcessorTests.swift
+++ b/Example/Tests/ShortcodeProcessorTests.swift
@@ -28,7 +28,7 @@ class ShortcodeProcessorTests: XCTestCase {
             return html
         })
         let sampleText = "[wpvideo OcobLTqC w=640 h=400 autoplay=true html5only=true] Some Text"
-        let parsedText = shortCodeParser.process(text: sampleText)
+        let parsedText = shortCodeParser.process(sampleText)
         XCTAssertEqual(parsedText, "<video src=\"videopress://OcobLTqC\" data-wpvideopress=\"OcobLTqC\" width=640 height=400 /> Some Text")
     }
 
@@ -42,7 +42,7 @@ class ShortcodeProcessorTests: XCTestCase {
             return html
         })
         let sampleText = "[video src=\"video-source.mp4\"]"
-        let parsedText = shortCodeParser.process(text: sampleText)
+        let parsedText = shortCodeParser.process(sampleText)
         XCTAssertEqual(parsedText, "<video src=\"video-source.mp4\" />")
     }
     


### PR DESCRIPTION
This PR:

- Adds `ProcessorPipeline` to Aztec.
- Adds a pre and post processor to Aztec.TextView (convenient for Apps to use).
- Hooks the pre and post processor to `setHTML()` and `getHTML()`.
- Moves `RegexProcessor` and the other processors to a file of their own.

The corresponding WPiOS PR integrating these changes is [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/7720).

I'll integrate with WPiOS as soon as this is merged into develop.