### PR TITLE
Preventing incorrect style removal

### DIFF
--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -19,7 +19,7 @@ class LayoutManager: NSLayoutManager {
     ///
     var preBackgroundColor = UIColor(red: 243.0/255.0, green: 246.0/255.0, blue: 248.0/255.0, alpha: 1.0)
 
-    ///
+    /// Closure that is expected to return the TypingAttributes associated to the Extra Line Fragment
     ///
     var extraLineFragmentTypingAttributes: (() -> [String: Any])!
 
@@ -53,7 +53,7 @@ private extension LayoutManager {
 
         let characterRange = self.characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
 
-        // Draw blockquotes
+        // Draw: Blockquotes
         textStorage.enumerateAttribute(NSParagraphStyleAttributeName, in: characterRange, options: []) { (object, range, stop) in
             guard let paragraphStyle = object as? ParagraphStyle, !paragraphStyle.blockquotes.isEmpty else {
                 return
@@ -63,40 +63,43 @@ private extension LayoutManager {
             let blockquoteGlyphRange = glyphRange(forCharacterRange: range, actualCharacterRange: nil)
 
             enumerateLineFragments(forGlyphRange: blockquoteGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
-
                 let lineRange = self.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
                 let lineCharacters = textStorage.attributedSubstring(from: lineRange).string
-                let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: rect, lineCharacters: lineCharacters, blockquoteIndent: blockquoteIndent)
+                let lineEndsParagraph = lineCharacters.isEndOfParagraph(before: lineCharacters.endIndex)
+                let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: blockquoteIndent, lineEndsParagraph: lineEndsParagraph)
 
                 self.drawBlockquote(in: blockquoteRect.integral, with: context)
             }
         }
 
-        if extraLineFragmentRect != .zero {
-            let typingAttributes = extraLineFragmentTypingAttributes()
-
-            guard let paragraphStyle = typingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle, !paragraphStyle.blockquotes.isEmpty else {
-                return
-            }
-
-            let blockquoteIndent = paragraphStyle.blockquoteIndent
-            // let extraLineRect = extraLineFragmentRect.offsetBy(dx: origin.x, dy: origin.y)
-            let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: extraLineFragmentRect, lineCharacters: "", blockquoteIndent: blockquoteIndent)
-            self.drawBlockquote(in: blockquoteRect.integral, with: context)
+        // Draw: Extra Line Fragment
+        guard extraLineFragmentRect != .zero else {
+            return
         }
+
+        let typingAttributes = extraLineFragmentTypingAttributes()
+        guard let paragraphStyle = typingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle, !paragraphStyle.blockquotes.isEmpty else {
+            return
+        }
+
+        let extraIndent = paragraphStyle.blockquoteIndent
+        let extraRect = blockquoteRect(origin: origin, lineRect: extraLineFragmentRect, blockquoteIndent: extraIndent, lineEndsParagraph: false)
+
+        drawBlockquote(in: extraRect.integral, with: context)
     }
+
 
     /// Returns the Rect in which the Blockquote should be rendered.
     ///
     /// - Parameters:
     ///     - origin: Origin of coordinates
     ///     - lineRect: Line Fragment's Rect
-    ///     - lineCharacters: Substring representing the current line
     ///     - blockquoteIndent: Blockquote Indentation Level for the current lineFragment
+    ///     - lineEndsParagraph: Indicates if the current blockquote line is the end of a Paragraph
     ///
     /// - Returns: Rect in which we should render the blockquote.
     ///
-    private func blockquoteRect(origin: CGPoint, lineRect: CGRect, lineCharacters: String, blockquoteIndent: CGFloat) -> CGRect {
+    private func blockquoteRect(origin: CGPoint, lineRect: CGRect, blockquoteIndent: CGFloat, lineEndsParagraph: Bool) -> CGRect {
         var blockquoteRect = lineRect.offsetBy(dx: origin.x, dy: origin.y)
         guard blockquoteIndent != 0 else {
             return blockquoteRect
@@ -107,12 +110,13 @@ private extension LayoutManager {
         blockquoteRect.size.width -= paddingWidth
 
         // Ref. Issue #645: Cheking if we this a middle line inside a blockquote paragraph
-        if lineCharacters.isEndOfParagraph(before: lineCharacters.endIndex) {
+        if lineEndsParagraph {
             blockquoteRect.size.height -= Metrics.paragraphSpacing * 0.5
         }
 
         return blockquoteRect
     }
+
 
     /// Draws a single Blockquote Line Fragment, in the specified Rectangle, using a given Graphics Context.
     ///
@@ -123,24 +127,6 @@ private extension LayoutManager {
         let borderRect = CGRect(origin: rect.origin, size: CGSize(width: 2, height: rect.height))
         blockquoteBorderColor.setFill()
         context.fill(borderRect)
-    }
-
-    ///
-    ///
-    private func mustDrawExtraLineFragment() -> Bool {
-        guard extraLineFragmentRect.height != 0 else {
-            return false
-        }
-
-        guard let extraTypingAttributes = extraLineFragmentTypingAttributes?() else {
-            return false
-        }
-
-        guard let extraStyle = extraTypingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle else {
-            return false
-        }
-
-        return !extraStyle.blockquotes.isEmpty
     }
 }
 
@@ -177,6 +163,7 @@ private extension LayoutManager {
 
     }
 
+
     /// Draws a single HTML Pre Line Fragment, in the specified Rectangle, using a given Graphics Context.
     ///
     private func drawHTMLPre(in rect: CGRect, with context: CGContext) {
@@ -184,6 +171,7 @@ private extension LayoutManager {
         context.fill(rect)
     }
 }
+
 
 // MARK: - Lists Helpers
 //
@@ -214,6 +202,7 @@ private extension LayoutManager {
             drawItem(number: markerNumber, in: markerRect, from: list, using: paragraphStyle, at: enclosingRange.location)
         }
     }
+
 
     /// Returns the Rect for the MarkerItem at the specified Range + Origin, within a given ParagraphStyle.
     ///

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -15,10 +15,14 @@ class LayoutManager: NSLayoutManager {
     ///
     var blockquoteBackgroundColor = UIColor(red: 0.91, green: 0.94, blue: 0.95, alpha: 1.0)
 
-
     /// HTML Pre Background Color
     ///
     var preBackgroundColor = UIColor(red: 243.0/255.0, green: 246.0/255.0, blue: 248.0/255.0, alpha: 1.0)
+
+    ///
+    ///
+    var extraLineFragmentTypingAttributes: (() -> [String: Any]?)?
+
 
     /// Draws the background, associated to a given Text Range
     ///
@@ -66,8 +70,14 @@ private extension LayoutManager {
 
                 self.drawBlockquote(in: blockquoteRect.integral, with: context)
             }
-        }
 
+            guard mustDrawExtraLineFragment() else {
+                return
+            }
+
+            let extraLineRect = extraLineFragmentRect.offsetBy(dx: origin.x, dy: origin.y)
+            self.drawBlockquote(in: extraLineRect, with: context)
+        }
     }
 
     /// Returns the Rect in which the Blockquote should be rendered.
@@ -108,7 +118,26 @@ private extension LayoutManager {
         blockquoteBorderColor.setFill()
         context.fill(borderRect)
     }
+
+    ///
+    ///
+    private func mustDrawExtraLineFragment() -> Bool {
+        guard extraLineFragmentRect.height != 0 else {
+            return false
+        }
+
+        guard let extraTypingAttributes = extraLineFragmentTypingAttributes?() else {
+            return false
+        }
+
+        guard let extraStyle = extraTypingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle else {
+            return false
+        }
+
+        return !extraStyle.blockquotes.isEmpty
+    }
 }
+
 
 // MARK: - PreFormatted Helpers
 //

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -21,7 +21,7 @@ class LayoutManager: NSLayoutManager {
 
     ///
     ///
-    var extraLineFragmentTypingAttributes: (() -> [String: Any]?)?
+    var extraLineFragmentTypingAttributes: (() -> [String: Any])!
 
 
     /// Draws the background, associated to a given Text Range
@@ -70,13 +70,19 @@ private extension LayoutManager {
 
                 self.drawBlockquote(in: blockquoteRect.integral, with: context)
             }
+        }
 
-            guard mustDrawExtraLineFragment() else {
+        if extraLineFragmentRect != .zero {
+            let typingAttributes = extraLineFragmentTypingAttributes()
+
+            guard let paragraphStyle = typingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle, !paragraphStyle.blockquotes.isEmpty else {
                 return
             }
 
-            let extraLineRect = extraLineFragmentRect.offsetBy(dx: origin.x, dy: origin.y)
-            self.drawBlockquote(in: extraLineRect, with: context)
+            let blockquoteIndent = paragraphStyle.blockquoteIndent
+            // let extraLineRect = extraLineFragmentRect.offsetBy(dx: origin.x, dy: origin.y)
+            let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: extraLineFragmentRect, lineCharacters: "", blockquoteIndent: blockquoteIndent)
+            self.drawBlockquote(in: blockquoteRect.integral, with: context)
         }
     }
 

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -21,7 +21,7 @@ class LayoutManager: NSLayoutManager {
 
     /// Closure that is expected to return the TypingAttributes associated to the Extra Line Fragment
     ///
-    var extraLineFragmentTypingAttributes: (() -> [String: Any])!
+    var extraLineFragmentTypingAttributes: (() -> [String: Any])?
 
 
     /// Draws the background, associated to a given Text Range
@@ -73,11 +73,10 @@ private extension LayoutManager {
         }
 
         // Draw: Extra Line Fragment
-        guard extraLineFragmentRect != .zero else {
+        guard extraLineFragmentRect != .zero, let typingAttributes = extraLineFragmentTypingAttributes?() else {
             return
         }
 
-        let typingAttributes = extraLineFragmentTypingAttributes()
         guard let paragraphStyle = typingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle, !paragraphStyle.blockquotes.isEmpty else {
             return
         }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -176,11 +176,26 @@ open class TextView: UITextView {
             ensureRemovalOfParagraphAttributesAfterSelectionChange()
             return super.typingAttributes
         }
-
         set {
             super.typingAttributes = newValue
         }
     }
+
+    /// This property returns the Attributes associated to the Extra Line Fragment.
+    ///
+    public var extraLineFragmentTypingAttributes: [String: Any] {
+        if selectedTextRange?.start == endOfDocument {
+            return typingAttributes
+        }
+
+        let document = textStorage.string
+        if document.isEndOfParagraph(at: document.endIndex) {
+            return [:]
+        }
+
+        return textStorage.attributes(at: max(document.characters.count - 1, 0), effectiveRange: nil)
+    }
+
 
     // MARK: - Init & deinit
 
@@ -251,11 +266,7 @@ open class TextView: UITextView {
         }
 
         aztecLayoutManager.extraLineFragmentTypingAttributes = { [weak self] in
-            guard let `self` = self, self.selectedTextRange?.start == self.endOfDocument else {
-                return [:]
-            }
-
-            return self.typingAttributes
+            return self?.extraLineFragmentTypingAttributes ?? [:]
         }
     }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -251,6 +251,18 @@ open class TextView: UITextView {
         }
 
         aztecLayoutManager.extraLineFragmentTypingAttributes = { [weak self] in
+
+            guard let `self` = self else {
+                return [:]
+            }
+
+            if self.selectedTextRange?.start == self.endOfDocument {
+                return self.typingAttributes
+            } else {
+                return [:]
+            }
+
+            /*
             guard let `self` = self else {
                 return nil
             }
@@ -265,6 +277,7 @@ open class TextView: UITextView {
 //            super.typingAttributes = initialAttributes
 
             return retrieved
+ */
         }
     }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -189,11 +189,12 @@ open class TextView: UITextView {
         }
 
         let document = textStorage.string
-        if document.isEndOfParagraph(at: document.endIndex) {
+        if document.isEndOfParagraph(before: document.endIndex) {
             return [:]
         }
 
-        return textStorage.attributes(at: max(document.characters.count - 1, 0), effectiveRange: nil)
+        let lastLocation = max(document.characters.count - 1, 0)
+        return textStorage.attributes(at: lastLocation, effectiveRange: nil)
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -193,9 +193,9 @@ open class TextView: UITextView {
         let layoutManager = LayoutManager()
         let container = NSTextContainer()
 
+        container.widthTracksTextView = true
         storage.addLayoutManager(layoutManager)
         layoutManager.addTextContainer(container)
-        container.widthTracksTextView = true
 
         super.init(frame: CGRect(x: 0, y: 0, width: 10, height: 10), textContainer: container)
         commonInit()
@@ -216,6 +216,7 @@ open class TextView: UITextView {
         linkTextAttributes = [NSUnderlineStyleAttributeName: NSNumber(value:NSUnderlineStyle.styleSingle.rawValue), NSForegroundColorAttributeName: self.tintColor]
         setupMenuController()
         setupAttachmentTouchDetection()
+        setupLayoutManager()
     }
 
     private func setupMenuController() {
@@ -242,6 +243,29 @@ open class TextView: UITextView {
             gesture.require(toFail: attachmentGestureRecognizer)
         }
         addGestureRecognizer(attachmentGestureRecognizer)
+    }
+
+    private func setupLayoutManager() {
+        guard let aztecLayoutManager = layoutManager as? LayoutManager else {
+            return
+        }
+
+        aztecLayoutManager.extraLineFragmentTypingAttributes = { [weak self] in
+            guard let `self` = self else {
+                return nil
+            }
+
+            return nil
+            let initialSelectedRange = self.selectedRange
+            let initialAttributes = self.typingAttributes
+            self.selectedRange = NSRange(location: self.textStorage.length, length: 0)
+
+            let retrieved = self.typingAttributes
+            self.selectedRange = initialSelectedRange
+//            super.typingAttributes = initialAttributes
+
+            return retrieved
+        }
     }
 
     // MARK: - Intercept copy paste operations

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1444,7 +1444,7 @@ private extension TextView {
     ///
     private func mustRemoveParagraphAttributesAfterSelectionChange() -> Bool {
         return selectedRange.location == storage.length
-            && storage.string.isEmptyLine(at: selectedRange.location)
+            && storage.string.isEmptyParagraph(at: selectedRange.location)
     }
 
     /// Removes the Paragraph Attributes [Blockquote, Pre, Lists] at the specified range. If the range

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -251,33 +251,11 @@ open class TextView: UITextView {
         }
 
         aztecLayoutManager.extraLineFragmentTypingAttributes = { [weak self] in
-
-            guard let `self` = self else {
+            guard let `self` = self, self.selectedTextRange?.start == self.endOfDocument else {
                 return [:]
             }
 
-            if self.selectedTextRange?.start == self.endOfDocument {
-                return self.typingAttributes
-            } else {
-                return [:]
-            }
-
-            /*
-            guard let `self` = self else {
-                return nil
-            }
-
-            return nil
-            let initialSelectedRange = self.selectedRange
-            let initialAttributes = self.typingAttributes
-            self.selectedRange = NSRange(location: self.textStorage.length, length: 0)
-
-            let retrieved = self.typingAttributes
-            self.selectedRange = initialSelectedRange
-//            super.typingAttributes = initialAttributes
-
-            return retrieved
- */
+            return self.typingAttributes
         }
     }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -184,17 +184,17 @@ open class TextView: UITextView {
     /// This property returns the Attributes associated to the Extra Line Fragment.
     ///
     public var extraLineFragmentTypingAttributes: [String: Any] {
-        if selectedTextRange?.start == endOfDocument {
+        guard selectedTextRange?.start != endOfDocument else {
             return typingAttributes
         }
 
         let document = textStorage.string
-        if document.isEndOfParagraph(before: document.endIndex) {
-            return [:]
+        guard document.isEndOfParagraph(before: document.endIndex) else {
+            let lastLocation = max(document.characters.count - 1, 0)
+            return textStorage.attributes(at: lastLocation, effectiveRange: nil)
         }
 
-        let lastLocation = max(document.characters.count - 1, 0)
-        return textStorage.attributes(at: lastLocation, effectiveRange: nil)
+        return [ NSParagraphStyleAttributeName: ParagraphStyle.default ]
     }
 
 


### PR DESCRIPTION
### Details:
In this PR we're implementing a mechanism that allows us to determine the Extra Line Fragment's Typing attributes.

This is required in order to draw the Background of empty Blockquote Line Fragments.

Fixes #718

### To test:
1. Launch the Empty Editor
2. Insert a Blockquote
3. Type `1` + **Shift + Enter** + `2`
4. Press Arrow Down
5. Hit **delete** Twice
6. Press Arrow UP
7. Type `3`

As a result, you should have, onscreen, a Blockquote with two lines. First line should read `31`, and the second line should be empty (yet, it's background should be properly rendered).

