### PR TITLE
Fixing Xcode 9 Build Errors

### DIFF
--- a/Aztec/Classes/Extensions/NSRange+Helpers.swift
+++ b/Aztec/Classes/Extensions/NSRange+Helpers.swift
@@ -139,8 +139,13 @@ extension Sequence where Iterator.Element == NSRange {
     }
 }
 
-extension NSRange: Equatable {
-    public static func ==(lhs: NSRange, rhs: NSRange) -> Bool{
-        return lhs.location == rhs.location && lhs.length == rhs.length
+#if swift(>=3.2)
+    // No Op
+#else
+    extension NSRange: Equatable {
+        public static func ==(lhs: NSRange, rhs: NSRange) -> Bool{
+            return lhs.location == rhs.location && lhs.length == rhs.length
+        }
     }
-}
+#endif
+

--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -81,15 +81,6 @@ public extension String {
         return start ..< end
     }
 
-    func range(from unicodeNSRange: Range<String.UnicodeScalarView.Index>) -> Range<String.Index>? {
-        guard let lowerBound = unicodeNSRange.lowerBound.samePosition(in: self),
-            let upperBound = unicodeNSRange.upperBound.samePosition(in: self) else {
-                return nil
-        }
-
-        return lowerBound ..< upperBound
-    }
-
     func nsRange(of string: String) -> NSRange? {
         guard let range = self.range(of: string) else {
             return nil
@@ -127,20 +118,6 @@ public extension String {
 
         let location = utf16.distance(from: utf16.startIndex, to: lowerBound)
         let length = utf16.distance(from: lowerBound, to: upperBound)
-
-        return NSRange(location: location, length: length)
-    }
-
-    /// Converts a `Range<String.UnicodeScalarView.Index>` into an Unicod Scalar `NSRange`.
-    ///
-    /// - Parameters:
-    ///     - range: the range to convert.
-    ///
-    /// - Returns: the requested `NSRange`.
-    ///
-    func nsRange(from range: Range<String.UnicodeScalarView.Index>) -> NSRange {
-        let location = unicodeScalars.distance(from: unicodeScalars.startIndex, to: range.lowerBound)
-        let length = unicodeScalars.distance(from: range.lowerBound, to: range.upperBound)
 
         return NSRange(location: location, length: length)
     }

--- a/Aztec/Classes/TextKit/HTMLStorage.swift
+++ b/Aztec/Classes/TextKit/HTMLStorage.swift
@@ -147,7 +147,7 @@ private extension HTMLStorage {
     ///
     struct Styles {
         static let defaultCommentColor = UIColor.lightGray
-        static let defaultTagColor = UIColor(colorLiteralRed: 0x00/255.0, green: 0x75/255.0, blue: 0xB6/255.0, alpha: 0xFF/255.0)
-        static let defaultQuotedColor = UIColor(colorLiteralRed: 0x6E/255.0, green: 0x96/255.0, blue: 0xB1/255.0, alpha: 0xFF/255.0)
+        static let defaultTagColor = UIColor(red: 0x00/255.0, green: 0x75/255.0, blue: 0xB6/255.0, alpha: 0xFF/255.0)
+        static let defaultQuotedColor = UIColor(red: 0x6E/255.0, green: 0x96/255.0, blue: 0xB1/255.0, alpha: 0xFF/255.0)
     }
 }

--- a/AztecTests/Extensions/UIColorHexParserTests.swift
+++ b/AztecTests/Extensions/UIColorHexParserTests.swift
@@ -28,7 +28,7 @@ class UIColorHexParserTests: XCTestCase {
 
         color = UIColor(hexString: "#FFFFFF")
 
-        XCTAssertEqual(color, UIColor.init(colorLiteralRed: 1, green: 1, blue: 1, alpha: 1))
+        XCTAssertEqual(color, UIColor(red: 1, green: 1, blue: 1, alpha: 1))
     }
 
     func testParseOf32bitsHexColors() {
@@ -46,7 +46,7 @@ class UIColorHexParserTests: XCTestCase {
 
         color = UIColor(hexString: "#FFFFFFFF")
 
-        XCTAssertEqual(color, UIColor.init(colorLiteralRed: 1, green: 1, blue: 1, alpha: 1))
+        XCTAssertEqual(color, UIColor(red: 1, green: 1, blue: 1, alpha: 1))
     }
 
     func testFailingColor() {

--- a/AztecTests/TextKit/TextViewStubAttachmentDelegate.swift
+++ b/AztecTests/TextKit/TextViewStubAttachmentDelegate.swift
@@ -4,7 +4,7 @@ import UIKit
 
 class TextViewStubAttachmentDelegate: TextViewAttachmentDelegate, TextViewAttachmentImageProvider {
 
-    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) {
+    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
         // NO OP!
     }
 

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -33,6 +33,7 @@ class TextViewTests: XCTestCase {
     func createTextView(withHTML html: String) -> TextView {
         let richTextView = Aztec.TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: UIImage())
         richTextView.textAttachmentDelegate = attachmentDelegate
+        richTextView.registerAttachmentImageProvider(attachmentDelegate)
         richTextView.setHTML(html)
 
         return richTextView


### PR DESCRIPTION
### Details:
- NSRange+Equatable implementation now is only available for Swift <3.2
- Nuked two unused Range helpers that were causing build errors
- Fixed a couple UIColor warnings
- Closures that (used to look like) `(Void) -> Void` are now enforced to be `() -> Void`
- Wired a missing `Image Provider` that was causing a crash

### To test:
- Verify that the unit tests are okay in Xcode 8 + 9
- Run a smoke test over Aztec

cc @diegoreymendez @SergioEstevao 
