### PR TITLE
iOS 11: Delete Backwards Workaround

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -457,9 +457,10 @@ open class TextView: UITextView {
 
         ensureRemovalOfParagraphStylesBeforeRemovingCharacter(at: selectedRange)
 
-        super.deleteBackward()
+        preserveTypingAttributes {
+            super.deleteBackward()
+        }
 
-        ensureTypingAttributesAreValid()
         ensureRemovalOfParagraphAttributesWhenPressingBackspaceAndEmptyingTheDocument()
         ensureCursorRedraw(afterEditing: deletedString.string)
         delegate?.textViewDidChange?(self)
@@ -974,14 +975,19 @@ open class TextView: UITextView {
     ///
     /// Issue: https://github.com/wordpress-mobile/AztecEditor-iOS/issues/749
     ///
-    private func ensureTypingAttributesAreValid() {
+    private func preserveTypingAttributes(beforeDeletion block: () -> Void) {
         let document = textStorage.string
         guard selectedRange.location == document.characters.count else {
+            block()
             return
         }
 
         let previousLocation = max(selectedRange.location - 1, 0)
-        typingAttributes = textStorage.attributes(at: previousLocation, effectiveRange: nil)
+        let previousAttributes = textStorage.attributes(at: previousLocation, effectiveRange: nil)
+
+        block()
+
+        typingAttributes = previousAttributes
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -457,20 +457,9 @@ open class TextView: UITextView {
 
         ensureRemovalOfParagraphStylesBeforeRemovingCharacter(at: selectedRange)
 
-        // WORKAROUND: iOS 11 introduced an issue that's causing UITextView to lose it's typing
-        // attributes under certain circumstances.  This workaround is analog to the one introduced in
-        /// the `insertText` call.
-        //
-        // Issue: https://github.com/wordpress-mobile/AztecEditor-iOS/issues/749
-        //
-        let workaroundTypingAttributes = typingAttributes
-
         super.deleteBackward()
 
-        // WORKAROUND: this line is related to the workaround above.
-        //
-        typingAttributes = workaroundTypingAttributes
-
+        ensureTypingAttributesAreValid()
         ensureRemovalOfParagraphAttributesWhenPressingBackspaceAndEmptyingTheDocument()
         ensureCursorRedraw(afterEditing: deletedString.string)
         delegate?.textViewDidChange?(self)
@@ -976,6 +965,23 @@ open class TextView: UITextView {
             self.selectedRange = pristine
             self.typingAttributes = beforeTypingAttributes
         }
+    }
+
+
+    // WORKAROUND: iOS 11 introduced an issue that's causing UITextView to lose it's typing
+    // attributes under certain circumstances. This method will determine the Typing Attributes based on
+    /// the TextStorage attributes, whenever possible.
+    ///
+    /// Issue: https://github.com/wordpress-mobile/AztecEditor-iOS/issues/749
+    ///
+    private func ensureTypingAttributesAreValid() {
+        let document = textStorage.string
+        guard selectedRange.location == document.characters.count else {
+            return
+        }
+
+        let previousLocation = max(selectedRange.location - 1, 0)
+        typingAttributes = textStorage.attributes(at: previousLocation, effectiveRange: nil)
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -457,7 +457,19 @@ open class TextView: UITextView {
 
         ensureRemovalOfParagraphStylesBeforeRemovingCharacter(at: selectedRange)
 
+        // WORKAROUND: iOS 11 introduced an issue that's causing UITextView to lose it's typing
+        // attributes under certain circumstances.  This workaround is analog to the one introduced in
+        /// the `insertText` call.
+        //
+        // Issue: https://github.com/wordpress-mobile/AztecEditor-iOS/issues/749
+        //
+        let workaroundTypingAttributes = typingAttributes
+
         super.deleteBackward()
+
+        // WORKAROUND: this line is related to the workaround above.
+        //
+        typingAttributes = workaroundTypingAttributes
 
         ensureRemovalOfParagraphAttributesWhenPressingBackspaceAndEmptyingTheDocument()
         ensureCursorRedraw(afterEditing: deletedString.string)

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1409,6 +1409,9 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.paragraphSeparator))
     }
 
+
+    // MARK: - Media
+
     func testInsertVideo() {
         let textView = createEmptyTextView()
         let _ = textView.replaceWithVideo(at: NSRange(location:0, length:0), sourceURL: URL(string: "video.mp4")!, posterURL: URL(string: "video.jpg"), placeHolderImage: nil)
@@ -1447,6 +1450,9 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(textView.getHTML(), "<p><video src=\"newVideo.mp4\" poster=\"video.jpg\" data-wpvideopress=\"ABCDE\"></video></p>")
     }
 
+
+    // MARK: - Comments
+
     /// This test check if the insertion of a Comment Attachment works correctly and the expected tag gets inserted
     ///
     func testInsertComment() {
@@ -1469,6 +1475,9 @@ class TextViewTests: XCTestCase {
 
         XCTAssertEqual(html, "<p><!--some other comment should go here--><!--more--></p>")
     }
+
+
+    // MARK: - HR
 
     /// This test check if the insertion of an horizontal ruler works correctly and the hr tag is inserted
     ///
@@ -1571,6 +1580,9 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone wp-image-169\" alt=\"Changed Alt\" title=\"Title\"></p>")
     }
 
+
+    // MARK: - Bugfixing
+
     /// This test verifies that the H1 Header does not get lost during the Rich <> Raw transitioning.
     ///
     func testToggleHtmlWithTwoEmptyLineBreaksDoesNotLooseHeaderStyle() {
@@ -1663,5 +1675,28 @@ class TextViewTests: XCTestCase {
         // Verify!
         let expected = "<ol><li><ol><li><ol><li><blockquote>First Item</blockquote></li></ol></li></ol></li></ol>"
         XCTAssert(textView.getHTML(prettyPrint: false) == expected)
+    }
+
+    /// This test verifies that the `deleteBackward` call does not result in loosing the Typing Attributes.
+    /// Precisely, we'll ensure that the Italics style isn't lost after hitting backspace, and retyping the
+    /// deleted character.
+    ///
+    /// Ref. Issue #749: Loosing Style after hitting Backspace
+    ///
+    func testDeleteBackwardsDoesNotEndUpLoosingItalicsStyle() {
+        let textView = createTextView(withHTML: "")
+
+        textView.toggleBoldface(self)
+        textView.insertText("First Line")
+        textView.insertText("\n")
+
+        textView.toggleItalics(self)
+        textView.insertText("Second")
+
+        let expectedHTML = textView.getHTML(prettyPrint: false)
+        textView.deleteBackward()
+        textView.insertText("d")
+
+        XCTAssertEqual(textView.getHTML(prettyPrint: false), expectedHTML)
     }
 }


### PR DESCRIPTION
### Details:
iOS 11's `insertText` / `deleteBackward`'s inner workings result into loosing the typingAttributes. This fix is analog to the one introduced via #725.

Fixes #749

cc @diegoreymendez 
Thanks in advance!

### To test:
1. Verify that the unit tests pass
2. Launch Aztec > Empty document
3. Toggle Bold
4. Type Here + Newline
5. Toggle Italics
6. Type Theree + Backspace twice
7. Type e
8. Verify that the new `e` character is in italics.

