### PR TITLE
Fixing Image Paste Glitch

### DIFF
--- a/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
@@ -35,7 +35,8 @@ extension NSAttributedString
                 return
             }
 
-            let image = UIImage(data: data)
+            let scale = UIScreen.main.scale
+            let image = UIImage(data: data, scale: scale)
             attachment.fileWrapper = nil
             attachment.image = image
         }

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -32,7 +32,7 @@ open class MediaAttachment: NSTextAttachment {
 
     /// Identifier used to match this attachment with a custom UIView subclass
     ///
-    private(set) open var identifier: String
+    open var identifier = String()
     
     /// Attachment URL
     ///
@@ -108,10 +108,20 @@ open class MediaAttachment: NSTextAttachment {
     /// Required Initializer
     ///
     required public init?(coder aDecoder: NSCoder) {
-        identifier = aDecoder.decodeObject(forKey: EncodeKeys.identifier.rawValue) as? String ?? String()
-        url = aDecoder.decodeObject(forKey: EncodeKeys.url.rawValue) as? URL
-
+        /// Note:
+        /// As unbelievable as it will sound, when de-archiving ImageAttachment, `MediaAttachment`'s
+        /// super.init(coder: aDecoder)` call results in a call to`ImageAttachment.init(data, ofType)`.
+        /// Which, of course, ends up being caught by MediaAttachment's `init(data, ofType)`.
+        ///
+        /// Bottom line, the *identifier* and *url* might end up reset, if assigned before the `super.init` call.
+        /// For that reason, we've tunned things, and move those two assignments below.
+        ///
+        /// *Please* keep them this way. May the reviewer forgive me, since this is horrible.
+        ///
         super.init(coder: aDecoder)
+
+        identifier = aDecoder.decodeObject(forKey: EncodeKeys.identifier.rawValue) as? String ?? identifier
+        url = aDecoder.decodeObject(forKey: EncodeKeys.url.rawValue) as? URL
     }
 
     /// Required Initializer

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -334,8 +334,9 @@ private extension MediaAttachment {
     /// Requests a new asset (asynchronously), and on completion, triggers a relayout cycle.
     ///
     private func updateImage(in textContainer: NSTextContainer?) {
-
-        self.image = delegate!.mediaAttachmentPlaceholderImageFor(attachment: self)
+        if mustDisplayPlaceholder {
+            displayPlaceholder()
+        }
 
         guard let url = url else {
             return
@@ -358,6 +359,19 @@ private extension MediaAttachment {
 
             self?.isFetchingImage = false
         })
+    }
+
+    /// Indicates if the Placeholder must be displayed, or we should preserve the `.image` attribute
+    /// the way it is.
+    ///
+    private var mustDisplayPlaceholder: Bool {
+        return url != nil
+    }
+
+    /// Refreshes the Attachment's Image with the Placeholder provided by the delegate.
+    ///
+    private func displayPlaceholder() {
+        image = delegate!.mediaAttachmentPlaceholderImageFor(attachment: self)
     }
 
     /// Invalidates the Layout in the specified TextContainer.

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -32,7 +32,7 @@ open class MediaAttachment: NSTextAttachment {
 
     /// Identifier used to match this attachment with a custom UIView subclass
     ///
-    open var identifier = String()
+    private(set) open var identifier = String()
     
     /// Attachment URL
     ///

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -127,8 +127,6 @@ open class MediaAttachment: NSTextAttachment {
     /// Required Initializer
     ///
     override required public init(data contentData: Data?, ofType uti: String?) {
-        identifier = ""
-
         super.init(data: contentData, ofType: uti)
     }
 

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -334,14 +334,11 @@ private extension MediaAttachment {
     /// Requests a new asset (asynchronously), and on completion, triggers a relayout cycle.
     ///
     private func updateImage(in textContainer: NSTextContainer?) {
-        if mustDisplayPlaceholder {
-            displayPlaceholder()
-        }
-
         guard let url = url else {
             return
         }
 
+        image = delegate!.mediaAttachmentPlaceholderImageFor(attachment: self)
         isFetchingImage = true
         retryCount += 1
 
@@ -359,19 +356,6 @@ private extension MediaAttachment {
 
             self?.isFetchingImage = false
         })
-    }
-
-    /// Indicates if the Placeholder must be displayed, or we should preserve the `.image` attribute
-    /// the way it is.
-    ///
-    private var mustDisplayPlaceholder: Bool {
-        return url != nil
-    }
-
-    /// Refreshes the Attachment's Image with the Placeholder provided by the delegate.
-    ///
-    private func displayPlaceholder() {
-        image = delegate!.mediaAttachmentPlaceholderImageFor(attachment: self)
     }
 
     /// Invalidates the Layout in the specified TextContainer.


### PR DESCRIPTION
### Details:
In this PR we're:

- Preserving the UIImage scale upon un-archival
- Not overriding a MediaAttachment's **image** with a placeholder, unless we've got an actual URL to request.

Fixes #722

### To test:
1. Launch the editor with sample content.
2. Copy all the sample content.
3. Go to the empty editor.
4. Paste the copied sample content.

Verify that the pasted images do load.
