### PR TITLE
Remove attributes on attachments

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/ImageFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/ImageFormatter.swift
@@ -63,7 +63,7 @@ class ImageFormatter: StandardAttributeFormatter {
                 attributeValue = ImageAttachment(identifier: UUID().uuidString)
             }
         }
-
+        // Comment: Sergio Estevao (2017-10-30) - We are not passing the representation because it's all save inside the extraAttributes property of the attachment.
         return super.apply(to: attributes, andStore: nil)
     }
 }

--- a/Aztec/Classes/Formatters/Implementations/ImageFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/ImageFormatter.swift
@@ -64,6 +64,6 @@ class ImageFormatter: StandardAttributeFormatter {
             }
         }
 
-        return super.apply(to: attributes, andStore: representation)
+        return super.apply(to: attributes, andStore: nil)
     }
 }

--- a/Aztec/Classes/Formatters/Implementations/VideoFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/VideoFormatter.swift
@@ -52,7 +52,7 @@ class VideoFormatter: StandardAttributeFormatter {
             //
             assert(representation == nil)
         }
-
+        // Comment: Sergio Estevao (2017-10-30) - We are not passing the representation because it's all save inside the extraAttributes property of the attachment.
         return super.apply(to: attributes, andStore: nil)
     }
 }

--- a/Aztec/Classes/Formatters/Implementations/VideoFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/VideoFormatter.swift
@@ -53,6 +53,6 @@ class VideoFormatter: StandardAttributeFormatter {
             assert(representation == nil)
         }
 
-        return super.apply(to: attributes, andStore: representation)
+        return super.apply(to: attributes, andStore: nil)
     }
 }

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1776,4 +1776,30 @@ class TextViewTests: XCTestCase {
         XCTAssert(textView.getHTML(prettyPrint: false) == expected)
     }
 
+    /// This test verifies that attributes on media attachment are being removed properly.
+    /// of text that never had H1 style, to begin with!.
+    ///
+    func testAttributesOnMediaAttachmentsAreRemoved() {
+        let textView = createTextView(withHTML: "<img src=\"http:\\\\placeholder\" data-wp_upload_id=\"ABCDE\" >")
+
+        guard let attachment = textView.storage.mediaAttachments.first else {
+            XCTFail("There must be an attachment")
+            return
+        }
+
+        guard let attributedValue = attachment.extraAttributes["data-wp_upload_id"] else {
+            XCTFail("There must be an attribute with the name data-wp_upload_i")
+            return
+        }
+
+        XCTAssertEqual(attributedValue, "ABCDE")
+
+        // Remove attribute
+        attachment.extraAttributes["data-wp_upload_id"] = nil
+
+        let html = textView.getHTML()
+
+        XCTAssertEqual(html, "<p><img src=\"http:\\\\placeholder\"></p>" )
+    }
+
 }

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1567,7 +1567,7 @@ class TextViewTests: XCTestCase {
         let html = "<img src=\"image.jpg\" class=\"alignnone\" alt=\"Alt\" title=\"Title\">"
         let textView = createTextView(withHTML: html)
 
-        XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone\" alt=\"Alt\" title=\"Title\"></p>")
+        XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone\" title=\"Title\" alt=\"Alt\"></p>")
 
         guard let attachment = textView.storage.mediaAttachments.first as? ImageAttachment else {
             XCTFail("An video attachment should be present")
@@ -1579,7 +1579,7 @@ class TextViewTests: XCTestCase {
         attachment.extraAttributes["alt"] = "Changed Alt"
         attachment.extraAttributes["class"] = "wp-image-169"
 
-        XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone wp-image-169\" alt=\"Changed Alt\" title=\"Title\"></p>")
+        XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone wp-image-169\" title=\"Title\" alt=\"Changed Alt\"></p>")
     }
 
 
@@ -1609,7 +1609,7 @@ class TextViewTests: XCTestCase {
     /// This test verifies that img class attributes are not duplicated
     ///
     func testParseImageDoesntDuplicateExtraAttributes() {
-        let html = "<img src=\"image.jpg\" class=\"wp-image-test\" alt=\"Alt\" title=\"Title\">"
+        let html = "<img src=\"image.jpg\" class=\"wp-image-test\" title=\"Title\" alt=\"Alt\">"
         let textView = createTextView(withHTML: html)
         let generatedHTML = textView.getHTML()
 
@@ -1780,7 +1780,7 @@ class TextViewTests: XCTestCase {
     /// of text that never had H1 style, to begin with!.
     ///
     func testAttributesOnMediaAttachmentsAreRemoved() {
-        let textView = createTextView(withHTML: "<img src=\"http:\\\\placeholder\" data-wp_upload_id=\"ABCDE\" >")
+        let textView = createTextView(withHTML: "<img src=\"http://placeholder\" data-wp_upload_id=\"ABCDE\" >")
 
         guard let attachment = textView.storage.mediaAttachments.first else {
             XCTFail("There must be an attachment")
@@ -1799,7 +1799,7 @@ class TextViewTests: XCTestCase {
 
         let html = textView.getHTML()
 
-        XCTAssertEqual(html, "<p><img src=\"http:\\\\placeholder\"></p>" )
+        XCTAssertEqual(html, "<p><img src=\"http://placeholder\"></p>" )
     }
 
 }


### PR DESCRIPTION
This PR is an attempt to allow removal of attributes on Media attachments.

For example if we have this html:

 `<img src="http://wordpress.com/logo.png" data-wp="ID">`

And then I want to remove the `data-wp` using the `extraAttributes` property on `MediaAttachment` I was unable to do it because it was being stored on the HTMLRepresentation of that element and saved back to the HTML.

The test method added on the PR show this clearer.

The change I'm proposing is to not save the original HTMLRepresentation for Media Attachments because they already have a mechanism to save all the attributes in them.

I'm open to other suggestion to solve this issue.



