### PR TITLE
Keyboard Switch: Fixing Vertical Padding Glitch

### DIFF
--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -709,9 +709,9 @@ extension EditorDemoController {
         if richTextView.inputView == to {
             return
         }
-        richTextView.resignFirstResponder()
+
         richTextView.inputView = to
-        richTextView.becomeFirstResponder()
+        richTextView.reloadInputViews()
     }
 
     func headerLevelForSelectedText() -> Header.HeaderType {


### PR DESCRIPTION
### Details:
This PR prevents an undesired vertical scrolling glitch, when switching to a custom Input View (ie. Header Level picker).

Fixes #756 
cc @diegoreymendez 

### To test:
1. Emtpy Document
2. Type enough text to cause vertical scrolling
3. Place the cursor at the bottom of the document
4. Press `H` / `List`'s format bar buttons

Verify that the vertical offset doesn't flicker at all.

