### PR TITLE
HeaderFormatter: Restoring default font size for .none header type

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -43,9 +43,10 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
             newParagraphStyle.replaceProperty(ofType: Header.self, with: header)
         }
 
+        let targetFontSize = headerFontSize(for: headerLevel, defaultSize: defaultSize)
         var resultingAttributes = attributes
         resultingAttributes[NSParagraphStyleAttributeName] = newParagraphStyle
-        resultingAttributes[NSFontAttributeName] = font.withSize(CGFloat(headerLevel.fontSize))
+        resultingAttributes[NSFontAttributeName] = font.withSize(CGFloat(targetFontSize))
 
         return resultingAttributes
     }
@@ -98,5 +99,13 @@ private extension HeaderFormatter {
         }
 
         return nil
+    }
+
+    func headerFontSize(for type: Header.HeaderType, defaultSize: Float?) -> Float {
+        guard type == .none, let defaultSize = defaultSize else {
+            return type.fontSize
+        }
+
+        return defaultSize
     }
 }


### PR DESCRIPTION
### Details:
Fixes #755
cc @diegoreymendez 

### To test:
1. Launch the Emtpy Editor
2. Type `Something` + newline
3. Press over the `H` format bar button, and pick the **Default** font
4. Type `Else`

Verify that the size of the font in (2) and (4) do match.
