### PR TITLE
Updating Attachments Delegate's API

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -39,9 +39,9 @@ protocol TextStorageAttachmentsDelegate: class {
     ///     - storage: The storage that is requesting the image.
     ///     - imageAttachment: The image that was added to the storage.
     ///
-    /// - Returns: the requested `NSURL` where the image is stored.
+    /// - Returns: the requested `URL` where the image is stored, or nil if it's not yet available.
     ///
-    func storage(_ storage: TextStorage, urlFor imageAttachment: ImageAttachment) -> URL
+    func storage(_ storage: TextStorage, urlFor imageAttachment: ImageAttachment) -> URL?
 
     /// Called when a attachment is removed from the storage.
     ///

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -28,9 +28,9 @@ public protocol TextViewAttachmentDelegate: class {
     ///     - textView: The textView that is requesting the image.
     ///     - imageAttachment: The image attachment that was added to the storage.
     ///
-    /// - Returns: the requested `NSURL` where the image is stored.
+    /// - Returns: the requested `URL` where the image is stored, or nil if it's not yet available.
     ///
-    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL
+    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL?
 
     /// Called when an attachment doesn't have an available source URL to provide an image representation.
     ///
@@ -1628,7 +1628,7 @@ extension TextView: TextStorageAttachmentsDelegate {
         return textAttachmentDelegate.textView(self, placeholderFor: attachment)
     }
     
-    func storage(_ storage: TextStorage, urlFor imageAttachment: ImageAttachment) -> URL {
+    func storage(_ storage: TextStorage, urlFor imageAttachment: ImageAttachment) -> URL? {
         guard let textAttachmentDelegate = textAttachmentDelegate else {
             fatalError("This class requires a text attachment delegate to be set.")
         }

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -104,8 +104,8 @@ class TextStorageTests: XCTestCase {
             deletedAttachmendIDCalledWithString = attachmentID
         }
 
-        func storage(_ storage: TextStorage, urlFor imageAttachment: ImageAttachment) -> URL {
-            return URL(string:"test://")!
+        func storage(_ storage: TextStorage, urlFor imageAttachment: ImageAttachment) -> URL? {
+            return URL(string:"test://")
         }
 
         func storage(_ storage: TextStorage, placeholderFor attachment: NSTextAttachment) -> UIImage {

--- a/AztecTests/TextKit/TextViewStubAttachmentDelegate.swift
+++ b/AztecTests/TextKit/TextViewStubAttachmentDelegate.swift
@@ -27,8 +27,8 @@ class TextViewStubAttachmentDelegate: TextViewAttachmentDelegate, TextViewAttach
         return placeholderImage
     }
 
-    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL {
-        return URL(string: "placeholder://")!
+    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL? {
+        return nil
     }
 
     func textView(_ textView: TextView, deletedAttachmentWith attachmentID: String) {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1026,14 +1026,13 @@ extension EditorDemoController: TextViewAttachmentDelegate {
         return placeholderImage
     }
 
-    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL {
-        
-        // TODO: start fake upload process
-        if let image = imageAttachment.image {
-            return saveToDisk(image: image)
-        } else {
-            return URL(string: "placeholder://")!
+    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL? {
+        guard let image = imageAttachment.image else {
+            return nil
         }
+
+        // TODO: start fake upload process
+        return saveToDisk(image: image)
     }
 
     func textView(_ textView: TextView, deletedAttachmentWith attachmentID: String) {


### PR DESCRIPTION
### Details:
In this PR we're allowing for `nil` MediaAttachment(s) URL. This will allow us to remove the `placeholder://` workaround that has served us well, but is behind a [WordPress iOS Issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/7973) in which Drag + Drop images won't immediately be displayed.

### To test:
1. Try adding new images
2. Verify nothing breaks
3. Verify that the unit tests still pass

cc @SergioEstevao 
Thanks in advance sir!

