### PR TITLE
Fixing Xcode9 Warnings

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -648,12 +648,10 @@ private extension FormatBar {
     func configureConstraints() {
         var leadingAnchor = self.leadingAnchor
         var trailingAnchor = self.trailingAnchor
-        var bottomAnchor = self.bottomAnchor
 
         if #available(iOS 11.0, *) {
             leadingAnchor = safeAreaLayoutGuide.leadingAnchor
             trailingAnchor = safeAreaLayoutGuide.trailingAnchor
-            bottomAnchor = layoutMarginsGuide.bottomAnchor
         }
 
         let overflowTrailingConstraint = overflowToggleItem.trailingAnchor.constraint(equalTo: trailingAnchor)

--- a/Example/Example/UnknownEditorViewController.swift
+++ b/Example/Example/UnknownEditorViewController.swift
@@ -39,7 +39,7 @@ class UnknownEditorViewController: UIViewController {
 
     /// Closure to be executed whenever the user cancels edition
     ///
-    var onDidCancel: ((Void) -> Void)?
+    var onDidCancel: (() -> Void)?
 
 
 


### PR DESCRIPTION
### Details:
- Removed unused variable
- Updated a closure signature to match the new standard

I'm afraid it seems not possible to get rid of the remaining warning (appears to be a Swift 3.2 Compiler glitch). Will probably go away whenever we jump over Swift 4.

### To test:
- Verify that the unit tests are green!

cc @diegoreymendez 
Thanks!


