### PR TITLE
TextView: Attachments Recognizer no longer receiving all touches

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1634,9 +1634,17 @@ extension TextView: TextStorageAttachmentsDelegate {
         return true
     }
 
-    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        guard let textView = textView else {
+            return false
+        }
 
-        guard let textView = self.textView else {
+        let locationInTextView = touch.location(in: textView)
+        return textView.attachmentAtPoint(locationInTextView) != nil
+    }
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard let textView = textView else {
             return false
         }
 
@@ -1652,9 +1660,8 @@ extension TextView: TextStorageAttachmentsDelegate {
     }
 
     func richTextViewWasPressed(_ recognizer: UIGestureRecognizer) {
-        guard let textView = self.textView,
-            recognizer.state == .recognized else {
-                return
+        guard let textView = textView, recognizer.state == .recognized else {
+            return
         }
 
         let locationInTextView = recognizer.location(in: textView)


### PR DESCRIPTION
### Details:
This PR updates the Attachments Gesture Recognizer, so that touches that fall beyond an image attachment aren't even accepted.

Fixes #765

### To test:
1. Launch the empty editor
2. Insert an image
3. Verify that you're still able to press over the attachment, and access it's options
4. Enter some text
5. Verify that iOS's Magnifier shows up after a long press

Needs Review: @SergioEstevao 
Thanks in advance sir!

