### PR TITLE
Improves spacing support for lists.

### DIFF
--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -292,6 +292,7 @@ private extension LayoutManager {
     private func markerParagraphStyle(indent: CGFloat) -> NSParagraphStyle {
         let tabStop = NSTextTab(textAlignment: .right, location: indent, options: [:])
         let paragraphStyle = NSMutableParagraphStyle()
+        
         paragraphStyle.tabStops = [tabStop]
 
         return paragraphStyle

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -95,8 +95,9 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
     override open func setParagraphStyle(_ baseParagraphStyle: NSParagraphStyle) {
         
+        super.setParagraphStyle(baseParagraphStyle)
+        
         guard let paragraphStyle = baseParagraphStyle as? ParagraphStyle else {
-            super.setParagraphStyle(baseParagraphStyle)
             return
         }
     

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -111,6 +111,9 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         baseFirstLineHeadIndent = paragraphStyle.baseFirstLineHeadIndent
         baseTailIndent = paragraphStyle.baseTailIndent
         
+        blockquoteParagraphSpacing = paragraphStyle.blockquoteParagraphSpacing
+        blockquoteParagraphSpacingBefore = paragraphStyle.blockquoteParagraphSpacingBefore
+        
         regularParagraphSpacing = paragraphStyle.regularParagraphSpacing
         regularParagraphSpacingBefore = paragraphStyle.regularParagraphSpacingBefore
         
@@ -199,12 +202,17 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     var textListParagraphSpacing = CGFloat(0)
     var textListParagraphSpacingBefore = CGFloat(0)
     
+    var blockquoteParagraphSpacing = CGFloat(0)
+    var blockquoteParagraphSpacingBefore = CGFloat(0)
+    
     open override var paragraphSpacing: CGFloat {
         get {
-            if lists.count == 0 {
-                return regularParagraphSpacing
-            } else {
+            if blockquotes.count > 0 {
+                return blockquoteParagraphSpacing
+            } else if lists.count > 0 {
                 return textListParagraphSpacing
+            } else {
+                return regularParagraphSpacing
             }
         }
         
@@ -215,10 +223,12 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     
     open override var paragraphSpacingBefore: CGFloat {
         get {
-            if lists.count == 0 {
-                return regularParagraphSpacingBefore
-            } else {
+            if blockquotes.count > 0 {
+                return blockquoteParagraphSpacingBefore
+            } else if lists.count > 0 {
                 return textListParagraphSpacingBefore
+            } else {
+                return regularParagraphSpacingBefore
             }
         }
         
@@ -243,9 +253,10 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         
         style.tabStops = tabStops
         style.lineSpacing = 8
+        style.blockquoteParagraphSpacing = 8
+        style.blockquoteParagraphSpacingBefore = 8
         style.regularParagraphSpacing = 8
         style.regularParagraphSpacingBefore = 8
-        
         style.textListParagraphSpacing = 0
         style.textListParagraphSpacingBefore = 0
         

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -93,23 +93,29 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         aCoder.encode(headerLevel, forKey: EncodingKeys.headerLevel.rawValue)
     }
 
-    override open func setParagraphStyle(_ obj: NSParagraphStyle) {
-        super.setParagraphStyle(obj)
-        guard let paragrahStyle = obj as? ParagraphStyle else {
+    override open func setParagraphStyle(_ baseParagraphStyle: NSParagraphStyle) {
+        
+        guard let paragraphStyle = baseParagraphStyle as? ParagraphStyle else {
+            super.setParagraphStyle(baseParagraphStyle)
             return
         }
-
-        headIndent = 0
-        firstLineHeadIndent = 0
-        tailIndent = 0
-
-        baseHeadIndent = paragrahStyle.baseHeadIndent
-        baseFirstLineHeadIndent = paragrahStyle.baseFirstLineHeadIndent
-        baseTailIndent = paragrahStyle.baseTailIndent
-        paragraphSpacing = paragrahStyle.paragraphSpacing
-        paragraphSpacingBefore = paragrahStyle.paragraphSpacingBefore
-
-        properties = paragrahStyle.properties
+    
+        // IMPORTANT: It's important to keep the implementation of this method custom for our ParagraphStyle class.
+        // The parent call tries to copy the properties that this class turned into calculated properties.
+        
+        // IMPORTANT 2: It's important to copy lists, blockquotes, etc before the other properties, since their values are
+        // calculated and sometimes based in these.
+        properties = paragraphStyle.properties
+        
+        baseHeadIndent = paragraphStyle.baseHeadIndent
+        baseFirstLineHeadIndent = paragraphStyle.baseFirstLineHeadIndent
+        baseTailIndent = paragraphStyle.baseTailIndent
+        
+        regularParagraphSpacing = paragraphStyle.regularParagraphSpacing
+        regularParagraphSpacingBefore = paragraphStyle.regularParagraphSpacingBefore
+        
+        textListParagraphSpacing = paragraphStyle.textListParagraphSpacing
+        textListParagraphSpacingBefore = paragraphStyle.textListParagraphSpacingBefore
     }
 
     open override var headIndent: CGFloat {
@@ -132,7 +138,8 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         }
 
         set {
-            baseFirstLineHeadIndent = newValue
+            // We're basically ignoring this by setting it on the parent.
+            super.firstLineHeadIndent = newValue
         }
     }
 
@@ -144,12 +151,9 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         }
 
         set {
-            baseTailIndent = newValue
+            // We're basically ignoring this by setting it on the parent.
+            super.tailIndent = newValue
         }
-    }
-
-    private func calculateExtraParagraphSpacing() -> CGFloat {         
-        return min(((CGFloat(self.blockquotes.count)) + (self.headerLevel == 0 ? 0.0 : 1.0)), 1.0) * Metrics.paragraphSpacing
     }
 
     /// The amount of indent for the blockquote of the paragraph if any.
@@ -189,8 +193,39 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     var baseFirstLineHeadIndent: CGFloat = 0
     var baseTailIndent: CGFloat = 0
     
+    var regularParagraphSpacing = CGFloat(0)
+    var regularParagraphSpacingBefore = CGFloat(0)
+    
     var textListParagraphSpacing = CGFloat(0)
     var textListParagraphSpacingBefore = CGFloat(0)
+    
+    open override var paragraphSpacing: CGFloat {
+        get {
+            if lists.count == 0 {
+                return regularParagraphSpacing
+            } else {
+                return textListParagraphSpacing
+            }
+        }
+        
+        set {
+            super.paragraphSpacing = newValue
+        }
+    }
+    
+    open override var paragraphSpacingBefore: CGFloat {
+        get {
+            if lists.count == 0 {
+                return regularParagraphSpacingBefore
+            } else {
+                return textListParagraphSpacingBefore
+            }
+        }
+        
+        set {
+            super.paragraphSpacingBefore = newValue
+        }
+    }
     
     // MARK: - Defaults
     
@@ -208,8 +243,11 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         
         style.tabStops = tabStops
         style.lineSpacing = 8
-        style.paragraphSpacing = 8
-        style.paragraphSpacingBefore = 8
+        style.regularParagraphSpacing = 8
+        style.regularParagraphSpacingBefore = 8
+        
+        style.textListParagraphSpacing = 0
+        style.textListParagraphSpacingBefore = 0
         
         return style
     }()

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -268,7 +268,6 @@ open class TextStorage: NSTextStorage {
         endEditing()
     }
 
-
     // MARK: - Styles: Toggling
 
     @discardableResult

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1341,7 +1341,7 @@ private extension EditorDemoController
 extension EditorDemoController {
 
     struct Constants {
-        static let defaultContentFont   = UIFont.systemFont(ofSize: 16)
+        static let defaultContentFont   = UIFont.systemFont(ofSize: 14)
         static let defaultHtmlFont      = UIFont.systemFont(ofSize: 24)
         static let defaultMissingImage  = Gridicon.iconOfType(.image)
         static let formatBarIconSize    = CGSize(width: 20.0, height: 20.0)


### PR DESCRIPTION
### Description:

Fixes #778.

Provides better spacing customization for lists.

### Sample Screenshots:

<img width="385" alt="screen shot 2017-10-19 at 9 35 54 am" src="https://user-images.githubusercontent.com/1836005/31771257-cc1c0d74-b4b1-11e7-9cc4-6c8697d1428b.png">

### Known issues:

While not perfect (the spacing between the beginning / end of lists and other paragraphs is off) this is the best approximation we can offer without going into a much greater effort.

### Testing:

1. Launch the empty editor
2. Start writing several paragraphs.
3. Start a list.  Add items, delete them.
4. Double ENTER to finish the list... make sure the spacing is consistent.
5. Switch to HTML mode and back, and make sure the spacing is not broken.