### PR TITLE
Improves paragraph style customization support.

### DIFF
--- a/Aztec/Classes/Extensions/NSAttributedString+HTMLInitializer.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+HTMLInitializer.swift
@@ -3,12 +3,12 @@ import UIKit
 
 extension NSAttributedString {
 
-    convenience init(withHTML html: String, usingDefaultFontDescriptor descriptor: UIFontDescriptor) {
+    convenience init(withHTML html: String, defaultAttributes: [String: Any]) {
 
         let htmlParser = HTMLParser()
         let rootNode = htmlParser.parse(html)
 
-        let serializer = AttributedStringSerializer(usingDefaultFontDescriptor: descriptor)
+        let serializer = AttributedStringSerializer(defaultAttributes: defaultAttributes)
         let attributedString = serializer.serialize(rootNode)
 
         self.init(attributedString: attributedString)

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -5,21 +5,13 @@ import UIKit
 ///
 class AttributedStringSerializer {
 
-    /// The default font descriptor that will be used as a base for conversions.
-    /// 
-    let defaultFontDescriptor: UIFontDescriptor
+    private let defaultAttributes: [String: Any]
 
     // MARK: - Initializers
 
-    required init(usingDefaultFontDescriptor defaultFontDescriptor: UIFontDescriptor) {
-        self.defaultFontDescriptor = defaultFontDescriptor
+    required init(defaultAttributes: [String: Any]) {
+        self.defaultAttributes = defaultAttributes
     }
-
-    private lazy var defaultAttributes: [String: Any] = {
-        let defaultFont = UIFont(descriptor: self.defaultFontDescriptor, size: self.defaultFontDescriptor.pointSize)
-        return [NSFontAttributeName: defaultFont,
-                NSParagraphStyleAttributeName: ParagraphStyle.default]
-    }()
 
 
     // MARK: - Conversion

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -1,13 +1,12 @@
 import Foundation
 import UIKit
 
-
 // MARK: - ParagraphStyle
 //
 open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
     // MARK: - CustomReflectable
-
+    
     public var customMirror: Mirror {
         get {
             return Mirror(self, children: ["blockquotes": blockquotes,
@@ -193,18 +192,18 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         return CGFloat(depth) * Metrics.listTextIndentation
     }
 
-    var baseHeadIndent: CGFloat = 0
-    var baseFirstLineHeadIndent: CGFloat = 0
-    var baseTailIndent: CGFloat = 0
+    open var baseHeadIndent: CGFloat = 0
+    open var baseFirstLineHeadIndent: CGFloat = 0
+    open var baseTailIndent: CGFloat = 0
     
-    var regularParagraphSpacing = CGFloat(0)
-    var regularParagraphSpacingBefore = CGFloat(0)
+    open var regularParagraphSpacing = CGFloat(0)
+    open var regularParagraphSpacingBefore = CGFloat(0)
     
-    var textListParagraphSpacing = CGFloat(0)
-    var textListParagraphSpacingBefore = CGFloat(0)
+    open var textListParagraphSpacing = CGFloat(0)
+    open var textListParagraphSpacingBefore = CGFloat(0)
     
-    var blockquoteParagraphSpacing = CGFloat(0)
-    var blockquoteParagraphSpacingBefore = CGFloat(0)
+    open var blockquoteParagraphSpacing = CGFloat(0)
+    open var blockquoteParagraphSpacingBefore = CGFloat(0)
     
     open override var paragraphSpacing: CGFloat {
         get {
@@ -240,7 +239,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     
     // MARK: - Defaults
     
-    private static var cachedDefault: ParagraphStyle = {
+    open override class var `default`: ParagraphStyle {
         let style = ParagraphStyle()
         
         var tabStops = [NSTextTab]()
@@ -262,14 +261,6 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         style.textListParagraphSpacingBefore = 0
         
         return style
-    }()
-    
-    static func setDefault(_ newDefault: ParagraphStyle) {
-        cachedDefault = newDefault
-    }
-    
-    open override class var `default`: ParagraphStyle {
-        return ParagraphStyle.cachedDefault
     }
 
     // MARK: - Equatable

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -341,11 +341,11 @@ open class TextStorage: NSTextStorage {
 
     }
 
-    func setHTML(_ html: String, withDefaultFontDescriptor defaultFontDescriptor: UIFontDescriptor) {
+    func setHTML(_ html: String, defaultAttributes: [String: Any]) {
 
         let originalLength = textStore.length
 
-        textStore = NSMutableAttributedString(withHTML: html, usingDefaultFontDescriptor: defaultFontDescriptor)
+        textStore = NSMutableAttributedString(withHTML: html, defaultAttributes: defaultAttributes)
 
         textStore.enumerateAttachmentsOfType(ImageAttachment.self) { [weak self] (attachment, _, _) in
             attachment.delegate = self

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -143,10 +143,16 @@ open class TextView: UITextView {
 
     var maximumListIndentationLevels = 7
 
-    // MARK: - Properties: GUI Defaults
+    // MARK: - Properties: UI Defaults
 
-    let defaultFont: UIFont
+    open let defaultFont: UIFont
+    open let defaultParagraphStyle: ParagraphStyle
     var defaultMissingImage: UIImage
+    
+    fileprivate var defaultAttributes: [String: Any] {
+        return [NSFontAttributeName: defaultFont,
+                NSParagraphStyleAttributeName: defaultParagraphStyle]
+    }
 
     // MARK: - Properties: Processors
 
@@ -191,7 +197,7 @@ open class TextView: UITextView {
         let string = textStorage.string
         
         guard !string.isEndOfParagraph(before: string.endIndex) else {
-            return [NSParagraphStyleAttributeName: ParagraphStyle.default]
+            return defaultAttributes
         }
         
         let lastLocation = max(string.characters.count - 1, 0)
@@ -202,9 +208,13 @@ open class TextView: UITextView {
 
     // MARK: - Init & deinit
 
-    public init(defaultFont: UIFont, defaultMissingImage: UIImage) {
+    public init(
+        defaultFont: UIFont,
+        defaultParagraphStyle: ParagraphStyle = ParagraphStyle.default,
+        defaultMissingImage: UIImage) {
         
         self.defaultFont = defaultFont
+        self.defaultParagraphStyle = defaultParagraphStyle
         self.defaultMissingImage = defaultMissingImage
 
         let storage = TextStorage()
@@ -222,7 +232,9 @@ open class TextView: UITextView {
     required public init?(coder aDecoder: NSCoder) {
 
         defaultFont = UIFont.systemFont(ofSize: 14)
+        defaultParagraphStyle = ParagraphStyle.default
         defaultMissingImage = Assets.imageIcon
+        
         super.init(coder: aDecoder)
         commonInit()
     }
@@ -232,7 +244,7 @@ open class TextView: UITextView {
         storage.attachmentsDelegate = self
         font = defaultFont
         linkTextAttributes = [NSUnderlineStyleAttributeName: NSNumber(value:NSUnderlineStyle.styleSingle.rawValue), NSForegroundColorAttributeName: self.tintColor]
-        typingAttributes[NSParagraphStyleAttributeName] = ParagraphStyle.default
+        typingAttributes = defaultAttributes
         setupMenuController()
         setupAttachmentTouchDetection()
         setupLayoutManager()
@@ -533,7 +545,7 @@ open class TextView: UITextView {
         //
         font = defaultFont
         
-        storage.setHTML(processedHTML, withDefaultFontDescriptor: font!.fontDescriptor)
+        storage.setHTML(processedHTML, defaultAttributes: defaultAttributes)
 
         if storage.length > 0 && selectedRange.location < storage.length {
             typingAttributes = storage.attributes(at: selectedRange.location, effectiveRange: nil)
@@ -810,13 +822,6 @@ open class TextView: UITextView {
         let line = LineAttachment()
         replace(at: range, with: line)
     }
-
-    fileprivate lazy var defaultAttributes: [String: Any] = {
-        return [
-            NSFontAttributeName: self.defaultFont,
-            NSParagraphStyleAttributeName: ParagraphStyle.default
-        ]
-    }()
 
     private lazy var paragraphFormatters: [AttributeFormatter] = [
         BlockquoteFormatter(),

--- a/AztecTests/Extensions/NSAttributedStringHTMLInitializerTests.swift
+++ b/AztecTests/Extensions/NSAttributedStringHTMLInitializerTests.swift
@@ -13,6 +13,9 @@ class NSAttributedStringHTMLInitializerTests: XCTestCase {
 
         let html = "<script>(adsbygoogle = window.adsbygoogle || []).push({});</script>"
 
-        XCTAssertNoThrow(NSAttributedString(withHTML: html, usingDefaultFontDescriptor: defaultFontDescriptor))
+        let defaultAttributes = [NSFontAttributeName: UIFont.systemFont(ofSize: 14),
+                                 NSParagraphStyleAttributeName: ParagraphStyle.default]
+        
+        XCTAssertNoThrow(NSAttributedString(withHTML: html, defaultAttributes: defaultAttributes))
     }
 }

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringSerializerTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringSerializerTests.swift
@@ -158,8 +158,10 @@ class AttributedStringSerializerTests: XCTestCase {
 extension AttributedStringSerializerTests {
 
     func attributedString(from node: Node) -> NSAttributedString {
-        let descriptor = UIFont.systemFont(ofSize: 14).fontDescriptor
-        let serializer = AttributedStringSerializer(usingDefaultFontDescriptor: descriptor)
+        let defaultAttributes = [NSFontAttributeName: UIFont.systemFont(ofSize: 14),
+                                 NSParagraphStyleAttributeName: ParagraphStyle.default]
+        
+        let serializer = AttributedStringSerializer(defaultAttributes: defaultAttributes)
 
         return serializer.serialize(node)
     }

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -161,7 +161,10 @@ class TextStorageTests: XCTestCase {
         let finalHTML = "<p>\(updatedHTML)</p>"
 
         // Setup
-        storage.setHTML(initialHTML, withDefaultFontDescriptor: UIFont.systemFont(ofSize: 10).fontDescriptor)
+        let defaultAttributes = [NSFontAttributeName: UIFont.systemFont(ofSize: 14),
+                                 NSParagraphStyleAttributeName: ParagraphStyle.default]
+        
+        storage.setHTML(initialHTML, defaultAttributes: defaultAttributes)
 
         // Find the Attachment
         var theAttachment: HTMLAttachment!
@@ -373,7 +376,11 @@ class TextStorageTests: XCTestCase {
     func testDeleteAllSelectionWhenContentHasComments() {
         let commentString = "This is a comment"
         let html = "<!--\(commentString)-->"
-        storage.setHTML(html, withDefaultFontDescriptor: UIFont.systemFont(ofSize: 14).fontDescriptor)
+
+        let defaultAttributes = [NSFontAttributeName: UIFont.systemFont(ofSize: 14),
+                                 NSParagraphStyleAttributeName: ParagraphStyle.default]
+        
+        storage.setHTML(html, defaultAttributes: defaultAttributes)
         storage.replaceCharacters(in: NSRange(location: 0, length: 1), with: NSAttributedString(string: ""))
 
         let resultHTML = storage.getHTML()

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -24,7 +24,9 @@ class TextViewTests: XCTestCase {
     // MARK: - TextView construction
 
     func createEmptyTextView() -> TextView {
-        let richTextView = Aztec.TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: UIImage())
+        let richTextView = Aztec.TextView(
+            defaultFont: UIFont.systemFont(ofSize: 14),
+            defaultMissingImage: UIImage())
         richTextView.textAttachmentDelegate = attachmentDelegate
         richTextView.registerAttachmentImageProvider(attachmentDelegate)
         return richTextView

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -16,7 +16,15 @@ class EditorDemoController: UIViewController {
     }()
 
     fileprivate(set) lazy var richTextView: Aztec.TextView = {
-        let textView = Aztec.TextView(defaultFont: Constants.defaultContentFont, defaultMissingImage: Constants.defaultMissingImage)
+
+        let paragraphStyle = Aztec.ParagraphStyle.default
+        
+        // This is where you'd normally customize paragraphStyle's values.
+        
+        let textView = Aztec.TextView(
+            defaultFont: Constants.defaultContentFont,
+            defaultParagraphStyle: paragraphStyle,
+            defaultMissingImage: Constants.defaultMissingImage)
 
         textView.inputProcessor =
             PipelineProcessor([CaptionShortcodePreProcessor(),


### PR DESCRIPTION
### Description:

While we had some support for paragraph customization, this PR make it fully accessible for third party apps.

### Changes:

- No longer uses `PragraphStyle.default` as Aztec's default.
- Relies on values provided to the view on initialization for defaults.  This ensures we can have different defaults for different `TextView`s within the same App.
- Several properties in `ParagraphStyle` are now open, so that Apps can customize them.
- `ParagraphStyle.default` is no longer cached, and is instead instantiated every time.  This is because `ParagraphStyle` is mutable and having a single cached instance means it'll be probably modified by the App.
- `ParagraphStyle.default` can no longer be set.
- Simplifies `AttributedStringSerializer`'s initializer considerably.

### Testing:

1. Go to [this line](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/783/files#diff-e7e4649f5f7465f68641a838cc55412fR22) in the code.
2. Modify [any of the values](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/783/files#diff-bdaaffdf124d77d47d70df9fafaa3bbcR195) now marked as open in `ParagraphStyle`.
3. Run the app and make sure the paragraph style is properly working as the default.
