### PR TITLE
Makes paragraph spacing customizable.

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/BlockquoteFormatter.swift
@@ -22,6 +22,7 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
 
     func apply(to attributes: [String : Any], andStore representation: HTMLRepresentation?) -> [String: Any] {
         let newParagraphStyle = ParagraphStyle()
+        
         if let paragraphStyle = attributes[NSParagraphStyleAttributeName] as? NSParagraphStyle {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -419,7 +419,7 @@ extension AttributedStringParser {
 }
 
 
-// MARK: - Paragraph Nodes: Alloc'ation
+// MARK: - Paragraph Nodes: Allocation
 //
 private extension AttributedStringParser {
 
@@ -616,7 +616,7 @@ private extension AttributedStringParser {
 }
 
 
-// MARK: - Style Nodes: Alloc'ation
+// MARK: - Style Nodes: Allocation
 //
 private extension AttributedStringParser {
 

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -17,7 +17,8 @@ class AttributedStringSerializer {
 
     private lazy var defaultAttributes: [String: Any] = {
         let defaultFont = UIFont(descriptor: self.defaultFontDescriptor, size: self.defaultFontDescriptor.pointSize)
-        return [NSFontAttributeName: defaultFont]
+        return [NSFontAttributeName: defaultFont,
+                NSParagraphStyleAttributeName: ParagraphStyle.default]
     }()
 
 

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -67,7 +67,7 @@ private extension LayoutManager {
                 let lineCharacters = textStorage.attributedSubstring(from: lineRange).string
                 let lineEndsParagraph = lineCharacters.isEndOfParagraph(before: lineCharacters.endIndex)
                 let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: blockquoteIndent, lineEndsParagraph: lineEndsParagraph)
-                
+
                 self.drawBlockquote(in: blockquoteRect.integral, with: context)
             }
         }
@@ -255,11 +255,11 @@ private extension LayoutManager {
         let markerText = NSAttributedString(string: markerPlain, attributes: markerAttributes)
 
         var yOffset = CGFloat(0)
-        
+
         if location > 0 {
             yOffset += style.paragraphSpacingBefore
         }
-        
+
         let markerRect = rect.offsetBy(dx: 0, dy: yOffset)
         markerText.draw(in: markerRect)
     }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -67,18 +67,20 @@ private extension LayoutManager {
                 let lineCharacters = textStorage.attributedSubstring(from: lineRange).string
                 let lineEndsParagraph = lineCharacters.isEndOfParagraph(before: lineCharacters.endIndex)
                 let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: blockquoteIndent, lineEndsParagraph: lineEndsParagraph)
-
+                
                 self.drawBlockquote(in: blockquoteRect.integral, with: context)
             }
         }
 
         // Draw: Extra Line Fragment
-        guard extraLineFragmentRect != .zero, let typingAttributes = extraLineFragmentTypingAttributes?() else {
-            return
+        guard extraLineFragmentRect.height != 0,
+            let typingAttributes = extraLineFragmentTypingAttributes?() else {
+                return
         }
 
-        guard let paragraphStyle = typingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle, !paragraphStyle.blockquotes.isEmpty else {
-            return
+        guard let paragraphStyle = typingAttributes[NSParagraphStyleAttributeName] as? ParagraphStyle,
+            !paragraphStyle.blockquotes.isEmpty else {
+                return
         }
 
         let extraIndent = paragraphStyle.blockquoteIndent
@@ -100,6 +102,7 @@ private extension LayoutManager {
     ///
     private func blockquoteRect(origin: CGPoint, lineRect: CGRect, blockquoteIndent: CGFloat, lineEndsParagraph: Bool) -> CGRect {
         var blockquoteRect = lineRect.offsetBy(dx: origin.x, dy: origin.y)
+        
         guard blockquoteIndent != 0 else {
             return blockquoteRect
         }
@@ -115,7 +118,6 @@ private extension LayoutManager {
 
         return blockquoteRect
     }
-
 
     /// Draws a single Blockquote Line Fragment, in the specified Rectangle, using a given Graphics Context.
     ///
@@ -252,12 +254,12 @@ private extension LayoutManager {
         let markerPlain = list.style.markerText(forItemNumber: number)
         let markerText = NSAttributedString(string: markerPlain, attributes: markerAttributes)
 
-        var yOffset = -style.paragraphSpacingBefore
-
-        if let font = markerAttributes[NSFontAttributeName] as? UIFont {
-            yOffset += (rect.height - font.lineHeight)
+        var yOffset = CGFloat(0)
+        
+        if location > 0 {
+            yOffset += style.paragraphSpacingBefore
         }
-
+        
         let markerRect = rect.offsetBy(dx: 0, dy: yOffset)
         markerText.draw(in: markerRect)
     }

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -102,14 +102,12 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         headIndent = 0
         firstLineHeadIndent = 0
         tailIndent = 0
-        paragraphSpacing = 0
-        paragraphSpacingBefore = 0
 
         baseHeadIndent = paragrahStyle.baseHeadIndent
         baseFirstLineHeadIndent = paragrahStyle.baseFirstLineHeadIndent
         baseTailIndent = paragrahStyle.baseTailIndent
-        baseParagraphSpacing = paragrahStyle.baseParagraphSpacing
-        baseParagraphSpacingBefore = paragrahStyle.baseParagraphSpacingBefore
+        paragraphSpacing = paragrahStyle.paragraphSpacing
+        paragraphSpacingBefore = paragrahStyle.paragraphSpacingBefore
 
         properties = paragrahStyle.properties
     }
@@ -154,30 +152,6 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         return min(((CGFloat(self.blockquotes.count)) + (self.headerLevel == 0 ? 0.0 : 1.0)), 1.0) * Metrics.paragraphSpacing
     }
 
-    open override var paragraphSpacing: CGFloat {
-        get {
-            let extra = calculateExtraParagraphSpacing()
-
-            return baseParagraphSpacing + extra
-        }
-
-        set {
-            baseParagraphSpacing = newValue
-        }
-    }
-
-    open override var paragraphSpacingBefore: CGFloat {
-        get {
-            let extra = calculateExtraParagraphSpacing()
-
-            return baseParagraphSpacingBefore + extra
-        }
-
-        set {
-            baseParagraphSpacingBefore = newValue
-        }
-    }
-
     /// The amount of indent for the blockquote of the paragraph if any.
     ///
     public var blockquoteIndent: CGFloat {
@@ -214,26 +188,42 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     var baseHeadIndent: CGFloat = 0
     var baseFirstLineHeadIndent: CGFloat = 0
     var baseTailIndent: CGFloat = 0
-    var baseParagraphSpacing: CGFloat = 0
-    var baseParagraphSpacingBefore: CGFloat = 0
-
-    open override class var `default`: NSParagraphStyle {
+    
+    var textListParagraphSpacing = CGFloat(0)
+    var textListParagraphSpacingBefore = CGFloat(0)
+    
+    // MARK: - Defaults
+    
+    private static var cachedDefault: ParagraphStyle = {
         let style = ParagraphStyle()
-
+        
         var tabStops = [NSTextTab]()
-
+        
         for intervalNumber in (1 ..< Metrics.tabStepCount) {
             let location = intervalNumber * Metrics.tabStepInterval
             let textTab = NSTextTab(textAlignment: .natural, location: CGFloat(location), options: [:])
-
+            
             tabStops.append(textTab)
         }
-
+        
         style.tabStops = tabStops
-
+        style.lineSpacing = 8
+        style.paragraphSpacing = 8
+        style.paragraphSpacingBefore = 8
+        
         return style
+    }()
+    
+    static func setDefault(_ newDefault: ParagraphStyle) {
+        cachedDefault = newDefault
+    }
+    
+    open override class var `default`: ParagraphStyle {
+        return ParagraphStyle.cachedDefault
     }
 
+    // MARK: - Equatable
+    
     open override func isEqual(_ object: Any?) -> Bool {
         guard let otherParagraph = object as? ParagraphStyle else {
             return false


### PR DESCRIPTION
### Description:

Fixes #547 

Paragraph spacing is now customizable per-app.  It's also nicer by default.

### Screenies:

<img width="383" alt="screen shot 2017-10-17 at 3 05 57 pm" src="https://user-images.githubusercontent.com/1836005/31733717-e5868892-b412-11e7-9a7c-ca3627cf092e.png">

### Testing:

**Test 1:**

Launch the editor with content and make sure it looks about right.

**Test 2:**

Launch an empty editor and start creating paragraphs, lists, block quotes.  Also use ENTER + SHIFT to create new lines in the same paragraph.

Make sure the spacing looks nicer than before and that it's consistent.

### Known issues:

Each list item is a different paragraph, so the spacing for lists is a bit off.  This will be handled in an upcoming PR.