### PR TITLE
HeaderFormatter: Restoring the default font size upon removal

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		B5B96DAB1E01B2F300791315 /* UIPasteboard+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B96DAA1E01B2F300791315 /* UIPasteboard+Helpers.swift */; };
 		B5BC4FEE1DA2C17800614582 /* NSAttributedString+Lists.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BC4FED1DA2C17800614582 /* NSAttributedString+Lists.swift */; };
 		B5BC4FF21DA2D17000614582 /* NSAttributedStringListsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BC4FF11DA2D17000614582 /* NSAttributedStringListsTests.swift */; };
+		B5C16A631F4DF77300B113CF /* HeaderFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C16A621F4DF77300B113CF /* HeaderFormatterTests.swift */; };
 		B5C99D3F1E72E2E700335355 /* UIStackView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C99D3E1E72E2E700335355 /* UIStackView+Helpers.swift */; };
 		B5D575811F226FF4003A62F6 /* UnsupportedHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D575801F226FF4003A62F6 /* UnsupportedHTMLTests.swift */; };
 		B5D575831F22820A003A62F6 /* HTMLRepresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D575821F22820A003A62F6 /* HTMLRepresentationTests.swift */; };
@@ -228,6 +229,7 @@
 		B5B96DAA1E01B2F300791315 /* UIPasteboard+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIPasteboard+Helpers.swift"; sourceTree = "<group>"; };
 		B5BC4FED1DA2C17800614582 /* NSAttributedString+Lists.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Lists.swift"; sourceTree = "<group>"; };
 		B5BC4FF11DA2D17000614582 /* NSAttributedStringListsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSAttributedStringListsTests.swift; path = Extensions/NSAttributedStringListsTests.swift; sourceTree = "<group>"; };
+		B5C16A621F4DF77300B113CF /* HeaderFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderFormatterTests.swift; sourceTree = "<group>"; };
 		B5C99D3E1E72E2E700335355 /* UIStackView+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStackView+Helpers.swift"; sourceTree = "<group>"; };
 		B5D575801F226FF4003A62F6 /* UnsupportedHTMLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UnsupportedHTMLTests.swift; path = TextKit/UnsupportedHTMLTests.swift; sourceTree = "<group>"; };
 		B5D575821F22820A003A62F6 /* HTMLRepresentationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HTMLRepresentationTests.swift; path = TextKit/HTMLRepresentationTests.swift; sourceTree = "<group>"; };
@@ -648,6 +650,7 @@
 				E11B775F1DBA14B40024E455 /* BlockquoteFormatterTests.swift */,
 				FFD436971E3180A500A0E26F /* FontFormatterTests.swift */,
 				B542D6411E9EB122009D12D3 /* PreFormaterTests.swift */,
+				B5C16A621F4DF77300B113CF /* HeaderFormatterTests.swift */,
 			);
 			path = Formatters;
 			sourceTree = "<group>";
@@ -1066,6 +1069,7 @@
 				FF152D8E1E68552A00FF596C /* StringRangeConversionTests.swift in Sources */,
 				59FEA07A1D8BDFA700D138DF /* InHTMLConverterTests.swift in Sources */,
 				E11B77601DBA14B40024E455 /* BlockquoteFormatterTests.swift in Sources */,
+				B5C16A631F4DF77300B113CF /* HeaderFormatterTests.swift in Sources */,
 				B5D575881F2288E2003A62F6 /* TextViewStubAttachmentDelegate.swift in Sources */,
 				B5DA1C1F1EBD1EA7000AAB45 /* OutHTMLConverterTests.swift in Sources */,
 				F1000CE91EAA5C720000B15B /* StringEndOfLineTests.swift in Sources */,

--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -17,7 +17,7 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
 
     /// Designated Initializer
     ///
-    init(headerLevel: Header.HeaderType = .h1, placeholderAttributes: [String : Any]? = nil) {
+    init(headerLevel: Header.HeaderType = .h1, placeholderAttributes: [String: Any]? = nil) {
         self.headerLevel = headerLevel
         self.placeholderAttributes = placeholderAttributes
     }
@@ -68,11 +68,12 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func present(in attributes: [String : Any]) -> Bool {
-        if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle {
-            return paragraphStyle.headerLevel != 0 && paragraphStyle.headerLevel == headerLevel.rawValue
+    func present(in attributes: [String: Any]) -> Bool {
+        guard let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle else {
+            return false
         }
-        return false
+
+        return paragraphStyle.headerLevel != 0 && paragraphStyle.headerLevel == headerLevel.rawValue
     }
 }
 

--- a/Aztec/Classes/TextKit/ParagraphProperty/Header.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/Header.swift
@@ -21,7 +21,7 @@ open class Header: ParagraphProperty {
 
         public var fontSize: CGFloat {
             switch self {
-            case .none: return 14
+            case .none: return Constants.defaultFontSize
             case .h1: return 36
             case .h2: return 24
             case .h3: return 21
@@ -38,27 +38,61 @@ open class Header: ParagraphProperty {
     ///
     let level: HeaderType
 
-    init(level: HeaderType, with representation: HTMLRepresentation? = nil) {
+    /// Default Font Size (corresponding to HeaderType.none)
+    ///
+    let defaultFontSize: CGFloat
+
+
+    // MARK: - Initializers
+
+    init(level: HeaderType, with representation: HTMLRepresentation? = nil, defaultFontSize: CGFloat? = nil) {
+        self.defaultFontSize = defaultFontSize ?? Constants.defaultFontSize
         self.level = level
         super.init(with: representation)
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        if aDecoder.containsValue(forKey: String(describing: HeaderType.self)),
-            let decodedStyle = HeaderType(rawValue:aDecoder.decodeInteger(forKey: String(describing: HeaderType.self))) {
-            level = decodedStyle
+        if aDecoder.containsValue(forKey: Keys.level),
+            let decodedLevel = HeaderType(rawValue: aDecoder.decodeInteger(forKey: Keys.level))
+        {
+            level = decodedLevel
         } else {
             level = .none
         }
+
+        if aDecoder.containsValue(forKey: Keys.level) {
+            defaultFontSize = CGFloat(aDecoder.decodeFloat(forKey: Keys.defaultFontSize))
+        } else {
+            defaultFontSize = Constants.defaultFontSize
+        }
+
         super.init(coder: aDecoder)
     }
 
+
+    // MARK: - NSCoder
+
     public override func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
-        aCoder.encode(level.rawValue, forKey: String(describing: HeaderType.self))
+        aCoder.encode(defaultFontSize, forKey: Keys.defaultFontSize)
+        aCoder.encode(level.rawValue, forKey: Keys.level)
     }
 
     static func ==(lhs: Header, rhs: Header) -> Bool {
         return lhs.level == rhs.level
+    }
+}
+
+
+// MARK: - Private Helpers
+//
+private extension Header {
+    struct Constants {
+        static let defaultFontSize = CGFloat(14)
+    }
+
+    struct Keys {
+        static let defaultFontSize = "defaultFontSize"
+        static let level = String(describing: HeaderType.self)
     }
 }

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -335,7 +335,7 @@ extension ParagraphStyle {
         }
     }
 
-    /// Removes the first ParagraphProperty present in the Properties collection with a given instance
+    /// Replaces the first ParagraphProperty present in the Properties collection with a given instance
     ///
     func replaceProperty(ofType type: AnyClass, with newProperty: ParagraphProperty) {
         for index in (0..<properties.count).reversed() {

--- a/AztecTests/Formatters/HeaderFormatterTests.swift
+++ b/AztecTests/Formatters/HeaderFormatterTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import Aztec
+
+
+// MARK: - HeaderFormatterTests
+//
+class HeaderFormatterTests: XCTestCase {
+
+    /// Sample Default Font Size
+    ///
+    private let defaultFontSize = CGFloat(9)
+
+    /// Sample Attributes
+    ///
+    private lazy var attributes: [String: Any] = {
+        return [NSFontAttributeName: UIFont.systemFont(ofSize: self.defaultFontSize)]
+    }()
+
+
+    /// Verifies that the default font size is effectively restored after the Header Formatter is removed.
+    ///
+    func testDefaultFontIsRestoredWhenFormattingIsRemoved() {
+        let formatter = HeaderFormatter(headerLevel: .h1, placeholderAttributes: nil)
+
+        let updatedAttrs = formatter.apply(to: attributes, andStore: nil)
+        let updatedFont = updatedAttrs[NSFontAttributeName] as! UIFont
+        XCTAssert(updatedFont.pointSize == formatter.headerLevel.fontSize)
+
+        let removedAttrs = formatter.remove(from: updatedAttrs)
+        let removedFont = removedAttrs[NSFontAttributeName] as! UIFont
+        XCTAssert(removedFont.pointSize == defaultFontSize)
+    }
+
+    /// Verifies that the Default Font is preserved whenever a Header Style is applied on top of an existant Header.
+    ///
+    func testDefaultFontIsPreservedWheneverTheHeaderLevelIsUpdated() {
+        let formatterH1 = HeaderFormatter(headerLevel: .h1, placeholderAttributes: nil)
+        let updatedH1Attrs = formatterH1.apply(to: attributes, andStore: nil)
+        let updatedH1Font = updatedH1Attrs[NSFontAttributeName] as! UIFont
+        XCTAssert(updatedH1Font.pointSize == formatterH1.headerLevel.fontSize)
+
+        let formatterH2 = HeaderFormatter(headerLevel: .h2, placeholderAttributes: nil)
+        let updatedH2Attrs = formatterH2.apply(to: attributes, andStore: nil)
+        let updatedH2Font = updatedH2Attrs[NSFontAttributeName] as! UIFont
+        XCTAssert(updatedH2Font.pointSize == formatterH2.headerLevel.fontSize)
+
+        let removedAttrs = formatterH2.remove(from: updatedH2Attrs)
+        let removedFont = removedAttrs[NSFontAttributeName] as! UIFont
+        XCTAssert(removedFont.pointSize == defaultFontSize)
+    }
+}

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1458,7 +1458,7 @@ private extension EditorDemoController
 extension EditorDemoController {
 
     struct Constants {
-        static let defaultContentFont   = UIFont.systemFont(ofSize: 14)
+        static let defaultContentFont   = UIFont.systemFont(ofSize: 16)
         static let defaultHtmlFont      = UIFont.systemFont(ofSize: 24)
         static let defaultMissingImage  = Gridicon.iconOfType(.image)
         static let formatBarIconSize    = CGSize(width: 20.0, height: 20.0)

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -697,10 +697,13 @@ extension EditorDemoController {
     }
 
     func toggleHeader(fromItem item: FormatBarItem) {
-        let headerOptions = Constants.headers.map { (headerType) -> OptionsTableViewOption in
-            return OptionsTableViewOption(image: headerType.iconImage,
-                                          title: NSAttributedString(string: headerType.description,
-                                                                    attributes:[NSFontAttributeName: UIFont.systemFont(ofSize: headerType.fontSize)]))
+        let headerOptions = Constants.headers.map { headerType -> OptionsTableViewOption in
+            let attributes = [
+                NSFontAttributeName: UIFont.systemFont(ofSize: headerType.fontSize)
+            ]
+
+            let title = NSAttributedString(string: headerType.description, attributes: attributes)
+            return OptionsTableViewOption(image: headerType.iconImage, title: title)
         }
 
         let selectedIndex = Constants.headers.index(of: self.headerLevelForSelectedText())
@@ -709,7 +712,9 @@ extension EditorDemoController {
                                                   fromBarItem: item,
                                                   selectedRowIndex: selectedIndex,
                                                   onSelect: { [weak self] selected in
-            guard let range = self?.richTextView.selectedRange else { return }
+            guard let range = self?.richTextView.selectedRange else {
+                return
+            }
 
             self?.richTextView.toggleHeader(Constants.headers[selected], range: range)
             self?.optionsViewController = nil


### PR DESCRIPTION
### Details:
In this PR we're updating the HeaderFormatter so that the default Font Size is preserved whenever a Header Style is applied / updated, and restored whenever the style gets effectively removed.

Fixes #677

### To test:
1. Verify the unit tests are happy
2. Launch the empty editor
3. Type `Pristine` + newline
4. Toggle H1
5. Type `Hello` + newline + `World`
6. Verify that the `World` word gets rendered in the exact same size as `Pristine`

cc @diegoreymendez  + @SergioEstevao 
Thanks in advance!

