### PR TITLE
Removes an assert.

### DIFF
--- a/Aztec/Classes/Extensions/UIFont+Traits.swift
+++ b/Aztec/Classes/Extensions/UIFont+Traits.swift
@@ -25,7 +25,6 @@ extension UIFont {
         }
 
         guard let newDescriptor = descriptor.withSymbolicTraits(newTraits) else {
-            assertionFailure("Unable to modify Font's Traits: \(self)")
             return self
         }
 

--- a/Aztec/Classes/Extensions/UIFont+Traits.swift
+++ b/Aztec/Classes/Extensions/UIFont+Traits.swift
@@ -25,6 +25,10 @@ extension UIFont {
         }
 
         guard let newDescriptor = descriptor.withSymbolicTraits(newTraits) else {
+            // A nil descriptor can be returned whenever the requested font cannot be found.
+            // This is a very viable scenario, and our default handling mechanism for it is to
+            // return the original, unmodified font.
+            //
             return self
         }
 


### PR DESCRIPTION
Removes an assert that was really triggered by normal usage of the library.  There's a default behavior in place to make sure the app handles the situation graciously.