### PR TITLE
Base modifications for CSS Support

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		F13CE53E1F4DD05E0043368D /* PipelineProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE53D1F4DD05E0043368D /* PipelineProcessor.swift */; };
 		F13CE5401F4DD08E0043368D /* RegexProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE53F1F4DD08E0043368D /* RegexProcessor.swift */; };
 		F14665451EA7C230008DE2B8 /* NSMutableAttributedStringReplaceOcurrencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14665441EA7C230008DE2B8 /* NSMutableAttributedStringReplaceOcurrencesTests.swift */; };
+		F168DB861F6381A00009BD0E /* CSSParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F168DB851F6381A00009BD0E /* CSSParserTests.swift */; };
 		F17BC86B1F4E466100398E2B /* NSAttributedString+HTMLInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17BC86A1F4E466100398E2B /* NSAttributedString+HTMLInitializer.swift */; };
 		F17BC8751F4E48FF00398E2B /* NSAttributedStringHTMLInitializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17BC8741F4E48FF00398E2B /* NSAttributedStringHTMLInitializerTests.swift */; };
 		F17BC8921F4E4BA500398E2B /* CSSPropertyRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17BC88F1F4E4BA500398E2B /* CSSPropertyRepresentation.swift */; };
@@ -269,6 +270,7 @@
 		F13CE53D1F4DD05E0043368D /* PipelineProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PipelineProcessor.swift; sourceTree = "<group>"; };
 		F13CE53F1F4DD08E0043368D /* RegexProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegexProcessor.swift; sourceTree = "<group>"; };
 		F14665441EA7C230008DE2B8 /* NSMutableAttributedStringReplaceOcurrencesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringReplaceOcurrencesTests.swift; sourceTree = "<group>"; };
+		F168DB851F6381A00009BD0E /* CSSParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSSParserTests.swift; sourceTree = "<group>"; };
 		F17BC86A1F4E466100398E2B /* NSAttributedString+HTMLInitializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+HTMLInitializer.swift"; sourceTree = "<group>"; };
 		F17BC8741F4E48FF00398E2B /* NSAttributedStringHTMLInitializerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSAttributedStringHTMLInitializerTests.swift; path = Extensions/NSAttributedStringHTMLInitializerTests.swift; sourceTree = "<group>"; };
 		F17BC88F1F4E4BA500398E2B /* CSSPropertyRepresentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSSPropertyRepresentation.swift; sourceTree = "<group>"; };
@@ -724,6 +726,7 @@
 		F17BC89C1F4E4F5A00398E2B /* Conversions */ = {
 			isa = PBXGroup;
 			children = (
+				F168DB851F6381A00009BD0E /* CSSParserTests.swift */,
 				F1953E241F4E544A00C717C9 /* HTMLParserTests.swift */,
 				F17BC89D1F4E4F5A00398E2B /* HTMLSerializerTests.swift */,
 			);
@@ -1104,6 +1107,7 @@
 				F1953E251F4E544A00C717C9 /* HTMLParserTests.swift in Sources */,
 				B5C16A631F4DF77300B113CF /* HeaderFormatterTests.swift in Sources */,
 				B5D575881F2288E2003A62F6 /* TextViewStubAttachmentDelegate.swift in Sources */,
+				F168DB861F6381A00009BD0E /* CSSParserTests.swift in Sources */,
 				F1000CE91EAA5C720000B15B /* StringEndOfLineTests.swift in Sources */,
 				F17BC8751F4E48FF00398E2B /* NSAttributedStringHTMLInitializerTests.swift in Sources */,
 				B542D6421E9EB122009D12D3 /* PreFormaterTests.swift in Sources */,

--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		F17BC8AB1F4E512800398E2B /* AttributedStringSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17BC8A91F4E512800398E2B /* AttributedStringSerializer.swift */; };
 		F17BC8B51F4E517100398E2B /* AttributedStringParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17BC8B31F4E517100398E2B /* AttributedStringParserTests.swift */; };
 		F17BC8B61F4E517100398E2B /* AttributedStringSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17BC8B41F4E517100398E2B /* AttributedStringSerializerTests.swift */; };
+		F184206A1F608D7C0079B782 /* Coding.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18420691F608D7C0079B782 /* Coding.swift */; };
 		F18733C81DA09737005AEB80 /* NSRangeComparisonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C71DA09737005AEB80 /* NSRangeComparisonTests.swift */; };
 		F18986E11EF2040A0060EDBA /* FontFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18986E01EF2040A0060EDBA /* FontFormatter.swift */; };
 		F18986E31EF204180060EDBA /* BoldFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18986E21EF204180060EDBA /* BoldFormatter.swift */; };
@@ -281,6 +282,7 @@
 		F17BC8A91F4E512800398E2B /* AttributedStringSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributedStringSerializer.swift; sourceTree = "<group>"; };
 		F17BC8B31F4E517100398E2B /* AttributedStringParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributedStringParserTests.swift; sourceTree = "<group>"; };
 		F17BC8B41F4E517100398E2B /* AttributedStringSerializerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributedStringSerializerTests.swift; sourceTree = "<group>"; };
+		F18420691F608D7C0079B782 /* Coding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Coding.swift; sourceTree = "<group>"; };
 		F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSRange+Helpers.swift"; sourceTree = "<group>"; };
 		F18733C71DA09737005AEB80 /* NSRangeComparisonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSRangeComparisonTests.swift; path = Extensions/NSRangeComparisonTests.swift; sourceTree = "<group>"; };
 		F18986E01EF2040A0060EDBA /* FontFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontFormatter.swift; sourceTree = "<group>"; };
@@ -407,6 +409,7 @@
 				599F25281D8BC9A1002871D6 /* GUI */,
 				599F25071D8BC9A1002871D6 /* Libxml2 */,
 				F16DD2C51EE998280083A098 /* NSAttributedString */,
+				F18420681F608D6C0079B782 /* NSCoding */,
 				FF20D63C1EDC389A00294B78 /* Processor */,
 				599F252E1D8BC9A1002871D6 /* TextKit */,
 			);
@@ -763,6 +766,14 @@
 			path = Conversions;
 			sourceTree = "<group>";
 		};
+		F18420681F608D6C0079B782 /* NSCoding */ = {
+			isa = PBXGroup;
+			children = (
+				F18420691F608D7C0079B782 /* Coding.swift */,
+			);
+			path = NSCoding;
+			sourceTree = "<group>";
+		};
 		F18733C61DA0970E005AEB80 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -985,6 +996,7 @@
 				F11326B01EF1AA91007FEE9A /* Header.swift in Sources */,
 				F1C05B9F1E37FD2F007510EA /* NSAttributedString+CharacterName.swift in Sources */,
 				F17BC8921F4E4BA500398E2B /* CSSPropertyRepresentation.swift in Sources */,
+				F184206A1F608D7C0079B782 /* Coding.swift in Sources */,
 				FF20D6411EDC389A00294B78 /* HTMLProcessor.swift in Sources */,
 				B5C99D3F1E72E2E700335355 /* UIStackView+Helpers.swift in Sources */,
 				F1C05B991E37F99D007510EA /* Character+Name.swift in Sources */,

--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		F18B81EB1EA5601000885F43 /* StringUnicodeScalarView+RangeConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B81EA1EA5601000885F43 /* StringUnicodeScalarView+RangeConversion.swift */; };
 		F18B81ED1EA560B700885F43 /* StringUTF16+RangeConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B81EC1EA560B700885F43 /* StringUTF16+RangeConversion.swift */; };
 		F1953E251F4E544A00C717C9 /* HTMLParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1953E241F4E544A00C717C9 /* HTMLParserTests.swift */; };
+		F19544051F588F1A00671B73 /* CSSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19544041F588F1A00671B73 /* CSSParser.swift */; };
 		F1C05B991E37F99D007510EA /* Character+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B981E37F99D007510EA /* Character+Name.swift */; };
 		F1C05B9D1E37FA77007510EA /* String+CharacterName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B9C1E37FA77007510EA /* String+CharacterName.swift */; };
 		F1C05B9F1E37FD2F007510EA /* NSAttributedString+CharacterName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B9E1E37FD2F007510EA /* NSAttributedString+CharacterName.swift */; };
@@ -288,6 +289,7 @@
 		F18B81EA1EA5601000885F43 /* StringUnicodeScalarView+RangeConversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StringUnicodeScalarView+RangeConversion.swift"; sourceTree = "<group>"; };
 		F18B81EC1EA560B700885F43 /* StringUTF16+RangeConversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StringUTF16+RangeConversion.swift"; sourceTree = "<group>"; };
 		F1953E241F4E544A00C717C9 /* HTMLParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLParserTests.swift; sourceTree = "<group>"; };
+		F19544041F588F1A00671B73 /* CSSParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSSParser.swift; sourceTree = "<group>"; };
 		F1C05B981E37F99D007510EA /* Character+Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Character+Name.swift"; sourceTree = "<group>"; };
 		F1C05B9C1E37FA77007510EA /* String+CharacterName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+CharacterName.swift"; sourceTree = "<group>"; };
 		F1C05B9E1E37FD2F007510EA /* NSAttributedString+CharacterName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+CharacterName.swift"; sourceTree = "<group>"; };
@@ -444,6 +446,7 @@
 		599F25091D8BC9A1002871D6 /* In */ = {
 			isa = PBXGroup;
 			children = (
+				F19544041F588F1A00671B73 /* CSSParser.swift */,
 				599F250A1D8BC9A1002871D6 /* InAttributeConverter.swift */,
 				599F250B1D8BC9A1002871D6 /* InAttributesConverter.swift */,
 				599F250C1D8BC9A1002871D6 /* HTMLParser.swift */,
@@ -998,6 +1001,7 @@
 				F17BC8931F4E4BA500398E2B /* HTMLRepresentation.swift in Sources */,
 				F18B81ED1EA560B700885F43 /* StringUTF16+RangeConversion.swift in Sources */,
 				F12F58631EF20394008AE298 /* AttributeFormatter.swift in Sources */,
+				F19544051F588F1A00671B73 /* CSSParser.swift in Sources */,
 				599F254E1D8BC9A1002871D6 /* FormatBarDelegate.swift in Sources */,
 				B5375F471EC2566200F5D7EC /* String+HTML.swift in Sources */,
 				F1C05B9D1E37FA77007510EA /* String+CharacterName.swift in Sources */,

--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -77,7 +77,7 @@
 		F11326B31EF1AA91007FEE9A /* ParagraphProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11326AD1EF1AA91007FEE9A /* ParagraphProperty.swift */; };
 		F11326B41EF1AA91007FEE9A /* TextList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11326AE1EF1AA91007FEE9A /* TextList.swift */; };
 		F127F7121F058B20008A00D7 /* StandardAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = F127F7111F058B20008A00D7 /* StandardAttribute.swift */; };
-		F127F7141F0591AD008A00D7 /* CSSProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = F127F7131F0591AD008A00D7 /* CSSProperty.swift */; };
+		F127F7141F0591AD008A00D7 /* CSSAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = F127F7131F0591AD008A00D7 /* CSSAttribute.swift */; };
 		F12F58631EF20394008AE298 /* AttributeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F58511EF20394008AE298 /* AttributeFormatter.swift */; };
 		F12F58651EF20394008AE298 /* ParagraphAttributeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F58531EF20394008AE298 /* ParagraphAttributeFormatter.swift */; };
 		F12F58661EF20394008AE298 /* StandardAttributeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12F58541EF20394008AE298 /* StandardAttributeFormatter.swift */; };
@@ -248,7 +248,7 @@
 		F11326AD1EF1AA91007FEE9A /* ParagraphProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParagraphProperty.swift; sourceTree = "<group>"; };
 		F11326AE1EF1AA91007FEE9A /* TextList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextList.swift; sourceTree = "<group>"; };
 		F127F7111F058B20008A00D7 /* StandardAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StandardAttribute.swift; sourceTree = "<group>"; };
-		F127F7131F0591AD008A00D7 /* CSSProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSSProperty.swift; sourceTree = "<group>"; };
+		F127F7131F0591AD008A00D7 /* CSSAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSSAttribute.swift; sourceTree = "<group>"; };
 		F12F58511EF20394008AE298 /* AttributeFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributeFormatter.swift; sourceTree = "<group>"; };
 		F12F58531EF20394008AE298 /* ParagraphAttributeFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParagraphAttributeFormatter.swift; sourceTree = "<group>"; };
 		F12F58541EF20394008AE298 /* StandardAttributeFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StandardAttributeFormatter.swift; sourceTree = "<group>"; };
@@ -782,7 +782,7 @@
 			isa = PBXGroup;
 			children = (
 				F1FA0E791E6EF514009D98EE /* Attribute.swift */,
-				F127F7131F0591AD008A00D7 /* CSSProperty.swift */,
+				F127F7131F0591AD008A00D7 /* CSSAttribute.swift */,
 				F1FA0E7A1E6EF514009D98EE /* CommentNode.swift */,
 				F1FA0E7B1E6EF514009D98EE /* ElementNode.swift */,
 				F1FA0E7E1E6EF514009D98EE /* Node.swift */,
@@ -988,7 +988,7 @@
 				FF20D6421EDC389A00294B78 /* Processor.swift in Sources */,
 				599F253B1D8BC9A1002871D6 /* InNodesConverter.swift in Sources */,
 				F18B81EB1EA5601000885F43 /* StringUnicodeScalarView+RangeConversion.swift in Sources */,
-				F127F7141F0591AD008A00D7 /* CSSProperty.swift in Sources */,
+				F127F7141F0591AD008A00D7 /* CSSAttribute.swift in Sources */,
 				F11326B31EF1AA91007FEE9A /* ParagraphProperty.swift in Sources */,
 				F11326B11EF1AA91007FEE9A /* HTMLParagraph.swift in Sources */,
 				FF20D6401EDC389A00294B78 /* HTMLAttributes.swift in Sources */,

--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -45,7 +45,7 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
 
         var resultingAttributes = attributes
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
-        resultingAttributes[NSFontAttributeName] = font.withSize(headerLevel.fontSize)
+        resultingAttributes[NSFontAttributeName] = font.withSize(CGFloat(headerLevel.fontSize))
 
         return resultingAttributes
     }
@@ -66,7 +66,7 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
 
         if let font = attributes[NSFontAttributeName] as? UIFont {
-            resultingAttributes[NSFontAttributeName] = font.withSize(header.defaultFontSize)
+            resultingAttributes[NSFontAttributeName] = font.withSize(CGFloat(header.defaultFontSize))
         }
 
         return resultingAttributes
@@ -86,7 +86,7 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
 //
 private extension HeaderFormatter {
 
-    func defaultFontSize(from attributes: [String: Any]) -> CGFloat? {
+    func defaultFontSize(from attributes: [String: Any]) -> Float? {
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
             let lastHeader = paragraphStyle.headers.last
         {
@@ -94,7 +94,7 @@ private extension HeaderFormatter {
         }
 
         if let font = attributes[NSFontAttributeName] as? UIFont {
-            return font.pointSize
+            return Float(font.pointSize)
         }
 
         return nil

--- a/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
@@ -69,6 +69,5 @@ class CSSParser {
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         return CSSAttribute(name: name, value: value)
-
     }
 }

--- a/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
@@ -60,6 +60,7 @@ class CSSParser {
         }
 
         let name = cssAttribute.substring(to: keyValueSeparatorRange.lowerBound)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard keyValueSeparatorRange.upperBound != cssAttribute.endIndex else {
             return CSSAttribute(name: name)

--- a/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
@@ -65,8 +65,7 @@ class CSSParser {
             return CSSAttribute(name: name)
         }
 
-        let valueStartIndex = cssAttribute.index(after: keyValueSeparatorRange.upperBound)
-        let value = cssAttribute.substring(from: valueStartIndex)
+        let value = cssAttribute.substring(from: keyValueSeparatorRange.upperBound)
 
         return CSSAttribute(name: name, value: value)
 

--- a/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+class CSSParser {
+
+    static let attributeSeparator = ";"
+    static let keyValueSeparator = ":"
+
+    /// Parses the provided inline CSS string
+    ///
+    /// - Parameters:
+    ///     - cssAttribute: a string containing inline CSS as read from an HTML document.
+    ///
+    /// - Returns: an array of `CSSAttribute` objects.
+    ///
+    func parse(_ css: String) -> [CSSAttribute] {
+
+        guard css.characters.count > 0 else {
+            return []
+        }
+
+        let attributeStrings = css.components(separatedBy: CSSParser.attributeSeparator)
+
+        return parse(attributeStrings)
+    }
+
+    /// Parses the provided CSS attributes (each string representing a single attribute).
+    ///
+    /// - Parameters:
+    ///     - cssAttributes: an array of strings containing the definition for CSS attributes.
+    ///
+    /// - Returns: an array of `CSSAttribute` objects.
+    ///
+    private func parse(_ cssAttributes: [String]) -> [CSSAttribute] {
+
+        let attributes = cssAttributes.flatMap { (cssAttribute) -> CSSAttribute? in
+            return parse(cssAttribute: cssAttribute)
+        }
+        
+        return attributes
+    }
+
+    /// Parses the provided CSS attribute.
+    ///
+    /// - Parameters:
+    ///     - cssAttribute: a string containing the definition of a CSS attributes.
+    ///
+    /// - Returns: the parsed `CSSAttribute` object.
+    ///
+    private func parse(cssAttribute: String) -> CSSAttribute {
+
+        guard let keyValueSeparatorRange = cssAttribute.range(of: CSSParser.keyValueSeparator) else {
+            return CSSAttribute(name: cssAttribute)
+        }
+
+        let name = cssAttribute.substring(to: keyValueSeparatorRange.lowerBound)
+
+        guard keyValueSeparatorRange.upperBound != cssAttribute.endIndex else {
+            return CSSAttribute(name: name)
+        }
+
+        let valueStartIndex = cssAttribute.index(after: keyValueSeparatorRange.upperBound)
+        let value = cssAttribute.substring(from: valueStartIndex)
+
+        return CSSAttribute(name: name, value: value)
+
+    }
+}

--- a/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
@@ -66,6 +66,7 @@ class CSSParser {
         }
 
         let value = cssAttribute.substring(from: keyValueSeparatorRange.upperBound)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
         return CSSAttribute(name: name, value: value)
 

--- a/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
@@ -33,7 +33,14 @@ class CSSParser {
     private func parse(_ cssAttributes: [String]) -> [CSSAttribute] {
 
         let attributes = cssAttributes.flatMap { (cssAttribute) -> CSSAttribute? in
-            return parse(cssAttribute: cssAttribute)
+
+            let trimmedAttribute = cssAttribute.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard trimmedAttribute.characters.count > 0 else {
+                return nil
+            }
+
+            return parse(cssAttribute: trimmedAttribute)
         }
         
         return attributes

--- a/Aztec/Classes/Libxml2/Converters/In/InAttributeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InAttributeConverter.swift
@@ -3,6 +3,10 @@ import libxml2
 
 class InAttributeConverter: SafeConverter {
 
+    let cssAttributeName = "style"
+
+    let cssParser = CSSParser()
+
     /// Converts a single attribute (from libxml2) into an HTML.Attribute
     ///
     /// - Parameters:
@@ -11,25 +15,32 @@ class InAttributeConverter: SafeConverter {
     /// - Returns: an HTML.Attribute.
     ///
     func convert(_ attribute: xmlAttr) -> Attribute {
-        
+
         let attributeName = String(cString: attribute.name)
-        let attributeValueRef = attribute.children
 
-        if let attributeValueRef = attributeValueRef {
-            let attributeValue = String(cString: attributeValueRef.pointee.content)
-
-            // The HTML 5 spec, in Section 2.4.2 (named "Boolean attributes") provides some examples
-            // showing that attributes that have a value equal to their names are boolean attributes
-            // and can be equivalently written without their value.  The latter is the normalized
-            // representation we currently support.
-            //
-            // So we're only loading the attribute's value if it's not equal to the attribute name.
-            //
-            if attributeName != attributeValue {
-                return Attribute(name: attributeName, string: attributeValue)
-            }
+        guard let attributeValueRef = attribute.children else {
+            return Attribute(name: attributeName)
         }
 
-        return Attribute(name: attributeName)
+        let attributeValue = String(cString: attributeValueRef.pointee.content)
+
+        // The HTML 5 spec, in Section 2.4.2 (named "Boolean attributes") provides some examples
+        // showing that attributes that have a value equal to their names are boolean attributes
+        // and can be equivalently written without their value.  The latter is the normalized
+        // representation we currently support.
+        //
+        // So we're only loading the attribute's value if it's not equal to the attribute name.
+        //
+        guard attributeName != attributeValue else {
+            return Attribute(name: attributeName)
+        }
+
+        guard attributeName != cssAttributeName else {
+            let cssAttributes = cssParser.parse(attributeValue)
+
+            return Attribute(name: attributeName, value: .inlineCss(cssAttributes))
+        }
+
+        return Attribute(name: attributeName, value: .string(attributeValue))
     }
 }

--- a/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
@@ -123,7 +123,7 @@ extension Attribute {
 
         init(withCSSString cssString: String) {
 
-            let components = cssString.components(separatedBy: CSSAttribute.attributeSeparator)
+            let components = cssString.components(separatedBy: CSSParser.attributeSeparator)
 
             guard !components.isEmpty else {
                 self = .none
@@ -212,7 +212,7 @@ extension Attribute {
                     result += property.toString()
 
                     if index < properties.count - 1 {
-                        result += CSSAttribute.attributeSeparator + " "
+                        result += CSSParser.attributeSeparator + " "
                     }
                 }
                 

--- a/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
@@ -21,28 +21,6 @@ class Attribute: NSObject, CustomReflectable, NSCoding {
         self.value = value
     }
 
-/*
-    init(name: String, string: String?) {
-        self.name = name
-
-        guard let string = string, !string.isEmpty else {
-            self.value = .none
-            return
-        }
-
-        guard name.lowercased() == cssAttributeName else {
-            self.value = .string(string)
-            return
-        }
-
-        self.value = Value(withCSSString: string)
-    }
-*/
-    // MARK: - CSS Parsing
-
-
-
-
     // MARK: - CustomReflectable
 
     public var customMirror: Mirror {

--- a/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
@@ -1,38 +1,5 @@
 import Foundation
 
-protocol Coding {
-    static func decode(with coder: NSCoder) -> Self?
-    func encode(with coder: NSCoder)
-}
-
-/// Offers NSCoding support for our enum, without having to change our arquitecture for it.
-///
-class NSCodingProxy<T: Coding>: NSObject, NSCoding {
-
-    let value: T
-
-    // MARK: - Initializing with value
-
-    init(for value: T) {
-        self.value = value
-    }
-
-    // MARK: - NSCoding support
-
-    required init?(coder: NSCoder) {
-
-        guard let value = T.decode(with: coder) else {
-            return nil
-        }
-
-        self.value = value
-    }
-
-    func encode(with aCoder: NSCoder) {
-        value.encode(with: aCoder)
-    }
-}
-
 /// Represents a basic attribute with no value.  This is also the base class for all other
 /// attributes.
 ///
@@ -191,7 +158,10 @@ extension Attribute {
 
             switch valueType {
             case .none:
-                return .none
+                // IMPORTANT: the `Value` prefix serves as disambiguation, since optionals also have
+                // a .none value!!!  Don't remove it!
+                //
+                return Value.none
             case .string:
                 let string = coder.decodeObject(forKey: Value.valueDataKey) as? String ?? ""
 

--- a/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Represents a basic attribute with no value.  This is also the base class for all other
 /// attributes.
 ///
-class Attribute: NSObject, CustomReflectable {
+class Attribute: CustomReflectable, Equatable, Hashable {
 
     // MARK: - Attribute Definition Properties
 
@@ -20,7 +20,7 @@ class Attribute: NSObject, CustomReflectable {
         self.name = name
         self.value = value
     }
-
+/*
     init(name: String, string: String?) {
         self.name = name
 
@@ -36,7 +36,7 @@ class Attribute: NSObject, CustomReflectable {
 
         self.value = Value(withCSSString: string)
     }
-
+*/
     // MARK: - CSS Parsing
 
 
@@ -52,12 +52,12 @@ class Attribute: NSObject, CustomReflectable {
 
     // MARK - Hashable
 
-    override var hashValue: Int {
-        return name.hashValue ^ value.hashValue
+    var hashValue: Int {
+        return ObjectIdentifier(self).hashValue
     }
 
     // MARK: - NSCoding
-
+/*
     public required convenience init?(coder aDecoder: NSCoder) {
         guard let name = aDecoder.decodeObject(forKey: Keys.name) as? String,
             let valueAsString = aDecoder.decodeObject(forKey: Keys.value) as? String?
@@ -67,15 +67,20 @@ class Attribute: NSObject, CustomReflectable {
 
         self.init(name: name, string: valueAsString)
     }
-
+*/
     // MARK: - Equatable
-
+/*
     override func isEqual(_ object: Any?) -> Bool {
         guard let rhs = object as? Attribute else {
             return false
         }
 
         return name == rhs.name && value == rhs.value
+    }
+*/
+
+    static func ==(lhs: Attribute, rhs: Attribute) -> Bool {
+        return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
 
     // MARK: - String Representation
@@ -94,6 +99,7 @@ class Attribute: NSObject, CustomReflectable {
 
 // MARK: - NSCoding Conformance
 //
+/*
 extension Attribute: NSCoding {
 
     struct Keys {
@@ -106,6 +112,7 @@ extension Attribute: NSCoding {
         aCoder.encode(value.toString(), forKey: Keys.value)
     }
 }
+ */
 
 
 // MARK: - Attribute.Value

--- a/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
@@ -1,12 +1,17 @@
 import Foundation
 
 
-// MARK: - CSSProperty
+// MARK: - CSSAttribute
 //
-class CSSProperty: Hashable {
+class CSSAttribute: Hashable {
     
     let name: String
     let value: String
+
+    // MARK: - Separators
+
+    static let attributeSeparator = ";"
+    static let keyValueSeparator = ":"
 
     // MARK: - Initializers
 
@@ -16,7 +21,7 @@ class CSSProperty: Hashable {
     }
 
     convenience init?(for string: String) {
-        let components = string.components(separatedBy: CSSProperty.keyValueSeparator)
+        let components = string.components(separatedBy: CSSAttribute.keyValueSeparator)
         guard let name = components.first, let value = components.last, components.count == 2 else {
             return nil
         }
@@ -33,19 +38,13 @@ class CSSProperty: Hashable {
     // MARK: - String Representation
 
     func toString() -> String {
-        return name + CSSProperty.keyValueSeparator + value
+        return name + CSSAttribute.keyValueSeparator + value
     }
 
     // MARK: - Equatable
 
-    static func ==(leftValue: CSSProperty, rightValue: CSSProperty) -> Bool {
+    static func ==(leftValue: CSSAttribute, rightValue: CSSAttribute) -> Bool {
         return leftValue.name == rightValue.name && leftValue.value == rightValue.value
     }
 }
 
-
-// MARK: - Helpers
-//
-private extension CSSProperty {
-    static let keyValueSeparator = ": "
-}

--- a/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
@@ -3,8 +3,8 @@ import Foundation
 
 // MARK: - CSSAttribute
 //
-class CSSAttribute: CustomReflectable, Hashable {
-    
+class CSSAttribute: NSObject, CustomReflectable, NSCoding {
+
     let name: String
     let value: String?
 
@@ -24,6 +24,23 @@ class CSSAttribute: CustomReflectable, Hashable {
         self.init(name: name, value: value)
     }
 
+    // MARK: - NSCoding
+
+    required init?(coder aDecoder: NSCoder) {
+        guard let name = aDecoder.decodeObject(forKey: #keyPath(name)) as? String,
+            let value = aDecoder.decodeObject(forKey: #keyPath(value)) as? String? else {
+                return nil
+        }
+
+        self.name = name
+        self.value = value
+    }
+
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(name, forKey: #keyPath(name))
+        aCoder.encode(value, forKey: #keyPath(value))
+    }
+
     // MARK: - CustomReflectable
 
     public var customMirror: Mirror {
@@ -34,7 +51,7 @@ class CSSAttribute: CustomReflectable, Hashable {
 
     // MARK: - Hashable
 
-    var hashValue: Int {
+    override var hashValue: Int {
 
         guard let value = value else {
             return name.hashValue

--- a/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
@@ -68,7 +68,7 @@ class CSSAttribute: NSObject, CustomReflectable, NSCoding {
             return name
         }
 
-        return name + CSSParser.keyValueSeparator + value
+        return name + CSSParser.keyValueSeparator + " " + value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Equatable

--- a/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
@@ -6,22 +6,17 @@ import Foundation
 class CSSAttribute: Hashable {
     
     let name: String
-    let value: String
-
-    // MARK: - Separators
-
-    static let attributeSeparator = ";"
-    static let keyValueSeparator = ":"
+    let value: String?
 
     // MARK: - Initializers
 
-    init(name: String, value: String) {
+    init(name: String, value: String? = nil) {
         self.name = name
         self.value = value
     }
 
     convenience init?(for string: String) {
-        let components = string.components(separatedBy: CSSAttribute.keyValueSeparator)
+        let components = string.components(separatedBy: CSSParser.keyValueSeparator)
         guard let name = components.first, let value = components.last, components.count == 2 else {
             return nil
         }
@@ -32,13 +27,23 @@ class CSSAttribute: Hashable {
     // MARK: - Hashable
 
     var hashValue: Int {
+
+        guard let value = value else {
+            return name.hashValue
+        }
+
         return name.hashValue ^ value.hashValue
     }
 
     // MARK: - String Representation
 
     func toString() -> String {
-        return name + CSSAttribute.keyValueSeparator + value
+
+        guard let value = value else {
+            return name
+        }
+
+        return name + CSSParser.keyValueSeparator + value
     }
 
     // MARK: - Equatable

--- a/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - CSSAttribute
 //
-class CSSAttribute: Hashable {
+class CSSAttribute: CustomReflectable, Hashable {
     
     let name: String
     let value: String?
@@ -22,6 +22,14 @@ class CSSAttribute: Hashable {
         }
 
         self.init(name: name, value: value)
+    }
+
+    // MARK: - CustomReflectable
+
+    public var customMirror: Mirror {
+        get {
+            return Mirror(self, children: ["name": name, "value": value ?? ""])
+        }
     }
 
     // MARK: - Hashable

--- a/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
@@ -73,6 +73,15 @@ class CSSAttribute: NSObject, CustomReflectable, NSCoding {
 
     // MARK: - Equatable
 
+    override func isEqual(_ object: Any?) -> Bool {
+
+        guard let rightValue = object as? CSSAttribute else {
+            return false
+        }
+
+        return self == rightValue
+    }
+
     static func ==(leftValue: CSSAttribute, rightValue: CSSAttribute) -> Bool {
         return leftValue.name == rightValue.name && leftValue.value == rightValue.value
     }

--- a/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/CSSAttribute.swift
@@ -17,8 +17,11 @@ class CSSAttribute: NSObject, CustomReflectable, NSCoding {
 
     convenience init?(for string: String) {
         let components = string.components(separatedBy: CSSParser.keyValueSeparator)
-        guard let name = components.first, let value = components.last, components.count == 2 else {
-            return nil
+
+        guard let name = components.first?.trimmingCharacters(in: .whitespacesAndNewlines),
+            let value = components.last?.trimmingCharacters(in: .whitespacesAndNewlines),
+            components.count == 2 else {
+                return nil
         }
 
         self.init(name: name, value: value)
@@ -32,8 +35,8 @@ class CSSAttribute: NSObject, CustomReflectable, NSCoding {
                 return nil
         }
 
-        self.name = name
-        self.value = value
+        self.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.value = value?.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     func encode(with aCoder: NSCoder) {

--- a/Aztec/Classes/NSAttributedString/Attributes/HTMLRepresentation.swift
+++ b/Aztec/Classes/NSAttributedString/Attributes/HTMLRepresentation.swift
@@ -6,7 +6,7 @@ class HTMLRepresentation: NSObject {
     enum Kind {
         case attribute(Attribute)
         case element(HTMLElementRepresentation)
-        case inlineCss(CSSProperty)
+        case inlineCss(CSSAttribute)
     }
 
     let kind: Kind
@@ -27,7 +27,7 @@ class HTMLRepresentation: NSObject {
         }
 
         if let rawCSS = aDecoder.decodeObject(forKey: Keys.inline) as? String,
-            let decodedCSS = CSSProperty(for: rawCSS) {
+            let decodedCSS = CSSAttribute(for: rawCSS) {
             kind = .inlineCss(decodedCSS)
             return
         }

--- a/Aztec/Classes/NSAttributedString/Attributes/HTMLRepresentation.swift
+++ b/Aztec/Classes/NSAttributedString/Attributes/HTMLRepresentation.swift
@@ -15,6 +15,14 @@ class HTMLRepresentation: NSObject {
         self.kind = kind
     }
 
+    // MARK: - NSCoding
+
+    struct Keys {
+        static let attribute = "attribute"
+        static let element = "element"
+        static let inline = "inline"
+    }
+
     public required init?(coder aDecoder: NSCoder) {
         if let attribute = aDecoder.decodeObject(forKey: Keys.attribute) as? Attribute {
             kind = .attribute(attribute)
@@ -34,18 +42,6 @@ class HTMLRepresentation: NSObject {
 
         fatalError()
     }
-}
-
-
-// MARK: - NSCoding Conformance
-//
-extension HTMLRepresentation: NSCoding {
-
-    struct Keys {
-        static let attribute = "attribute"
-        static let element = "element"
-        static let inline = "inline"
-    }
 
     open func encode(with aCoder: NSCoder) {
         switch kind {
@@ -62,7 +58,7 @@ extension HTMLRepresentation: NSCoding {
 
 // MARK: - HTMLElementRepresentation
 //
-class HTMLElementRepresentation: NSObject {
+class HTMLElementRepresentation: NSObject, CustomReflectable {
     let name: String
     let attributes: [Attribute]
 
@@ -85,6 +81,16 @@ class HTMLElementRepresentation: NSObject {
         self.init(name: name, attributes: attributes)
     }
 
+    // MARK: - CustomReflectable
+
+    public var customMirror: Mirror {
+        get {
+            return Mirror(self, children: ["name": name, "attributes": attributes], ancestorRepresentation: .suppressed)
+        }
+    }
+
+    // MARK: - Misc
+
     func attribute(named name: String) -> Attribute? {
         return attributes.first(where: { attribute -> Bool in
             return attribute.name == name
@@ -98,7 +104,7 @@ class HTMLElementRepresentation: NSObject {
     // MARK: - Equatable
 
     static func ==(lhs: HTMLElementRepresentation, rhs: HTMLElementRepresentation) -> Bool {
-        return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+        return lhs.name == rhs.name && lhs.attributes == rhs.attributes
     }
 }
 

--- a/Aztec/Classes/NSAttributedString/Attributes/HTMLRepresentation.swift
+++ b/Aztec/Classes/NSAttributedString/Attributes/HTMLRepresentation.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// This enum specifies the different entities that can represent a style in HTML.
 ///
-class HTMLRepresentation: NSObject {
+class HTMLRepresentation: NSObject, NSCoding {
     enum Kind {
         case attribute(Attribute)
         case element(HTMLElementRepresentation)

--- a/Aztec/Classes/NSAttributedString/Attributes/HTMLRepresentation.swift
+++ b/Aztec/Classes/NSAttributedString/Attributes/HTMLRepresentation.swift
@@ -58,7 +58,7 @@ class HTMLRepresentation: NSObject, NSCoding {
 
 // MARK: - HTMLElementRepresentation
 //
-class HTMLElementRepresentation: NSObject, CustomReflectable {
+class HTMLElementRepresentation: NSObject, CustomReflectable, NSCoding {
     let name: String
     let attributes: [Attribute]
 
@@ -71,14 +71,21 @@ class HTMLElementRepresentation: NSObject, CustomReflectable {
         self.init(name: elementNode.name, attributes: elementNode.attributes)
     }
 
+    // MARK: - NSCoding
+
     public required convenience init?(coder aDecoder: NSCoder) {
-        guard let name = aDecoder.decodeObject(forKey: Keys.name) as? String,
-            let attributes = aDecoder.decodeObject(forKey: Keys.attributes) as? [Attribute]
+        guard let name = aDecoder.decodeObject(forKey: #keyPath(name)) as? String,
+            let attributes = aDecoder.decodeObject(forKey: #keyPath(attributes)) as? [Attribute]
         else {
             fatalError()
         }
 
         self.init(name: name, attributes: attributes)
+    }
+
+    open func encode(with aCoder: NSCoder) {
+        aCoder.encode(name, forKey: #keyPath(name))
+        aCoder.encode(attributes, forKey: #keyPath(attributes))
     }
 
     // MARK: - CustomReflectable
@@ -105,21 +112,5 @@ class HTMLElementRepresentation: NSObject, CustomReflectable {
 
     static func ==(lhs: HTMLElementRepresentation, rhs: HTMLElementRepresentation) -> Bool {
         return lhs.name == rhs.name && lhs.attributes == rhs.attributes
-    }
-}
-
-
-// MARK: - NSCoding Conformance
-//
-extension HTMLElementRepresentation: NSCoding {
-
-    struct Keys {
-        static let name = "name"
-        static let attributes = "attributes"
-    }
-
-    open func encode(with aCoder: NSCoder) {
-        aCoder.encode(name, forKey: Keys.name)
-        aCoder.encode(attributes, forKey: Keys.attributes)
     }
 }

--- a/Aztec/Classes/NSAttributedString/Attributes/HTMLRepresentation.swift
+++ b/Aztec/Classes/NSAttributedString/Attributes/HTMLRepresentation.swift
@@ -98,7 +98,7 @@ class HTMLElementRepresentation: NSObject {
     // MARK: - Equatable
 
     static func ==(lhs: HTMLElementRepresentation, rhs: HTMLElementRepresentation) -> Bool {
-        return type(of: lhs) == type(of: rhs) && lhs.name == rhs.name && lhs.attributes == rhs.attributes
+        return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
 }
 

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -180,7 +180,7 @@ class AttributedStringSerializer {
         return [:]
     }()
 
-    public lazy var elementFormattersMap: [StandardElementType: AttributeFormatter] = { [unowned self] in
+    public lazy var elementFormattersMap: [StandardElementType: AttributeFormatter] = {
         return [
             .blockquote: self.blockquoteFormatter,
             .div: self.divFormatter,
@@ -240,31 +240,31 @@ private extension AttributedStringSerializer {
     ///
     /// - Returns: an attributes dictionary, for use in an NSAttributedString.
     ///
-    func attributes(for element: ElementNode, inheriting attributes: [String: Any]) -> [String: Any] {
+    func attributes(for element: ElementNode, inheriting inheritedAttributes: [String: Any]) -> [String: Any] {
 
         guard !(element is RootNode) else {
-            return attributes
+            return inheritedAttributes
         }
 
         let elementRepresentation = HTMLElementRepresentation(element)
         let representation = HTMLRepresentation(for: .element(elementRepresentation))
-        var finalAttributes = attributes
+        var finalAttributes = inheritedAttributes
 
         if let elementFormatter = formatter(for: element) {
             finalAttributes = elementFormatter.apply(to: finalAttributes, andStore: representation)
         } else if element.name == StandardElementType.li.rawValue {
             // ^ Since LI is handled by the OL and UL formatters, we can safely ignore it here.
-            finalAttributes = attributes
+            finalAttributes = inheritedAttributes
         } else {
             finalAttributes = self.attributes(storing: elementRepresentation, in: finalAttributes)
         }
 
-        finalAttributes = stringAttributes(for: element.attributes, inheriting: finalAttributes)
+        finalAttributes = self.attributes(for: element.attributes, inheriting: finalAttributes)
         
         return finalAttributes
     }
 
-    /// Calculates the string attributes for the specified HTML attributes.  Returns a dictionary
+    /// Calculates the attributes for the specified HTML attributes.  Returns a dictionary
     /// including the inherited attributes.
     ///
     /// - Parameters:
@@ -273,17 +273,17 @@ private extension AttributedStringSerializer {
     ///
     /// - Returns: an attributes dictionary, for use in an NSAttributedString.
     ///
-    private func stringAttributes(for htmlAttributes: [Attribute], inheriting inheritedAttributes: [String: Any]) -> [String: Any] {
+    private func attributes(for htmlAttributes: [Attribute], inheriting inheritedAttributes: [String: Any]) -> [String: Any] {
 
         let finalAttributes = htmlAttributes.reduce(inheritedAttributes) { (previousAttributes, htmlAttribute) -> [String: Any] in
-            return stringAttributes(for: htmlAttribute, inheriting: previousAttributes)
+            return attributes(for: htmlAttribute, inheriting: previousAttributes)
         }
 
         return finalAttributes
     }
 
 
-    /// Calculates the string attributes for the specified HTML attribute.  Returns a dictionary
+    /// Calculates the attributes for the specified HTML attribute.  Returns a dictionary
     /// including inherited attributes.
     ///
     /// - Parameters:
@@ -292,11 +292,7 @@ private extension AttributedStringSerializer {
     ///
     /// - Returns: an attributes dictionary, for use in an NSAttributedString.
     ///
-    private func stringAttributes(for attribute: Attribute, inheriting inheritedAttributes: [String: Any]) -> [String: Any] {
-
-        if attribute.name.lowercased() == "style" {
-            return [:]
-        }
+    private func attributes(for attribute: Attribute, inheriting inheritedAttributes: [String: Any]) -> [String: Any] {
 
         let attributes: [String:Any]
 

--- a/Aztec/Classes/NSCoding/Coding.swift
+++ b/Aztec/Classes/NSCoding/Coding.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Protocol the enum or struct must implement.
+///
+protocol Coding {
+    static func decode(with coder: NSCoder) -> Self?
+    func encode(with coder: NSCoder)
+}
+
+/// Offers NSCoding support for our enum, without having to change our arquitecture for it.
+///
+class NSCodingProxy<T: Coding>: NSObject, NSCoding {
+
+    let value: T
+
+    // MARK: - Initializing with value
+
+    init(for value: T) {
+        self.value = value
+    }
+
+    // MARK: - NSCoding support
+
+    required init?(coder: NSCoder) {
+
+        guard let value = T.decode(with: coder) else {
+            return nil
+        }
+
+        self.value = value
+    }
+
+    func encode(with aCoder: NSCoder) {
+        value.encode(with: aCoder)
+    }
+}

--- a/Aztec/Classes/TextKit/ParagraphProperty/Header.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/Header.swift
@@ -19,7 +19,7 @@ open class Header: ParagraphProperty {
         case h5 = 5
         case h6 = 6
 
-        public var fontSize: CGFloat {
+        public var fontSize: Float {
             switch self {
             case .none: return Constants.defaultFontSize
             case .h1: return 36
@@ -40,12 +40,12 @@ open class Header: ParagraphProperty {
 
     /// Default Font Size (corresponding to HeaderType.none)
     ///
-    let defaultFontSize: CGFloat
+    let defaultFontSize: Float
 
 
     // MARK: - Initializers
 
-    init(level: HeaderType, with representation: HTMLRepresentation? = nil, defaultFontSize: CGFloat? = nil) {
+    init(level: HeaderType, with representation: HTMLRepresentation? = nil, defaultFontSize: Float? = nil) {
         self.defaultFontSize = defaultFontSize ?? Constants.defaultFontSize
         self.level = level
         super.init(with: representation)
@@ -61,7 +61,7 @@ open class Header: ParagraphProperty {
         }
 
         if aDecoder.containsValue(forKey: Keys.level) {
-            defaultFontSize = CGFloat(aDecoder.decodeFloat(forKey: Keys.defaultFontSize))
+            defaultFontSize = aDecoder.decodeFloat(forKey: Keys.defaultFontSize)
         } else {
             defaultFontSize = Constants.defaultFontSize
         }
@@ -88,7 +88,7 @@ open class Header: ParagraphProperty {
 //
 private extension Header {
     struct Constants {
-        static let defaultFontSize = CGFloat(14)
+        static let defaultFontSize = Float(14)
     }
 
     struct Keys {

--- a/AztecTests/Formatters/HeaderFormatterTests.swift
+++ b/AztecTests/Formatters/HeaderFormatterTests.swift
@@ -24,7 +24,7 @@ class HeaderFormatterTests: XCTestCase {
 
         let updatedAttrs = formatter.apply(to: attributes, andStore: nil)
         let updatedFont = updatedAttrs[NSFontAttributeName] as! UIFont
-        XCTAssert(updatedFont.pointSize == formatter.headerLevel.fontSize)
+        XCTAssert(updatedFont.pointSize == CGFloat(formatter.headerLevel.fontSize))
 
         let removedAttrs = formatter.remove(from: updatedAttrs)
         let removedFont = removedAttrs[NSFontAttributeName] as! UIFont
@@ -37,12 +37,12 @@ class HeaderFormatterTests: XCTestCase {
         let formatterH1 = HeaderFormatter(headerLevel: .h1, placeholderAttributes: nil)
         let updatedH1Attrs = formatterH1.apply(to: attributes, andStore: nil)
         let updatedH1Font = updatedH1Attrs[NSFontAttributeName] as! UIFont
-        XCTAssert(updatedH1Font.pointSize == formatterH1.headerLevel.fontSize)
+        XCTAssert(updatedH1Font.pointSize == CGFloat(formatterH1.headerLevel.fontSize))
 
         let formatterH2 = HeaderFormatter(headerLevel: .h2, placeholderAttributes: nil)
         let updatedH2Attrs = formatterH2.apply(to: attributes, andStore: nil)
         let updatedH2Font = updatedH2Attrs[NSFontAttributeName] as! UIFont
-        XCTAssert(updatedH2Font.pointSize == formatterH2.headerLevel.fontSize)
+        XCTAssert(updatedH2Font.pointSize == CGFloat(formatterH2.headerLevel.fontSize))
 
         let removedAttrs = formatterH2.remove(from: updatedH2Attrs)
         let removedFont = removedAttrs[NSFontAttributeName] as! UIFont

--- a/AztecTests/HTML/Conversions/CSSParserTests.swift
+++ b/AztecTests/HTML/Conversions/CSSParserTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import Aztec
+
+class CSSParserTests: XCTestCase {
+
+    func testParsingCSS() {
+
+        let cssAttributeName = "color"
+        let cssAttributeValue = "blue"
+
+        let parser = CSSParser()
+        let cssString = "\(cssAttributeName):\(cssAttributeValue);"
+
+        let attributes = parser.parse(cssString)
+
+        XCTAssertTrue(attributes.contains(CSSAttribute(name: cssAttributeName, value: cssAttributeValue)))
+    }
+
+    func testParsingCSSWithoutClosingSemicolon() {
+
+        let cssAttributeName = "color"
+        let cssAttributeValue = "blue"
+
+        let parser = CSSParser()
+        let cssString = "\(cssAttributeName):\(cssAttributeValue)"
+
+        let attributes = parser.parse(cssString)
+
+        XCTAssertTrue(attributes.contains(CSSAttribute(name: cssAttributeName, value: cssAttributeValue)))
+    }
+
+    func testParsingCSSWithExtraSpaces() {
+
+        let cssAttributeName = "color"
+        let cssAttributeValue = "blue"
+
+        let parser = CSSParser()
+        let cssString = "  \(cssAttributeName)     :     \(cssAttributeValue)     ;"
+
+        let attributes = parser.parse(cssString)
+
+        XCTAssertTrue(attributes.contains(CSSAttribute(name: cssAttributeName, value: cssAttributeValue)))
+    }
+
+    func testParsingCSSWithMultipleValues() {
+
+        let inputAttributes = [
+            "color": "blue",
+            "text-decoration": "underline"
+        ]
+
+        let parser = CSSParser()
+
+        let cssString = inputAttributes.reduce("") { (previous, nextAttribute) -> String in
+            return previous + nextAttribute.key + ": " + nextAttribute.value + "; "
+        }
+
+        let attributes = parser.parse(cssString)
+
+        XCTAssertEqual(inputAttributes.count, attributes.count)
+
+        for inputAttribute in inputAttributes {
+            XCTAssertTrue(attributes.contains(CSSAttribute(name: inputAttribute.key, value: inputAttribute.value)))
+        }
+    }
+
+    func testParsingCSSWithMultipleValuesAndExtraSpaces() {
+
+        let inputAttributes = [
+            "color": "blue",
+            "text-decoration": "underline"
+        ]
+
+        let parser = CSSParser()
+
+        let cssString = inputAttributes.reduce("") { (previous, nextAttribute) -> String in
+            return previous + "    " + nextAttribute.key + "   :  " + nextAttribute.value + "    ;    "
+        }
+
+        let attributes = parser.parse(cssString)
+
+        XCTAssertEqual(inputAttributes.count, attributes.count)
+
+        for inputAttribute in inputAttributes {
+            XCTAssertTrue(attributes.contains(CSSAttribute(name: inputAttribute.key, value: inputAttribute.value)))
+        }
+    }
+}

--- a/AztecTests/HTML/Conversions/CSSParserTests.swift
+++ b/AztecTests/HTML/Conversions/CSSParserTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 class CSSParserTests: XCTestCase {
 
+    /// Tests parsing input CSS: "color: blue;"
+    ///
     func testParsingCSS() {
 
         let cssAttributeName = "color"
@@ -16,6 +18,8 @@ class CSSParserTests: XCTestCase {
         XCTAssertTrue(attributes.contains(CSSAttribute(name: cssAttributeName, value: cssAttributeValue)))
     }
 
+    /// Tests parsing input CSS: "color: blue"
+    ///
     func testParsingCSSWithoutClosingSemicolon() {
 
         let cssAttributeName = "color"
@@ -29,19 +33,23 @@ class CSSParserTests: XCTestCase {
         XCTAssertTrue(attributes.contains(CSSAttribute(name: cssAttributeName, value: cssAttributeValue)))
     }
 
+    /// Tests parsing input CSS: "  color  :  blue  ;  "
+    ///
     func testParsingCSSWithExtraSpaces() {
 
         let cssAttributeName = "color"
         let cssAttributeValue = "blue"
 
         let parser = CSSParser()
-        let cssString = "  \(cssAttributeName)     :     \(cssAttributeValue)     ;"
+        let cssString = "  \(cssAttributeName)  :  \(cssAttributeValue)  ;  "
 
         let attributes = parser.parse(cssString)
 
         XCTAssertTrue(attributes.contains(CSSAttribute(name: cssAttributeName, value: cssAttributeValue)))
     }
 
+    /// Tests parsing input CSS: "color: blue; text-decoration: underline;"
+    ///
     func testParsingCSSWithMultipleValues() {
 
         let inputAttributes = [
@@ -64,6 +72,8 @@ class CSSParserTests: XCTestCase {
         }
     }
 
+    /// Tests parsing input CSS: "color  :  blue  ;  text-decoration  :  underline  ;  "
+    ///
     func testParsingCSSWithMultipleValuesAndExtraSpaces() {
 
         let inputAttributes = [
@@ -74,7 +84,7 @@ class CSSParserTests: XCTestCase {
         let parser = CSSParser()
 
         let cssString = inputAttributes.reduce("") { (previous, nextAttribute) -> String in
-            return previous + "    " + nextAttribute.key + "   :  " + nextAttribute.value + "    ;    "
+            return previous + nextAttribute.key + "  :  " + nextAttribute.value + "  ;  "
         }
 
         let attributes = parser.parse(cssString)

--- a/AztecTests/HTML/Nodes/ElementNodeTests.swift
+++ b/AztecTests/HTML/Nodes/ElementNodeTests.swift
@@ -11,7 +11,7 @@ class ElementNodeTests: XCTestCase {
     ///
     func testEqualityOperatorEffectivelyReturnsFalseWhenNodesDiffer() {
         let text1 = TextNode(text: "First Children Here")
-        let attribute1 = Attribute(name: "some", string: "value")
+        let attribute1 = Attribute(name: "some", value: .string("value"))
         let style1 = ElementNode(name: "style", attributes: [attribute1], children: [text1])
 
         let text2 = TextNode(text: "Second Child!")
@@ -27,11 +27,11 @@ class ElementNodeTests: XCTestCase {
     ///
     func testEqualityOperatorEffectivelyReturnsTrueWhenNodesAreEqual() {
         let text1 = TextNode(text: "First Children Here")
-        let attribute1 = Attribute(name: "some", string: "value")
+        let attribute1 = Attribute(name: "some", value: .string("value"))
         let style1 = ElementNode(name: "style", attributes: [attribute1], children: [text1])
 
         let text2 = TextNode(text: "First Children Here")
-        let attribute2 = Attribute(name: "some", string: "value")
+        let attribute2 = Attribute(name: "some", value: .string("value"))
         let style2 = ElementNode(name: "style", attributes: [attribute2], children: [text2])
 
         XCTAssert(style1 == style2)

--- a/AztecTests/TextKit/HTMLRepresentationTests.swift
+++ b/AztecTests/TextKit/HTMLRepresentationTests.swift
@@ -60,7 +60,7 @@ private extension HTMLRepresentationTests {
     }
 
     var sampleAttribute: Attribute {
-        return Attribute(name: "css", value: .inlineCss([sampleCSS]))
+        return Attribute(name: "style", value: .inlineCss([sampleCSS]))
     }
 
     var sampleElement: HTMLElementRepresentation {

--- a/AztecTests/TextKit/HTMLRepresentationTests.swift
+++ b/AztecTests/TextKit/HTMLRepresentationTests.swift
@@ -55,8 +55,8 @@ class HTMLRepresentationTests: XCTestCase {
 //
 private extension HTMLRepresentationTests {
 
-    var sampleCSS: CSSProperty {
-        return CSSProperty(name: "some", value: "thing")
+    var sampleCSS: CSSAttribute {
+        return CSSAttribute(name: "some", value: "thing")
     }
 
     var sampleAttribute: Attribute {

--- a/AztecTests/TextKit/UnsupportedHTMLTests.swift
+++ b/AztecTests/TextKit/UnsupportedHTMLTests.swift
@@ -35,8 +35,8 @@ private extension UnsupportedHTMLTests {
 
     var sampleAttributes: [Attribute] {
         return [
-            Attribute(name: "none", value: .none),
-            Attribute(name: "string", value: .string("value")),
+            Attribute(name: "someBoolAttribute", value: .none),
+            Attribute(name: "someStringAttribute", value: .string("value")),
             Attribute(name: "style", value: .inlineCss([self.sampleCSS]))
         ]
     }

--- a/AztecTests/TextKit/UnsupportedHTMLTests.swift
+++ b/AztecTests/TextKit/UnsupportedHTMLTests.swift
@@ -29,8 +29,8 @@ class UnsupportedHTMLTests: XCTestCase {
 // MARK: - Helpers
 //
 private extension UnsupportedHTMLTests {
-    var sampleCSS: CSSProperty {
-        return CSSProperty(name: "text", value: "bold")
+    var sampleCSS: CSSAttribute {
+        return CSSAttribute(name: "text", value: "bold")
     }
 
     var sampleAttributes: [Attribute] {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -565,7 +565,7 @@ extension EditorDemoController {
     func toggleHeader(fromItem item: FormatBarItem) {
         let headerOptions = Constants.headers.map { headerType -> OptionsTableViewOption in
             let attributes = [
-                NSFontAttributeName: UIFont.systemFont(ofSize: headerType.fontSize)
+                NSFontAttributeName: UIFont.systemFont(ofSize: CGFloat(headerType.fontSize))
             ]
 
             let title = NSAttributedString(string: headerType.description, attributes: attributes)


### PR DESCRIPTION
### Description:

Several changes to support CSS styling.  Brings #285 forward.

### Details:

This PR moves us towards CSS support by:

- Adding class `CSSParser`.
- Integrating the CSS parsing step as part of the HTML parsing.
- Adding support for copying and pasting CSS attributes.

Also not directly related:

- Renames `CSSProperty` to `CSSAttribute`, for a more precise naming.
- Reorganizes the element -> formatters map, so that the same formatters can be reused for attributes if necessary.
- Introduces the `Coding` protocol and the `NSCodingProxy` class so we can implement `NSCoding` in `enum`s and `struct`s.  This will bring our code closer to the new Coding features in Swift 4.

### How to test:

**Test 1:**

1. Write some HTML with attributes (and CSS attributes).
2. Switch to visual mode.
3. Copy the text.
4. Paste it.
5 Switch to HTML mode and make sure no data was lost.

**Test 2:**

1. Open the sample editor with content.
2. Copy and paste all of the content.
3. Make sure HTML attributes are not lost in the process.
4. Make sure the app doesn't crash (of course compare against develop).