### PR TITLE
String+EndOfLine: Renaming Helper

### DIFF
--- a/Aztec/Classes/Extensions/String+EndOfLine.swift
+++ b/Aztec/Classes/Extensions/String+EndOfLine.swift
@@ -2,33 +2,33 @@ import Foundation
 
 extension String {
 
-    /// Checks if the receiver has an empty paragraph at the specified index.
+    /// Checks if the receiver has an empty line at the specified index.
     ///
     /// - Parameters:
     ///     - index: the receiver's index to check
     ///
-    /// - Returns: `true` if the specified index is in an empty paragraph, `false` otherwise.
+    /// - Returns: `true` if the specified index is in an empty line, `false` otherwise.
     ///
-    func isEmptyParagraph(at index: String.Index) -> Bool {
+    func isEmptyLine(at index: String.Index) -> Bool {
         return isStartOfNewLine(at: index) && isEndOfLine(at: index)
     }
 
-    /// Checks if the receiver has an empty paragraph at the specified offset.
+    /// Checks if the receiver has an empty line at the specified offset.
     ///
     /// - Parameters:
     ///     - offset: the receiver's offset to check
     ///
-    /// - Returns: `true` if the specified offset is in an empty paragraph, `false` otherwise.
+    /// - Returns: `true` if the specified offset is in an empty line, `false` otherwise.
     ///
-    func isEmptyParagraph(at offset: Int) -> Bool {
+    func isEmptyLine(at offset: Int) -> Bool {
         guard let index = self.indexFromLocation(offset) else {
             return true
         }        
         
-        return isEmptyParagraph(at: index)
+        return isEmptyLine(at: index)
     }
 
-    /// Checks if the receiver has an empty paragraph at the specified offset and if the offset
+    /// Checks if the receiver has an empty line at the specified offset and if the offset
     /// corresponds to EOF (end-of-file).
     ///
     /// - Parameters:
@@ -36,8 +36,8 @@ extension String {
     ///
     /// - Returns: `true` if the specified offset is in an empty paragraph, `false` otherwise.
     ///
-    func isEmptyParagraphAtEndOfFile(at offset: Int) -> Bool {
-        return offset == characters.count && isEmptyParagraph(at: offset)
+    func isEmptyLineAtEndOfFile(at offset: Int) -> Bool {
+        return offset == characters.count && isEmptyLine(at: offset)
     }
 
     /// This methods verifies if the receiver string is an end-of-line character.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -810,7 +810,7 @@ open class TextView: UITextView {
         }
 
         if selectedRangeForSwift.location == textStorage.length
-            && textStorage.string.isEmptyParagraph(at: selectedRangeForSwift.location) {
+            && textStorage.string.isEmptyLine(at: selectedRangeForSwift.location) {
 
             insertEndOfLineCharacter()
         }
@@ -1323,7 +1323,7 @@ private extension TextView {
     /// - Returns: `true` if we should nuke the paragraph attributes.
     ///
     private func mustRemoveParagraphStylesBeforeRemovingCharacter(at range: NSRange) -> Bool {
-        return storage.string.isEmptyParagraph(at: range.location)
+        return storage.string.isEmptyLine(at: range.location)
     }
 
     // MARK: - WORKAROUND: Removing paragraph styles after entering a newline.
@@ -1348,7 +1348,7 @@ private extension TextView {
     /// - Returns: `true` if we should remove paragraph attributes, otherwise it returns `false`.
     ///
     private func mustRemoveSingleLineParagraphAttributesAfterPressingEnter(input: String) -> Bool {
-        return input.isEndOfLine() && storage.string.isEmptyParagraph(at: selectedRange.location)
+        return input.isEndOfLine() && storage.string.isEmptyLine(at: selectedRange.location)
     }
 
 
@@ -1397,7 +1397,7 @@ private extension TextView {
     ///
     private func mustRemoveParagraphAttributesWhenPressingEnterInAnEmptyParagraph(input: String) -> Bool {
         return input.isEndOfLine()
-            && storage.string.isEmptyParagraph(at: selectedRange.location)
+            && storage.string.isEmptyLine(at: selectedRange.location)
             && (BlockquoteFormatter().present(in: typingAttributes)
                 || TextListFormatter.listsOfAnyKindPresent(in: typingAttributes)
                 || PreFormatter().present(in: typingAttributes))
@@ -1444,7 +1444,7 @@ private extension TextView {
     ///
     private func mustRemoveParagraphAttributesAfterSelectionChange() -> Bool {
         return selectedRange.location == storage.length
-            && storage.string.isEmptyParagraph(at: selectedRange.location)
+            && storage.string.isEmptyLine(at: selectedRange.location)
     }
 
     /// Removes the Paragraph Attributes [Blockquote, Pre, Lists] at the specified range. If the range

--- a/AztecTests/StringEndOfLineTests.swift
+++ b/AztecTests/StringEndOfLineTests.swift
@@ -17,80 +17,80 @@ class StringEndOfLineTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - isEmptyParagraph(at index:)
+    // MARK: - isEmptyLine(at index:)
 
-    func testIsEmptyParagraphAtIndex1() {
+    func testIsEmptyLineAtIndex1() {
         let string = "Hello there"
         let index = string.endIndex
 
-        XCTAssertFalse(string.isEmptyParagraph(at: index))
+        XCTAssertFalse(string.isEmptyLine(at: index))
     }
 
-    func testIsEmptyParagraphAtIndex2() {
+    func testIsEmptyLineAtIndex2() {
         let string = "Hello there"
         let index = string.startIndex
 
-        XCTAssertFalse(string.isEmptyParagraph(at: index))
+        XCTAssertFalse(string.isEmptyLine(at: index))
     }
 
-    func testIsEmptyParagraphAtIndex3() {
+    func testIsEmptyLineAtIndex3() {
         let string = ""
         let index = string.startIndex
 
-        XCTAssertTrue(string.isEmptyParagraph(at: index))
+        XCTAssertTrue(string.isEmptyLine(at: index))
     }
 
-    func testIsEmptyParagraphAtIndex4() {
+    func testIsEmptyLineAtIndex4() {
         for separator in endOfLineSeparators {
             let string = separator
             let index = string.startIndex
 
-            XCTAssertTrue(string.isEmptyParagraph(at: index))
+            XCTAssertTrue(string.isEmptyLine(at: index))
         }
     }
 
-    func testIsEmptyParagraphAtIndex5() {
+    func testIsEmptyLineAtIndex5() {
         for separator in endOfLineSeparators {
             let string = separator
             let index = string.endIndex
 
-            XCTAssertTrue(string.isEmptyParagraph(at: index))
+            XCTAssertTrue(string.isEmptyLine(at: index))
         }
     }
 
-    func testIsEmptyParagraphAtIndex6() {
+    func testIsEmptyLineAtIndex6() {
         for separator in endOfLineSeparators {
             let string = "🌎\(separator)"
             let index = string.startIndex
 
-            XCTAssertFalse(string.isEmptyParagraph(at: index))
+            XCTAssertFalse(string.isEmptyLine(at: index))
         }
     }
 
-    func testIsEmptyParagraphAtIndex7() {
+    func testIsEmptyLineAtIndex7() {
         for separator in endOfLineSeparators {
             let string = "🌎\(separator)"
             let index = string.endIndex
 
-            XCTAssertTrue(string.isEmptyParagraph(at: index))
+            XCTAssertTrue(string.isEmptyLine(at: index))
         }
     }
 
-    func testIsEmptyParagraphAtIndex8() {
+    func testIsEmptyLineAtIndex8() {
         for separator in endOfLineSeparators {
             let string = "\(separator)🌎"
             let index = string.startIndex
 
-            XCTAssertTrue(string.isEmptyParagraph(at: index))
+            XCTAssertTrue(string.isEmptyLine(at: index))
         }
     }
 
-    func testIsEmptyParagraphAtIndex9() {
+    func testIsEmptyLineAtIndex9() {
         for separator in endOfLineSeparators {
             let string = "\(separator)🌎"
             let index = string.endIndex
 
-            XCTAssertFalse(string.isEmptyParagraph(at: index))
+            XCTAssertFalse(string.isEmptyLine(at: index))
         }
     }
 
@@ -101,7 +101,7 @@ class StringEndOfLineTests: XCTestCase {
             let string = separator
             let index = string.startIndex
 
-            XCTAssertTrue(string.isEmptyParagraph(at: index))
+            XCTAssertTrue(string.isEmptyLine(at: index))
         }
     }
 
@@ -110,7 +110,7 @@ class StringEndOfLineTests: XCTestCase {
             let string = separator
             let index = string.endIndex
 
-            XCTAssertTrue(string.isEmptyParagraph(at: index))
+            XCTAssertTrue(string.isEmptyLine(at: index))
         }
     }
 
@@ -119,7 +119,7 @@ class StringEndOfLineTests: XCTestCase {
             let string = "🌎\(separator)"
             let index = string.startIndex
 
-            XCTAssertFalse(string.isEmptyParagraph(at: index))
+            XCTAssertFalse(string.isEmptyLine(at: index))
         }
     }
 
@@ -128,7 +128,7 @@ class StringEndOfLineTests: XCTestCase {
             let string = "🌎\(separator)"
             let index = string.endIndex
 
-            XCTAssertTrue(string.isEmptyParagraph(at: index))
+            XCTAssertTrue(string.isEmptyLine(at: index))
         }
     }
 
@@ -137,7 +137,7 @@ class StringEndOfLineTests: XCTestCase {
             let string = "\(separator)🌎"
             let index = string.startIndex
 
-            XCTAssertTrue(string.isEmptyParagraph(at: index))
+            XCTAssertTrue(string.isEmptyLine(at: index))
         }
     }
 
@@ -146,7 +146,7 @@ class StringEndOfLineTests: XCTestCase {
             let string = "\(separator)🌎"
             let index = string.endIndex
 
-            XCTAssertFalse(string.isEmptyParagraph(at: index))
+            XCTAssertFalse(string.isEmptyLine(at: index))
         }
     }
 


### PR DESCRIPTION
### Details:
Our **isEndOfParagraph** helper, actually, should be named **isEndOfLine**, since it checks if a given position is the beginning AND end of a line (condition which doesn't imply End of Paragraph!).

### To test:
Verify that the unit tests run correctly.

cc @diegoreymendez 
Thanks!


