### PR TITLE
HTMLStorage: Adds missing initializer

### DIFF
--- a/Aztec/Classes/TextKit/HTMLStorage.swift
+++ b/Aztec/Classes/TextKit/HTMLStorage.swift
@@ -30,6 +30,22 @@ open class HTMLStorage: NSTextStorage {
 
     // MARK: - Initializers
 
+    public override init() {
+        // Note:
+        // iOS 11 has changed the way Copy + Paste works. As far as we can tell, upon Paste, the system
+        // instantiates a new UITextView stack, and renders it on top of the one in use.
+        // This (appears) to be the cause of a glitch in which the pasted text would temporarily appear out
+        // of phase, on top of the "pre paste UI".
+        //
+        // We're adding a ridiculosly small defaultFont here, in order to force the "Secondary" UITextView
+        // not to render anything.
+        //
+        // Ref. https://github.com/wordpress-mobile/AztecEditor-iOS/issues/771
+        //
+        font = UIFont.systemFont(ofSize: 4)
+        super.init()
+    }
+
     public init(defaultFont: UIFont) {
         font = defaultFont
         super.init()


### PR DESCRIPTION
### Details:
In this PR we're adding a missing initializer, which is the cause of #771.

iOS 11 has changed the way paste works. As far as we can tell, the system instantiates a secondary UITextView + an entire TextKit stack, during the Paste OP.

Unsurprisingly, this is the actual cause of the [ghost image visible in this video](https://cloudup.com/csK0LoMHHNJ). As a workaround, we're setting a ridiculously small "Default Font", so that whenever the system itself instantiates a **HTMLStorage** entity, the font would be so small it won't even get rendered.

Apologies.

Fixes #771
Needs Review: @diegoreymendez 

### To test:
1. Launch Aztec's `Editor Demo` (populated w/text)
2. Switch to HTML mode
3. Copy all of the contents
4. Paste

As a result, verify that Aztec does not crash.
