### PR TITLE
Adds documentation to integrate Aztec with Carthage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Then:
 
 1. Open your project, head to **Build Settings** for your target and add `$(SDKROOT)/usr/include/libxml2/` to your **Header Search Paths**.
 2. Go to `Build Phases` > `Link Binary With Libraries` and add `Aztec.framework`.
+3. Add `import Aztec` to your project's source.
 
 ## Integrating the Library with CocoaPods
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,23 @@ Once Carthage finishes, you should open the file `Aztec.xcworkspace` from the ro
 
 Make sure the `AztecExample` target it selected, and press CMD + R to run it.
 
-## Using the Library
+## Integrating the Library with Carthage
+
+WordPress-Aztec-iOS is available through [Carthage](https://github.com/Carthage/Carthage). To install
+it, simply add the following line to your Cartfile:
+
+```bash
+github "wordpress-mobile/AztecEditor-iOS" "develop"
+```
+
+Follow [these instructions](https://github.com/Carthage/Carthage#getting-started) to build `Aztec.framework`.
+
+Then:
+
+1. Open your project, head to **Build Settings** for your target and add `$(SDKROOT)/usr/include/libxml2/` to your **Header Search Paths**.
+2. Go to `Build Phases` > `Link Binary With Libraries` and add `Aztec.framework`.
+
+## Integrating the Library with CocoaPods
 
 WordPress-Aztec-iOS is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:


### PR DESCRIPTION
Fixes #734 

Following @azone 's contribution in https://github.com/wordpress-mobile/AztecEditor-iOS/pull/733, this PR adds some extra information to make it easier to integrate Aztec into third party Apps through Carthage.

**To test:**

1. Create an empty Xcode project to integrate Aztec to.
2. Follow the new instructions in README.md and make sure they're clear enough.

IMPORTANT: make sure you add `import Aztec` somewhere in your project's sources and build it to make sure Aztec was properly integrated.