### PR TITLE
Fix keyboard auto-correction crash issue(if the view is inherited from TextView)

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -233,6 +233,13 @@ open class TextStorage: NSTextStorage {
 
         return textStore.attributes(at: location, effectiveRange: range)
     }
+
+    private func replaceTextStoreString(_ range: NSRange, with string: String) {
+        let utf16String = textStoreString.utf16
+        let startIndex = utf16String.index(utf16String.startIndex, offsetBy: range.location)
+        let endIndex = utf16String.index(startIndex, offsetBy: range.length)
+        textStoreString.replaceSubrange(startIndex..<endIndex, with: string)
+    }
  
     override open func replaceCharacters(in range: NSRange, with str: String) {
 
@@ -241,10 +248,7 @@ open class TextStorage: NSTextStorage {
         detectAttachmentRemoved(in: range)
         textStore.replaceCharacters(in: range, with: str)
 
-        let utf16String = textStoreString.utf16
-        let startIndex = utf16String.index(utf16String.startIndex, offsetBy: range.location)
-        let endIndex = utf16String.index(startIndex, offsetBy: range.length)
-        textStoreString.replaceSubrange(startIndex..<endIndex, with: str)
+        replaceTextStoreString(range, with: str)
 
         edited(.editedCharacters, range: range, changeInLength: str.characters.count - range.length)
         
@@ -260,10 +264,7 @@ open class TextStorage: NSTextStorage {
         detectAttachmentRemoved(in: range)
         textStore.replaceCharacters(in: range, with: preprocessedString)
 
-        let utf16String = textStoreString.utf16
-        let startIndex = utf16String.index(utf16String.startIndex, offsetBy: range.location)
-        let endIndex = utf16String.index(startIndex, offsetBy: range.length)
-        textStoreString.replaceSubrange(startIndex..<endIndex, with: attrString.string)
+        replaceTextStoreString(range, with: attrString.string)
 
         edited([.editedAttributes, .editedCharacters], range: range, changeInLength: attrString.length - range.length)
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -83,6 +83,8 @@ open class TextStorage: NSTextStorage {
 
     fileprivate var textStore = NSMutableAttributedString(string: "", attributes: nil)
 
+    fileprivate var textStoreString = ""
+
 
     // MARK: - Delegates
 
@@ -99,7 +101,7 @@ open class TextStorage: NSTextStorage {
     // MARK: - Calculated Properties
 
     override open var string: String {
-        return textStore.string
+        return textStoreString
     }
 
     open var mediaAttachments: [MediaAttachment] {
@@ -239,6 +241,11 @@ open class TextStorage: NSTextStorage {
         detectAttachmentRemoved(in: range)
         textStore.replaceCharacters(in: range, with: str)
 
+        let utf16String = textStoreString.utf16
+        let startIndex = utf16String.index(utf16String.startIndex, offsetBy: range.location)
+        let endIndex = utf16String.index(startIndex, offsetBy: range.length)
+        textStoreString.replaceSubrange(startIndex..<endIndex, with: str)
+
         edited(.editedCharacters, range: range, changeInLength: str.characters.count - range.length)
         
         endEditing()
@@ -252,6 +259,12 @@ open class TextStorage: NSTextStorage {
 
         detectAttachmentRemoved(in: range)
         textStore.replaceCharacters(in: range, with: preprocessedString)
+
+        let utf16String = textStoreString.utf16
+        let startIndex = utf16String.index(utf16String.startIndex, offsetBy: range.location)
+        let endIndex = utf16String.index(startIndex, offsetBy: range.length)
+        textStoreString.replaceSubrange(startIndex..<endIndex, with: attrString.string)
+
         edited([.editedAttributes, .editedCharacters], range: range, changeInLength: attrString.length - range.length)
 
         endEditing()
@@ -359,6 +372,8 @@ open class TextStorage: NSTextStorage {
         textStore.enumerateAttachmentsOfType(HTMLAttachment.self) { [weak self] (attachment, _, _) in
             attachment.delegate = self
         }
+
+        textStoreString = textStore.string
 
         edited([.editedAttributes, .editedCharacters], range: NSRange(location: 0, length: originalLength), changeInLength: textStore.length - originalLength)
     }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -83,8 +83,6 @@ open class TextStorage: NSTextStorage {
 
     fileprivate var textStore = NSMutableAttributedString(string: "", attributes: nil)
 
-    fileprivate var textStoreString = ""
-
 
     // MARK: - Delegates
 
@@ -101,7 +99,7 @@ open class TextStorage: NSTextStorage {
     // MARK: - Calculated Properties
 
     override open var string: String {
-        return textStoreString
+        return textStore.string
     }
 
     open var mediaAttachments: [MediaAttachment] {
@@ -241,11 +239,6 @@ open class TextStorage: NSTextStorage {
         detectAttachmentRemoved(in: range)
         textStore.replaceCharacters(in: range, with: str)
 
-        let utf16String = textStoreString.utf16
-        let startIndex = utf16String.index(utf16String.startIndex, offsetBy: range.location)
-        let endIndex = utf16String.index(startIndex, offsetBy: range.length)
-        textStoreString.replaceSubrange(startIndex..<endIndex, with: str)
-
         edited(.editedCharacters, range: range, changeInLength: str.characters.count - range.length)
         
         endEditing()
@@ -259,12 +252,6 @@ open class TextStorage: NSTextStorage {
 
         detectAttachmentRemoved(in: range)
         textStore.replaceCharacters(in: range, with: preprocessedString)
-
-        let utf16String = textStoreString.utf16
-        let startIndex = utf16String.index(utf16String.startIndex, offsetBy: range.location)
-        let endIndex = utf16String.index(startIndex, offsetBy: range.length)
-        textStoreString.replaceSubrange(startIndex..<endIndex, with: attrString.string)
-
         edited([.editedAttributes, .editedCharacters], range: range, changeInLength: attrString.length - range.length)
 
         endEditing()
@@ -372,8 +359,6 @@ open class TextStorage: NSTextStorage {
         textStore.enumerateAttachmentsOfType(HTMLAttachment.self) { [weak self] (attachment, _, _) in
             attachment.delegate = self
         }
-
-        textStoreString = textStore.string
 
         edited([.editedAttributes, .editedCharacters], range: NSRange(location: 0, length: originalLength), changeInLength: textStore.length - originalLength)
     }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -233,13 +233,6 @@ open class TextStorage: NSTextStorage {
 
         return textStore.attributes(at: location, effectiveRange: range)
     }
-
-    private func replaceTextStoreString(_ range: NSRange, with string: String) {
-        let utf16String = textStoreString.utf16
-        let startIndex = utf16String.index(utf16String.startIndex, offsetBy: range.location)
-        let endIndex = utf16String.index(startIndex, offsetBy: range.length)
-        textStoreString.replaceSubrange(startIndex..<endIndex, with: string)
-    }
  
     override open func replaceCharacters(in range: NSRange, with str: String) {
 
@@ -248,7 +241,10 @@ open class TextStorage: NSTextStorage {
         detectAttachmentRemoved(in: range)
         textStore.replaceCharacters(in: range, with: str)
 
-        replaceTextStoreString(range, with: str)
+        let utf16String = textStoreString.utf16
+        let startIndex = utf16String.index(utf16String.startIndex, offsetBy: range.location)
+        let endIndex = utf16String.index(startIndex, offsetBy: range.length)
+        textStoreString.replaceSubrange(startIndex..<endIndex, with: str)
 
         edited(.editedCharacters, range: range, changeInLength: str.characters.count - range.length)
         
@@ -264,7 +260,10 @@ open class TextStorage: NSTextStorage {
         detectAttachmentRemoved(in: range)
         textStore.replaceCharacters(in: range, with: preprocessedString)
 
-        replaceTextStoreString(range, with: attrString.string)
+        let utf16String = textStoreString.utf16
+        let startIndex = utf16String.index(utf16String.startIndex, offsetBy: range.location)
+        let endIndex = utf16String.index(startIndex, offsetBy: range.length)
+        textStoreString.replaceSubrange(startIndex..<endIndex, with: attrString.string)
 
         edited([.editedAttributes, .editedCharacters], range: range, changeInLength: attrString.length - range.length)
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1013,7 +1013,7 @@ open class TextView: UITextView {
             // From here on, it's just calling the same method in `super`.
             //
             let selector = #selector(TextView.replaceRangeWithTextWithoutClosingTyping(_:replacementText:))
-            let imp = class_getMethodImplementation(self.superclass, selector)
+            let imp = class_getMethodImplementation(TextView.superclass(), selector)
             
             typealias ClosureType = @convention(c) (AnyObject, Selector, UITextRange, String) -> Void
             let superMethod: ClosureType = unsafeBitCast(imp, to: ClosureType.self)


### PR DESCRIPTION
Fixes keyboard auto-correction crash issue(if the view is inherited from TextView)

To test(recur):
1. Open Aztec.xcworkspace
2. Create new view inherited from TextView
3. Replace TextView to the view just created
4. Type any english words
6. Press space button in keyboard
7. If not crash, press again.

Device: iPhone 7, OS version: iOS 11