### PR TITLE
Fix/iphone x toolbar

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -156,7 +156,7 @@ open class FormatBar: UIView {
         let availableWidth = visibleWidth
         guard availableWidth > 0 else { return [] }
 
-        let visibleItemCount = Int(floor(availableWidth / Constants.stackButtonWidth))
+        let visibleItemCount = Int(floor(availableWidth / Constants.defaultButtonWidth))
 
         let allItems = items
         let leadingItemCount = leadingItem != nil ? 1 : 0
@@ -177,7 +177,7 @@ open class FormatBar: UIView {
             trailingItem.sizeToFit()
             return trailingItem.bounds.size.width + Constants.trailingButtonMargin
         } else {
-            return Constants.stackButtonWidth
+            return Constants.defaultButtonWidth
         }
     }
 
@@ -328,7 +328,7 @@ open class FormatBar: UIView {
     open override func safeAreaInsetsDidChange() {
         super.safeAreaInsetsDidChange()
 
-        let newHeight = Constants.stackButtonWidth + safeAreaInsets.bottom
+        let newHeight = Constants.defaultBarHeight + safeAreaInsets.bottom
         if newHeight != heightConstraint?.constant {
             heightConstraint?.constant = newHeight
             layoutIfNeeded()
@@ -347,7 +347,7 @@ open class FormatBar: UIView {
     }
 
     open override var intrinsicContentSize: CGSize {
-        var height = Constants.formatBarHeight
+        var height = Constants.defaultBarHeight
         if let heightConstraint = self.heightConstraint {
             height = heightConstraint.constant
         }
@@ -658,7 +658,7 @@ private extension FormatBar {
             scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
             scrollView.topAnchor.constraint(equalTo: topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            scrollView.heightAnchor.constraint(equalToConstant: Constants.formatBarHeight)
+            scrollView.heightAnchor.constraint(equalToConstant: Constants.defaultBarHeight)
         ])
 
         NSLayoutConstraint.activate([
@@ -760,10 +760,18 @@ extension FormatBar: UIScrollViewDelegate {
     }
 }
 
+// MARK: - Constants
+extension FormatBar {
+    struct Constants {
+        static let defaultBarHeight = CGFloat(44)
+        static let defaultButtonWidth = Constants.defaultBarHeight
+        static let defaultButtonHeight = Constants.defaultBarHeight
+    }
+}
+
 // MARK: - Private Constants
 //
 private extension FormatBar {
-
     struct Animations {
         static let durationLong = TimeInterval(0.3)
         static let durationShort = TimeInterval(0.15)
@@ -785,17 +793,15 @@ private extension FormatBar {
             static let springInitialVelocity = CGFloat(1.0)
         }
     }
+}
 
-    struct Constants {
-        static let overflowExpandedUserDefaultsKey = "AztecFormatBarOverflowExpandedKey"
-        static let fixedSeparatorMidPointPaddingX = CGFloat(5)
-        static let stackViewCompactSpacing = CGFloat(0)
-        static let stackViewRegularSpacing = CGFloat(0)
-        static let formatBarHeight = CGFloat(44)
-        static let stackButtonWidth = Constants.formatBarHeight
-        static let horizontalDividerHeight = CGFloat(1)
-        static let trailingButtonMargin = CGFloat(12)
-    }
+private extension FormatBar.Constants {
+    static let overflowExpandedUserDefaultsKey = "AztecFormatBarOverflowExpandedKey"
+    static let fixedSeparatorMidPointPaddingX = CGFloat(5)
+    static let stackViewCompactSpacing = CGFloat(0)
+    static let stackViewRegularSpacing = CGFloat(0)
+    static let horizontalDividerHeight = CGFloat(1)
+    static let trailingButtonMargin = CGFloat(12)
 }
 
 private extension UIView {

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -576,6 +576,14 @@ private extension FormatBar {
     /// Sets up the Constraints
     ///
     func configureConstraints() {
+        var leadingAnchor = self.leadingAnchor
+        var trailingAnchor = self.trailingAnchor
+
+        if #available(iOS 11.0, *) {
+            leadingAnchor = safeAreaLayoutGuide.leadingAnchor
+            trailingAnchor = safeAreaLayoutGuide.trailingAnchor
+        }
+
         let overflowTrailingConstraint = overflowToggleItem.trailingAnchor.constraint(equalTo: trailingAnchor)
         overflowTrailingConstraint.priority = UILayoutPriorityDefaultLow
 
@@ -597,16 +605,16 @@ private extension FormatBar {
         ])
 
         NSLayoutConstraint.activate([
-            topDivider.leadingAnchor.constraint(equalTo: leadingAnchor),
-            topDivider.trailingAnchor.constraint(equalTo: trailingAnchor),
+            topDivider.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            topDivider.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             topDivider.topAnchor.constraint(equalTo: topAnchor),
             topDivider.heightAnchor.constraint(equalToConstant: Constants.horizontalDividerHeight)
         ])
 
         NSLayoutConstraint.activate([
-            bottomDivider.leadingAnchor.constraint(equalTo: leadingAnchor),
-            bottomDivider.trailingAnchor.constraint(equalTo: trailingAnchor),
             bottomDivider.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bottomDivider.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            bottomDivider.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             bottomDivider.heightAnchor.constraint(equalToConstant: Constants.horizontalDividerHeight)
         ])
 

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -292,6 +292,8 @@ open class FormatBar: UIView {
         super.init(frame: .zero)
         backgroundColor = .white
 
+        autoresizingMask = [ .flexibleHeight ]
+
         configure(scrollView: scrollView)
         configureScrollableStackView()
 
@@ -440,6 +442,7 @@ open class FormatBar: UIView {
         if newHeight != heightConstraint?.constant {
             heightConstraint?.constant = newHeight
             updateDividerInsets()
+            invalidateIntrinsicContentSize()
             layoutIfNeeded()
         }
     }
@@ -661,14 +664,14 @@ private extension FormatBar {
 
         NSLayoutConstraint.activate([
             overflowToggleItem.topAnchor.constraint(equalTo: topAnchor),
-            overflowToggleItem.bottomAnchor.constraint(equalTo: bottomAnchor),
+            overflowToggleItem.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
             overflowToggleItem.leadingAnchor.constraint(greaterThanOrEqualTo: scrollableStackView.trailingAnchor),
             overflowTrailingConstraint
         ])
 
         NSLayoutConstraint.activate([
             trailingItemContainer.topAnchor.constraint(equalTo: topAnchor),
-            trailingItemContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
+            trailingItemContainer.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
             trailingItemContainer.leadingAnchor.constraint(greaterThanOrEqualTo: scrollableStackView.trailingAnchor),
             trailingItemTrailingConstraint
         ])
@@ -691,7 +694,6 @@ private extension FormatBar {
             scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
             scrollView.topAnchor.constraint(equalTo: topAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
             scrollView.heightAnchor.constraint(equalToConstant: Constants.defaultBarHeight)
         ])
 

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -311,6 +311,14 @@ open class FormatBar: UIView {
         configureConstraints()
     }
 
+    open override func didMoveToWindow() {
+        super.didMoveToWindow()
+
+        if #available(iOS 11.0, *) {
+            updateForSafeAreaInsets()
+        }
+    }
+
 
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
@@ -328,12 +336,7 @@ open class FormatBar: UIView {
     open override func safeAreaInsetsDidChange() {
         super.safeAreaInsetsDidChange()
 
-        let newHeight = Constants.defaultBarHeight + safeAreaInsets.bottom
-        if newHeight != heightConstraint?.constant {
-            heightConstraint?.constant = newHeight
-            updateDividerInsets()
-            layoutIfNeeded()
-        }
+        updateForSafeAreaInsets()
     }
 
     // We're overriding this method so we can easily access the system height
@@ -429,6 +432,16 @@ open class FormatBar: UIView {
     fileprivate func updateOverflowToggleItemVisibility() {
         let hasOverflowItems = !overflowItems.isEmpty
         overflowToggleItem.isHidden = !hasOverflowItems || trailingItem != nil
+    }
+
+    @available(iOS 11.0, *)
+    fileprivate func updateForSafeAreaInsets() {
+        let newHeight = Constants.defaultBarHeight + safeAreaInsets.bottom
+        if newHeight != heightConstraint?.constant {
+            heightConstraint?.constant = newHeight
+            updateDividerInsets()
+            layoutIfNeeded()
+        }
     }
 
     @available(iOS 11.0, *)

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -331,6 +331,7 @@ open class FormatBar: UIView {
         let newHeight = Constants.defaultBarHeight + safeAreaInsets.bottom
         if newHeight != heightConstraint?.constant {
             heightConstraint?.constant = newHeight
+            updateDividerInsets()
             layoutIfNeeded()
         }
     }
@@ -428,6 +429,26 @@ open class FormatBar: UIView {
     fileprivate func updateOverflowToggleItemVisibility() {
         let hasOverflowItems = !overflowItems.isEmpty
         overflowToggleItem.isHidden = !hasOverflowItems || trailingItem != nil
+    }
+
+    @available(iOS 11.0, *)
+    fileprivate func updateDividerInsets() {
+        var dividerInsets = UIEdgeInsets.zero
+
+        // If we have safe area insets, we'll end up expanding the toolbar vertically.
+        // In that situation, we'll inset any dividers slightly to improve the appearance.
+        if safeAreaInsets.bottom > 0 {
+            dividerInsets = UIEdgeInsets(top: Constants.expandedFormatBarDividerInset,
+                                         left: 0,
+                                         bottom: Constants.expandedFormatBarDividerInset,
+                                         right: 0)
+        }
+
+        scrollableStackView.arrangedSubviews.forEach({ item in
+            if let item = item as? FormatBarDividerItem {
+                item.layoutMargins = dividerInsets
+            }
+        })
     }
     
     @IBAction func handleButtonTouch(_ sender: FormatBarItem) {
@@ -802,6 +823,7 @@ private extension FormatBar.Constants {
     static let stackViewRegularSpacing = CGFloat(0)
     static let horizontalDividerHeight = CGFloat(1)
     static let trailingButtonMargin = CGFloat(12)
+    static let expandedFormatBarDividerInset = CGFloat(5)
 }
 
 private extension UIView {

--- a/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
@@ -149,7 +149,27 @@ open class FormatBarItem: UIButton {
 }
 
 class FormatBarDividerItem: UIView {
+    init() {
+        super.init(frame: .zero)
+
+        layoutMargins = .zero
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// You can modify the divider item's layout margins to
+    override var layoutMargins: UIEdgeInsets {
+        didSet {
+            if !UIEdgeInsetsEqualToEdgeInsets(layoutMargins, oldValue) {
+                invalidateIntrinsicContentSize()
+                setNeedsLayout()
+            }
+        }
+    }
+
     override var intrinsicContentSize: CGSize {
-        return CGSize(width: 1.0, height: 44.0)
+        return CGSize(width: 1.0, height: FormatBar.Constants.defaultButtonHeight - layoutMargins.top - layoutMargins.bottom)
     }
 }

--- a/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
@@ -101,13 +101,14 @@ open class FormatBarItem: UIButton {
     // MARK: - Lifecycle
 
     public convenience init(image: UIImage, identifier: String? = nil) {
-        let defaultFrame = CGRect(x: 0, y: 0, width: 44, height: 44)
+        let defaultFrame = CGRect(x: 0, y: 0, width: FormatBar.Constants.defaultButtonWidth, height: FormatBar.Constants.defaultButtonHeight)
         self.init(image: image, frame: defaultFrame)
         self.identifier = identifier
     }
 
     open override var intrinsicContentSize: CGSize {
-        return CGSize(width: 44.0, height: 44.0)
+        return CGSize(width: FormatBar.Constants.defaultButtonWidth,
+                      height: FormatBar.Constants.defaultButtonHeight)
     }
 
     public init(image: UIImage, frame: CGRect) {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -914,6 +914,7 @@ extension EditorDemoController {
 
         toolbar.overflowToggleIcon = Gridicon.iconOfType(.ellipsis)
         toolbar.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 44.0)
+        toolbar.autoresizingMask = [ .flexibleHeight ]
         toolbar.formatter = self
 
         toolbar.leadingItem = mediaItem


### PR DESCRIPTION
Refs #728 and https://github.com/wordpress-mobile/WordPress-iOS/issues/7821

This PR adjusts the FormatBar so it better handles the iPhone X's screen and safe insets. In particular:

* The edges of the toolbar's buttons' container is now constrained to the safe area guides on either side, so in landscape we don't flow underneath the notch.
* The bar now adapts its height if the software keyboard is hidden (due to a hardware keyboard being connected) so it no longer sits underneath the home indicator.

![iphone-x-format-bar-before-after](https://user-images.githubusercontent.com/4780/31229337-3ea60988-a9d8-11e7-8bde-4e4555901771.png)

To test:

* Build and run the sample app on iPhone X.
* In the demo editor, check the toolbar's appearance in the following scenarios:
   * Portrait, hardware keyboard connected (you can use Cmd+K to toggle it) so toolbar sits at bottom of screen
   * Landscape, hardware keyboard connected
   * Landscape, hardware keyboard disconnected

Needs review: @SergioEstevao 