### PR TITLE
Issue/8045 aztec image links

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
@@ -101,6 +101,10 @@ extension Attribute {
         case inlineCss([CSSAttribute])
 
         // MARK: - Initializers
+		
+		init(withString string: String) {
+			self = .string(string)
+		}
 
         init(withCSSString cssString: String) {
 

--- a/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Attribute.swift
@@ -101,10 +101,10 @@ extension Attribute {
         case inlineCss([CSSAttribute])
 
         // MARK: - Initializers
-		
-		init(withString string: String) {
-			self = .string(string)
-		}
+
+        init(withString string: String) {
+            self = .string(string)
+        }
 
         init(withCSSString cssString: String) {
 

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -716,7 +716,7 @@ private extension AttributedStringParser {
             element = ElementNode(type: .a)
         }
 
-        element.updateAttribute(named: "href", value: .string(urlString))
+        element.updateAttribute(named: HTMLLinkAttribute.Href.rawValue, value: .string(urlString))
 
         return element
     }
@@ -901,7 +901,7 @@ private extension AttributedStringParser {
 
         if let linkText = attachment.linkURL?.absoluteString {
             let hrefValue = Attribute.Value(withString: linkText)
-            let hrefAttribute = Attribute(name: "href", value: hrefValue)
+            let hrefAttribute = Attribute(name: HTMLLinkAttribute.Href.rawValue, value: hrefValue)
             let linkElement = ElementNode(type: .a, attributes: [hrefAttribute], children: [element])
 
             return linkElement

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -898,17 +898,17 @@ private extension AttributedStringParser {
             }
             element.updateAttribute(named: key, value: .string(finalValue))
         }
-		
+
 		// if the image attachment has a linkURL set,
 		// wrap the .img element node in a .a node
-		if let linkText = attachment.linkURL?.absoluteString {
-			let hrefValue = Attribute.Value(withString: linkText)
-			let hrefAttribute = Attribute(name: "href", value: hrefValue)
-			let linkElement = ElementNode(type: .a, attributes: [hrefAttribute], children: [element])
-			
-			return linkElement
-		}
-		
+        if let linkText = attachment.linkURL?.absoluteString {
+            let hrefValue = Attribute.Value(withString: linkText)
+            let hrefAttribute = Attribute(name: "href", value: hrefValue)
+            let linkElement = ElementNode(type: .a, attributes: [hrefAttribute], children: [element])
+
+            return linkElement
+        }
+
         return element
     }
 

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -902,7 +902,7 @@ private extension AttributedStringParser {
 		// if the image attachment has a linkURL set,
 		// wrap the .img element node in a .a node
 		if let linkText = attachment.linkURL?.absoluteString {
-			let hrefValue = Attribute.Value(withCSSString: linkText)
+			let hrefValue = Attribute.Value(withString: linkText)
 			let hrefAttribute = Attribute(name: "href", value: hrefValue)
 			let linkElement = ElementNode(type: .a, attributes: [hrefAttribute], children: [element])
 			

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -899,8 +899,6 @@ private extension AttributedStringParser {
             element.updateAttribute(named: key, value: .string(finalValue))
         }
 
-		// if the image attachment has a linkURL set,
-		// wrap the .img element node in a .a node
         if let linkText = attachment.linkURL?.absoluteString {
             let hrefValue = Attribute.Value(withString: linkText)
             let hrefAttribute = Attribute(name: "href", value: hrefValue)

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -898,7 +898,17 @@ private extension AttributedStringParser {
             }
             element.updateAttribute(named: key, value: .string(finalValue))
         }
-
+		
+		// if the image attachment has a linkURL set,
+		// wrap the .img element node in a .a node
+		if let linkText = attachment.linkURL?.absoluteString {
+			let hrefValue = Attribute.Value(withCSSString: linkText)
+			let hrefAttribute = Attribute(name: "href", value: hrefValue)
+			let linkElement = ElementNode(type: .a, attributes: [hrefAttribute], children: [element])
+			
+			return linkElement
+		}
+		
         return element
     }
 

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -101,38 +101,37 @@ class AttributedStringSerializer {
         guard element.isSupportedByEditor() else {
             return serialize(unsupported: element, inheriting: attributes)
         }
-		
-		// if the element is of type '.a' and contains a '.img'
-		if element.isNodeType(.a) && element.children.count == 1 {
-			if let imgElement = element.children.first as? ElementNode, imgElement.isNodeType(.img) {
-				
-				// get the URL
-				if let linkText = element.stringValueForAttribute(named: "href"), let urlString = imgElement.stringValueForAttribute(named: "src") {
-					if let url = URL(string: urlString) {
-						// create an ImageAttachment and assign the linkURL
-						let attachment = ImageAttachment(identifier: UUID().uuidString, url: url)
-						attachment.linkURL = URL(string: linkText)
-						
-						// return the attachment
-						let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
-						return NSAttributedString(attachment: attachment, attributes: imgAttributes)
-					}
-				}
-			}
-		}
-		
-		
-		// else process as usual
-		let childAttributes = self.attributes(for: element, inheriting: attributes)
-		let content = NSMutableAttributedString()
-		
+
+        let childAttributes = self.attributes(for: element, inheriting: attributes)
+        let content = NSMutableAttributedString()
+
         if let representation = implicitRepresentation(for: element, inheriting: childAttributes) {
             content.append(representation)
         } else {
-            for child in element.children {
-                let childContent = serialize(child, inheriting: childAttributes)
-                content.append(childContent)
-            }
+			
+			// if the element is of type '.a' and contains a '.img'
+			if element.isNodeType(.a) && element.children.count == 1 {
+				if let imgElement = element.children.first as? ElementNode, imgElement.isNodeType(.img) {
+					
+					// get the URL
+					if let linkText = element.stringValueForAttribute(named: "href"), let urlString = imgElement.stringValueForAttribute(named: "src") {
+						if let url = URL(string: urlString) {
+							// create an ImageAttachment and assign the linkURL
+							let attachment = ImageAttachment(identifier: UUID().uuidString, url: url)
+							attachment.linkURL = URL(string: linkText)
+							
+							let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
+							let attributedString = NSAttributedString(attachment: attachment, attributes: imgAttributes)
+							content.append(attributedString)
+						}
+					}
+				}
+			} else {
+				for child in element.children {
+					let childContent = serialize(child, inheriting: childAttributes)
+					content.append(childContent)
+				}
+			}
         }
 
         guard !element.needsClosingParagraphSeparator() else {

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -114,12 +114,12 @@ class AttributedStringSerializer {
                     
                     // get the link URL and assign it to the image attachment
                     if let linkText = element.stringValueForAttribute(named: "href") {
-                            let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
-                            if let attachment = imgAttributes[NSAttachmentAttributeName] as? ImageAttachment {
-                                attachment.linkURL = URL(string: linkText)
-                            }
-                            let attributedString = NSAttributedString(string: String(UnicodeScalar(NSAttachmentCharacter)!), attributes: imgAttributes)
+                        let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
+                        if let attachment = imgAttributes[NSAttachmentAttributeName] as? ImageAttachment,
+                            let attributedString = implicitRepresentation(for: imgElement, inheriting: imgAttributes) {
+                            attachment.linkURL = URL(string: linkText)
                             content.append(attributedString)
+                        }
                     }
                 }
             } else {

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -108,18 +108,9 @@ class AttributedStringSerializer {
         if let representation = implicitRepresentation(for: element, inheriting: childAttributes) {
             content.append(representation)
         } else {
-            if let imgElement = linkedImageElement(for: element) {
-                let linkText = element.stringValueForAttribute(named: "href") ?? ""
-                let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
-                let attachment = imgAttributes[NSAttachmentAttributeName] as! ImageAttachment
-                let attributedString = implicitRepresentation(for: imgElement, inheriting: imgAttributes)!
-                attachment.linkURL = URL(string: linkText)
-                content.append(attributedString)
-            } else {
-                for child in element.children {
-                    let childContent = serialize(child, inheriting: childAttributes)
-                    content.append(childContent)
-                }
+            for child in element.children {
+                let childContent = serialize(child, inheriting: childAttributes)
+                content.append(childContent)
             }
         }
 
@@ -128,24 +119,6 @@ class AttributedStringSerializer {
         }
 
         return content
-    }
-    
-    /// Checks if the specified node is of type '.a' with one child '.img' node.
-    /// If true, returns the '.img' node.
-    ///
-    /// - Parameters:
-    ///     - element: the node to get the information from
-    ///
-    /// - Returns: the child '.img' node if there is one
-    ///
-    fileprivate func linkedImageElement(for element: ElementNode) -> ElementNode? {
-        guard element.isNodeType(.a) && element.children.count == 1,
-            let imgElement = element.children.first as? ElementNode,
-            imgElement.isNodeType(.img) else {
-                return nil
-        }
-
-        return imgElement
     }
 
     /// Serializes an unsupported element.
@@ -405,6 +378,15 @@ private extension AttributedStringSerializer {
         guard let elementType = element.standardName else {
             return nil
         }
+        
+        if let imgElement = linkedImageElement(for: element) {
+            let linkText = element.stringValueForAttribute(named: "href") ?? ""
+            let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
+            let attachment = imgAttributes[NSAttachmentAttributeName] as! ImageAttachment
+            let representation = implicitRepresentation(for: imgElement, inheriting: imgAttributes)!
+            attachment.linkURL = URL(string: linkText)
+            return representation
+        }
 
         return implicitRepresentation(for: elementType, inheriting: attributes)
     }
@@ -428,6 +410,24 @@ private extension AttributedStringSerializer {
         default:
             return nil
         }
+    }
+    
+    /// Checks if the specified node is of type '.a' with one child '.img' node.
+    /// If true, returns the '.img' node.
+    ///
+    /// - Parameters:
+    ///     - element: the node to get the information from
+    ///
+    /// - Returns: the child '.img' node if there is one
+    ///
+    private func linkedImageElement(for element: ElementNode) -> ElementNode? {
+        guard element.isNodeType(.a) && element.children.count == 1,
+            let imgElement = element.children.first as? ElementNode,
+            imgElement.isNodeType(.img) else {
+                return nil
+        }
+        
+        return imgElement
     }
 
 }

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -91,7 +91,7 @@ class AttributedStringSerializer {
     /// Serializes an `ElementNode`.
     ///
     /// - Parameters:
-    ///     - node: the node to convert to `NSAttributedString`.
+    ///     - element: the node to convert to `NSAttributedString`.
     ///     - attributes: the inherited attributes from parent nodes.
     ///
     /// - Returns: the converted node as an `NSAttributedString`.
@@ -110,7 +110,6 @@ class AttributedStringSerializer {
         } else {
             if let imgElement = linkedImageElement(for: element) {
                 let linkText = element.stringValueForAttribute(named: "href") ?? ""
-                // retrieve the image attachment, and assign the link URL to it
                 let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
                 if let attachment = imgAttributes[NSAttachmentAttributeName] as? ImageAttachment,
                     let attributedString = implicitRepresentation(for: imgElement, inheriting: imgAttributes) {
@@ -136,7 +135,7 @@ class AttributedStringSerializer {
     /// If true, returns the '.img' node.
     ///
     /// - Parameters:
-    ///     - node: the node to get the information from.
+    ///     - element: the node to get the information from
     ///
     /// - Returns: the child '.img' node if there is one
     ///
@@ -151,6 +150,12 @@ class AttributedStringSerializer {
     }
 
     /// Serializes an unsupported element.
+    ///
+    /// - Parameters:
+    ///     - element: the node to convert to `NSAttributedString`.
+    ///     - attributes: the inherited attributes from parent nodes.
+    ///
+    /// - Returns: the converted node as an `NSAttributedString`.
     ///
     fileprivate func serialize(unsupported element: ElementNode, inheriting attributes: [String:Any]) -> NSAttributedString {
         let serializer = HTMLSerializer()
@@ -258,7 +263,8 @@ private extension AttributedStringSerializer {
     /// attributes.
     ///
     /// - Parameters:
-    ///     - node: the node to get the information from.
+    ///     - element: the node to get the information from.
+    ///     - inheritedAttributes: the inherited attributes from parent nodes.
     ///
     /// - Returns: an attributes dictionary, for use in an NSAttributedString.
     ///
@@ -290,7 +296,7 @@ private extension AttributedStringSerializer {
     /// including the inherited attributes.
     ///
     /// - Parameters:
-    ///     - htmlAttributes: the HTML attributes to get calculate the string attributes from.
+    ///     - htmlAttributes: the HTML attributes to calculate the string attributes from.
     ///     - inheritedAttributes: the attributes that will be inherited.
     ///
     /// - Returns: an attributes dictionary, for use in an NSAttributedString.
@@ -309,7 +315,7 @@ private extension AttributedStringSerializer {
     /// including inherited attributes.
     ///
     /// - Parameters:
-    ///     - attributeRepresentation: the element representation.
+    ///     - attribute: the attribute to calculate the string attributes from.
     ///     - inheritedAttributes: the attributes that will be inherited.
     ///
     /// - Returns: an attributes dictionary, for use in an NSAttributedString.
@@ -333,7 +339,7 @@ private extension AttributedStringSerializer {
     /// Stores the specified HTMLElementRepresentation in a collection of NSAttributedString Attributes.
     ///
     /// - Parameters:
-    ///     - elementRepresentation: Instance of HTMLElementRepresentation to be stored.
+    ///     - representation: Instance of HTMLElementRepresentation to be stored.
     ///     - attributes: Attributes where we should store the HTML Representation.
     ///
     /// - Returns: A collection of NSAttributedString Attributes, including the specified HTMLElementRepresentation.

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -24,7 +24,13 @@ class AttributedStringSerializer {
     /// - Returns: the requested attributed string.
     ///
     func serialize(_ node: Node) -> NSAttributedString {
-        return serialize(node, inheriting: defaultAttributes)
+		
+		let serialized = serialize(node, inheriting: defaultAttributes)
+		
+		// print("SERIALIZED: \(serialized)")
+		
+        // return serialize(node, inheriting: defaultAttributes)
+		return serialized
     }
 
     /// Recursive serialization method.  Useful for maintaining the font style of parent nodes.
@@ -97,14 +103,46 @@ class AttributedStringSerializer {
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
     fileprivate func serialize(_ element: ElementNode, inheriting attributes: [String: Any]) -> NSAttributedString {
+		
+		// print("serialize ElementNode")
 
         guard element.isSupportedByEditor() else {
             return serialize(unsupported: element, inheriting: attributes)
         }
-
-        let childAttributes = self.attributes(for: element, inheriting: attributes)
-        let content = NSMutableAttributedString()
-
+		
+		
+		if element.isNodeType(.a) && element.children.count == 1 {
+			if let imgElement = element.children.first as? ElementNode, imgElement.isNodeType(.img) {
+				print("FOUND AN IMAGE WRAPPED IN A LINK")
+				
+				// found an image inside of a <a href></a>
+				
+				
+				
+				// get the URL
+				if let linkText = element.stringValueForAttribute(named: "href") {
+					print("link: \(linkText)")
+					
+					// create an ImageAttachment and assign the linkURL
+					let attachment = ImageAttachment()
+					attachment.linkURL = URL.init(string: linkText)
+					
+					
+					// TODO: try something with this?
+					// NSAttributedString(string: String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
+					
+					
+					// return the attachment
+					// using what attributes?
+					let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
+					return NSAttributedString(attachment: attachment, attributes: imgAttributes)
+				}
+			}
+		}
+		
+		let childAttributes = self.attributes(for: element, inheriting: attributes)
+		let content = NSMutableAttributedString()
+		
         if let representation = implicitRepresentation(for: element, inheriting: childAttributes) {
             content.append(representation)
         } else {
@@ -385,9 +423,21 @@ private extension AttributedStringSerializer {
     /// - Returns: the requested implicit representation, if one exists, or `nil`.
     ///
     private func implicitRepresentation(for elementType: StandardElementType, inheriting attributes: [String:Any]) -> NSAttributedString? {
-
         switch elementType {
-        case .hr, .img, .video:
+		case .img:
+			print("implicitRepresentation - attributes: \(attributes)")
+			
+			/*
+			// remove the NSLink attribute?
+			var mutableAttributes = attributes
+			mutableAttributes["NSLink"] = nil
+			return NSAttributedString(string: String(UnicodeScalar(NSAttachmentCharacter)!), attributes: mutableAttributes)
+			*/
+
+			
+			// TODO:
+			return NSAttributedString(string: String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
+        case .hr, .video:
             return NSAttributedString(string: String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
         case .br:
             return NSAttributedString(.lineSeparator, attributes: attributes)

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -108,30 +108,26 @@ class AttributedStringSerializer {
         if let representation = implicitRepresentation(for: element, inheriting: childAttributes) {
             content.append(representation)
         } else {
-			
-			// if the element is of type '.a' and contains a '.img'
-			if element.isNodeType(.a) && element.children.count == 1 {
-				if let imgElement = element.children.first as? ElementNode, imgElement.isNodeType(.img) {
-					
-					// get the URL
-					if let linkText = element.stringValueForAttribute(named: "href"), let urlString = imgElement.stringValueForAttribute(named: "src") {
-						if let url = URL(string: urlString) {
-							// create an ImageAttachment and assign the linkURL
-							let attachment = ImageAttachment(identifier: UUID().uuidString, url: url)
-							attachment.linkURL = URL(string: linkText)
-							
-							let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
-							let attributedString = NSAttributedString(attachment: attachment, attributes: imgAttributes)
-							content.append(attributedString)
-						}
-					}
-				}
-			} else {
-				for child in element.children {
-					let childContent = serialize(child, inheriting: childAttributes)
-					content.append(childContent)
-				}
-			}
+            // if the element is of type '.a' and contains a '.img'
+            if element.isNodeType(.a) && element.children.count == 1 {
+                if let imgElement = element.children.first as? ElementNode, imgElement.isNodeType(.img) {
+                    
+                    // get the link URL and assign it to the image attachment
+                    if let linkText = element.stringValueForAttribute(named: "href") {
+                            let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
+                            if let attachment = imgAttributes[NSAttachmentAttributeName] as? ImageAttachment {
+                                attachment.linkURL = URL(string: linkText)
+                            }
+                            let attributedString = NSAttributedString(string: String(UnicodeScalar(NSAttachmentCharacter)!), attributes: imgAttributes)
+                            content.append(attributedString)
+                    }
+                }
+            } else {
+                for child in element.children {
+                    let childContent = serialize(child, inheriting: childAttributes)
+                    content.append(childContent)
+                }
+            }
         }
 
         guard !element.needsClosingParagraphSeparator() else {

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -111,7 +111,7 @@ class AttributedStringSerializer {
             // if the element is of type '.a' and contains a '.img'
             if element.isNodeType(.a) && element.children.count == 1 {
                 if let imgElement = element.children.first as? ElementNode, imgElement.isNodeType(.img) {
-                    
+
                     // get the link URL and assign it to the image attachment
                     if let linkText = element.stringValueForAttribute(named: "href") {
                         let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -111,11 +111,10 @@ class AttributedStringSerializer {
             if let imgElement = linkedImageElement(for: element) {
                 let linkText = element.stringValueForAttribute(named: "href") ?? ""
                 let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
-                if let attachment = imgAttributes[NSAttachmentAttributeName] as? ImageAttachment,
-                    let attributedString = implicitRepresentation(for: imgElement, inheriting: imgAttributes) {
-                    attachment.linkURL = URL(string: linkText)
-                    content.append(attributedString)
-                }
+                let attachment = imgAttributes[NSAttachmentAttributeName] as! ImageAttachment
+                let attributedString = implicitRepresentation(for: imgElement, inheriting: imgAttributes)!
+                attachment.linkURL = URL(string: linkText)
+                content.append(attributedString)
             } else {
                 for child in element.children {
                     let childContent = serialize(child, inheriting: childAttributes)

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -380,12 +380,16 @@ private extension AttributedStringSerializer {
         }
         
         if let imgElement = linkedImageElement(for: element) {
-            let linkText = element.stringValueForAttribute(named: HTMLLinkAttribute.Href.rawValue) ?? ""
-            let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
+            var attributesWithoutLink = attributes
+            attributesWithoutLink[NSLinkAttributeName] = nil
+            attributesWithoutLink[LinkFormatter.htmlRepresentationKey] = nil
+
+            let imgAttributes = self.attributes(for: imgElement, inheriting: attributesWithoutLink)
             let attachment = imgAttributes[NSAttachmentAttributeName] as! ImageAttachment
-            let representation = implicitRepresentation(for: imgElement, inheriting: imgAttributes)!
+            let linkText = element.stringValueForAttribute(named: HTMLLinkAttribute.Href.rawValue) ?? ""
             attachment.linkURL = URL(string: linkText)
-            return representation
+            
+            return implicitRepresentation(for: imgElement, inheriting: imgAttributes)!
         }
 
         return implicitRepresentation(for: elementType, inheriting: attributes)

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -380,7 +380,7 @@ private extension AttributedStringSerializer {
         }
         
         if let imgElement = linkedImageElement(for: element) {
-            let linkText = element.stringValueForAttribute(named: "href") ?? ""
+            let linkText = element.stringValueForAttribute(named: HTMLLinkAttribute.Href.rawValue) ?? ""
             let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
             let attachment = imgAttributes[NSAttachmentAttributeName] as! ImageAttachment
             let representation = implicitRepresentation(for: imgElement, inheriting: imgAttributes)!

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -108,13 +108,8 @@ class AttributedStringSerializer {
         if let representation = implicitRepresentation(for: element, inheriting: childAttributes) {
             content.append(representation)
         } else {
-            // if the node is of type '.a' with one child of type '.img', retrieve the '.img' node
-            if let imgElement = linkedImageElementFor(element) {
-                // get the link URL text
-                var linkText = ""
-                if let hrefText = element.stringValueForAttribute(named: "href") {
-                    linkText = hrefText
-                }
+            if let imgElement = linkedImageElement(for: element) {
+                let linkText = element.stringValueForAttribute(named: "href") ?? ""
                 // retrieve the image attachment, and assign the link URL to it
                 let imgAttributes = self.attributes(for: imgElement, inheriting: attributes)
                 if let attachment = imgAttributes[NSAttachmentAttributeName] as? ImageAttachment,
@@ -145,13 +140,11 @@ class AttributedStringSerializer {
     ///
     /// - Returns: the child '.img' node if there is one
     ///
-    fileprivate func linkedImageElementFor(_ element: ElementNode) -> ElementNode? {
-        guard element.isNodeType(.a) && element.children.count == 1 else {
-            return nil
-        }
-
-        guard let imgElement = element.children.first as? ElementNode, imgElement.isNodeType(.img) else {
-            return nil
+    fileprivate func linkedImageElement(for element: ElementNode) -> ElementNode? {
+        guard element.isNodeType(.a) && element.children.count == 1,
+            let imgElement = element.children.first as? ElementNode,
+            imgElement.isNodeType(.img) else {
+                return nil
         }
 
         return imgElement

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -5,10 +5,10 @@ import UIKit
 /// Custom text attachment.
 ///
 open class ImageAttachment: MediaAttachment {
-	
-	/// Attachment Link URL
-	///
-	open var linkURL: URL?
+
+    /// Attachment Link URL
+    ///
+    open var linkURL: URL?
 
     /// Attachment Alignment
     ///
@@ -59,8 +59,8 @@ open class ImageAttachment: MediaAttachment {
                 self.size = size
             }
         }
-		
-		linkURL = aDecoder.decodeObject(forKey: EncodeKeys.linkURL.rawValue) as? URL
+
+        linkURL = aDecoder.decodeObject(forKey: EncodeKeys.linkURL.rawValue) as? URL
     }
 
     /// Required Initializer
@@ -76,15 +76,15 @@ open class ImageAttachment: MediaAttachment {
         super.encode(with: aCoder)
         aCoder.encode(alignment.rawValue, forKey: EncodeKeys.alignment.rawValue)
         aCoder.encode(size.rawValue, forKey: EncodeKeys.size.rawValue)
-		if let linkURL = self.linkURL {
-			aCoder.encode(linkURL, forKey: EncodeKeys.linkURL.rawValue)
-		}
+        if let linkURL = self.linkURL {
+            aCoder.encode(linkURL, forKey: EncodeKeys.linkURL.rawValue)
+        }
     }
 
     fileprivate enum EncodeKeys: String {
         case alignment
         case size
-		case linkURL
+        case linkURL
     }
 
 
@@ -140,7 +140,7 @@ extension ImageAttachment {
 
         clone.size = size
         clone.alignment = alignment
-		clone.linkURL = linkURL
+        clone.linkURL = linkURL
 
         return clone
     }

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -39,12 +39,6 @@ open class ImageAttachment: MediaAttachment {
     ///
     required public init(identifier: String, url: URL? = nil) {
         super.init(identifier: identifier, url: url)
-		
-		
-		
-		// by default use the URL of the image as its link
-		// NOPE: this is bad...
-		// self.linkURL = url
     }
 
 

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -5,6 +5,10 @@ import UIKit
 /// Custom text attachment.
 ///
 open class ImageAttachment: MediaAttachment {
+	
+	/// Attachment Link URL
+	///
+	open var linkURL: URL?
 
     /// Attachment Alignment
     ///
@@ -35,6 +39,12 @@ open class ImageAttachment: MediaAttachment {
     ///
     required public init(identifier: String, url: URL? = nil) {
         super.init(identifier: identifier, url: url)
+		
+		
+		
+		// by default use the URL of the image as its link
+		// NOPE: this is bad...
+		// self.linkURL = url
     }
 
 
@@ -55,6 +65,8 @@ open class ImageAttachment: MediaAttachment {
                 self.size = size
             }
         }
+		
+		linkURL = aDecoder.decodeObject(forKey: EncodeKeys.linkURL.rawValue) as? URL
     }
 
     /// Required Initializer
@@ -70,11 +82,15 @@ open class ImageAttachment: MediaAttachment {
         super.encode(with: aCoder)
         aCoder.encode(alignment.rawValue, forKey: EncodeKeys.alignment.rawValue)
         aCoder.encode(size.rawValue, forKey: EncodeKeys.size.rawValue)
+		if let linkURL = self.linkURL {
+			aCoder.encode(linkURL, forKey: EncodeKeys.linkURL.rawValue)
+		}
     }
 
     fileprivate enum EncodeKeys: String {
         case alignment
         case size
+		case linkURL
     }
 
 
@@ -130,6 +146,7 @@ extension ImageAttachment {
 
         clone.size = size
         clone.alignment = alignment
+		clone.linkURL = linkURL
 
         return clone
     }

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringSerializerTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringSerializerTests.swift
@@ -150,6 +150,20 @@ class AttributedStringSerializerTests: XCTestCase {
 
         XCTAssertEqual(outHtml, inHtml)
     }
+    
+    /// Verifies that a linked image is properly converted from HTML to attributed string and back to HTML.
+    ///
+    func testLinkedImageGetsProperlyEncodedAndDecoded() {
+        let inHtml = "<p><a href=\"https://wordpress.com\"><img src=\"https://s.w.org/about/images/wordpress-logo-notext-bg.png\"></a></p>"
+        
+        let inNode = HTMLParser().parse(inHtml)
+        let attrString = attributedString(from: inNode)
+        
+        let outNode = AttributedStringParser().parse(attrString)
+        let outHtml = HTMLSerializer().serialize(outNode)
+        
+        XCTAssertEqual(outHtml, inHtml)
+    }
 }
 
 

--- a/Example/Example/AttachmentDetailsViewController.storyboard
+++ b/Example/Example/AttachmentDetailsViewController.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13174"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -99,10 +100,35 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="Link URL" id="slN-cK-Z2o">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="wff-mK-IFy">
+                                        <rect key="frame" x="0.0" y="355.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="wff-mK-IFy" id="qBg-OX-o6B">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="fsr-eq-4v0">
+                                                    <rect key="frame" x="16" y="7" width="336" height="30"/>
+                                                    <nil key="textColor"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <textInputTraits key="textInputTraits" keyboardType="URL"/>
+                                                </textField>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="fsr-eq-4v0" firstAttribute="leading" secondItem="qBg-OX-o6B" secondAttribute="leadingMargin" constant="8" id="ISh-Dm-qik"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="fsr-eq-4v0" secondAttribute="trailing" constant="15" id="iNi-CO-VRX"/>
+                                                <constraint firstItem="fsr-eq-4v0" firstAttribute="centerY" secondItem="qBg-OX-o6B" secondAttribute="centerY" id="w9t-nE-OXg"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                             <tableViewSection headerTitle="Alt" id="mai-mB-SYg" userLabel="Alt">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="gvh-UL-4kA">
-                                        <rect key="frame" x="0.0" y="355.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="455.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="gvh-UL-4kA" id="kJp-I8-6JL">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -133,6 +159,7 @@
                     <connections>
                         <outlet property="alignmentSegmentedControl" destination="hM7-SO-P7P" id="PmN-Ow-kgM"/>
                         <outlet property="altTextField" destination="fBd-rD-kOx" id="mbm-a3-pyI"/>
+                        <outlet property="linkURLTextField" destination="fsr-eq-4v0" id="Qxl-b5-hw6"/>
                         <outlet property="sizeSegmentedControl" destination="qWp-hq-exU" id="4SD-YC-4G2"/>
                         <outlet property="sourceURLTextField" destination="6H9-eI-Wgd" id="tvl-R1-1GN"/>
                     </connections>

--- a/Example/Example/AttachmentDetailsViewController.swift
+++ b/Example/Example/AttachmentDetailsViewController.swift
@@ -11,7 +11,7 @@ class AttachmentDetailsViewController: UITableViewController
     @IBOutlet var altTextField: UITextField!
 
     var attachment: ImageAttachment?
-    var onUpdate: ((ImageAttachment.Alignment, ImageAttachment.Size, URL, URL?, String?) -> Void)?
+    var onUpdate: ((_ alignment: ImageAttachment.Alignment, _ size: ImageAttachment.Size, _ imageURL: URL, _ linkURL: URL?, _ altText: String?) -> Void)?
 
 
     override func viewDidLoad() {
@@ -70,10 +70,7 @@ class AttachmentDetailsViewController: UITableViewController
             return
         }
         let alt = altTextField.text
-        var linkURL: URL?
-        if let linkText = linkURLTextField.text {
-            linkURL = URL(string: linkText)
-        }
+        let linkURL = URL(string: linkURLTextField.text ?? "")
         onUpdate(alignment.toAttachmentAlignment(), size.toAttachmentSize(), url, linkURL, alt)
         dismiss(animated: true, completion: nil)
     }

--- a/Example/Example/AttachmentDetailsViewController.swift
+++ b/Example/Example/AttachmentDetailsViewController.swift
@@ -7,10 +7,11 @@ class AttachmentDetailsViewController: UITableViewController
     @IBOutlet var alignmentSegmentedControl: UISegmentedControl!
     @IBOutlet var sizeSegmentedControl: UISegmentedControl!
     @IBOutlet var sourceURLTextField: UITextField!
+	@IBOutlet var linkURLTextField: UITextField!
     @IBOutlet var altTextField: UITextField!
 
     var attachment: ImageAttachment?
-    var onUpdate: ((ImageAttachment.Alignment, ImageAttachment.Size, URL, String?) -> Void)?
+    var onUpdate: ((ImageAttachment.Alignment, ImageAttachment.Size, URL, URL?, String?) -> Void)?
 
 
     override func viewDidLoad() {
@@ -43,6 +44,8 @@ class AttachmentDetailsViewController: UITableViewController
         sizeSegmentedControl.selectedSegmentIndex = size.rawValue
 
         sourceURLTextField.text = attachment.url?.absoluteString
+		
+		linkURLTextField.text = attachment.linkURL?.absoluteString
 
         altTextField.text = attachment.extraAttributes["alt"]
     }
@@ -67,7 +70,11 @@ class AttachmentDetailsViewController: UITableViewController
             return
         }
         let alt = altTextField.text
-        onUpdate(alignment.toAttachmentAlignment(), size.toAttachmentSize(), url, alt)
+		var linkURL: URL?
+		if let linkText = linkURLTextField.text {
+			linkURL = URL.init(string: linkText)
+		}
+        onUpdate(alignment.toAttachmentAlignment(), size.toAttachmentSize(), url, linkURL, alt)
         dismiss(animated: true, completion: nil)
     }
 

--- a/Example/Example/AttachmentDetailsViewController.swift
+++ b/Example/Example/AttachmentDetailsViewController.swift
@@ -7,7 +7,7 @@ class AttachmentDetailsViewController: UITableViewController
     @IBOutlet var alignmentSegmentedControl: UISegmentedControl!
     @IBOutlet var sizeSegmentedControl: UISegmentedControl!
     @IBOutlet var sourceURLTextField: UITextField!
-	@IBOutlet var linkURLTextField: UITextField!
+    @IBOutlet var linkURLTextField: UITextField!
     @IBOutlet var altTextField: UITextField!
 
     var attachment: ImageAttachment?
@@ -44,8 +44,8 @@ class AttachmentDetailsViewController: UITableViewController
         sizeSegmentedControl.selectedSegmentIndex = size.rawValue
 
         sourceURLTextField.text = attachment.url?.absoluteString
-		
-		linkURLTextField.text = attachment.linkURL?.absoluteString
+
+        linkURLTextField.text = attachment.linkURL?.absoluteString
 
         altTextField.text = attachment.extraAttributes["alt"]
     }
@@ -70,10 +70,10 @@ class AttachmentDetailsViewController: UITableViewController
             return
         }
         let alt = altTextField.text
-		var linkURL: URL?
-		if let linkText = linkURLTextField.text {
-			linkURL = URL.init(string: linkText)
-		}
+        var linkURL: URL?
+        if let linkText = linkURLTextField.text {
+            linkURL = URL(string: linkText)
+        }
         onUpdate(alignment.toAttachmentAlignment(), size.toAttachmentSize(), url, linkURL, alt)
         dismiss(animated: true, completion: nil)
     }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1327,19 +1327,19 @@ private extension EditorDemoController
     func displayDetailsForAttachment(_ attachment: ImageAttachment, position:CGPoint) {
         let detailsViewController = AttachmentDetailsViewController.controller()
         detailsViewController.attachment = attachment
-		detailsViewController.onUpdate = { (alignment, size, url, linkURL, alt) in
-			self.richTextView.edit(attachment) { updated in
-				if let alt = alt {
-					updated.extraAttributes["alt"] = alt
-				}
-				
-				updated.alignment = alignment
-				updated.size = size
-				updated.linkURL = linkURL
-				
-				updated.updateURL(url)
-			}
-		}
+        detailsViewController.onUpdate = { (alignment, size, url, linkURL, alt) in
+            self.richTextView.edit(attachment) { updated in
+                if let alt = alt {
+                    updated.extraAttributes["alt"] = alt
+                }
+
+                updated.alignment = alignment
+                updated.size = size
+                updated.linkURL = linkURL
+
+                updated.updateURL(url)
+            }
+        }
 
         let navigationController = UINavigationController(rootViewController: detailsViewController)        
         present(navigationController, animated: true, completion: nil)

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1218,6 +1218,7 @@ private extension EditorDemoController
         let fileURL = saveToDisk(image: image)
         
         let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange, sourceURL: fileURL, placeHolderImage: image)
+        attachment.linkURL = fileURL
         let imageID = attachment.identifier
         let progress = Progress(parent: nil, userInfo: [MediaProgressKey.mediaID: imageID])
         progress.totalUnitCount = 100

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -157,6 +157,8 @@ class EditorDemoController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+		
+		self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .play, target: self, action: #selector(printAttributedText))
 
         edgesForExtendedLayout = UIRectEdge()
         navigationController?.navigationBar.isTranslucent = false
@@ -185,6 +187,34 @@ class EditorDemoController: UIViewController {
         MediaAttachment.defaultAppearance.progressHeight = 2.0
         MediaAttachment.defaultAppearance.overlayColor = UIColor(white: 0.5, alpha: 0.5)
     }
+	
+	func printAttributedText() {
+		
+		if let imageAttachment = self.richTextView.attributedText.attribute(NSAttachmentAttributeName, at: 0, effectiveRange: nil) as? ImageAttachment {
+			
+			if let linkText = imageAttachment.linkURL?.absoluteString {
+				print("link for image attachment: \(linkText)")
+			} else {
+				print("link for image attachment: [NO LINK URL]")
+			}
+		} else {
+			print("link for image attachment: [NO IMAGE ATTACHMENT]")
+		}
+
+		
+		if let richAttributedText = self.richTextView.attributedText {
+			print("rich text view attributedText: \(richAttributedText)")
+		}
+		
+		/*
+		if let htmlAttributedText = self.htmlTextView.attributedText {
+			print("html text view attributedText: \(htmlAttributedText)")
+		}
+		*/
+		
+		// same output:
+		// print("textStorage: \(self.richTextView.textStorage)")
+	}
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -1327,18 +1357,19 @@ private extension EditorDemoController
     func displayDetailsForAttachment(_ attachment: ImageAttachment, position:CGPoint) {
         let detailsViewController = AttachmentDetailsViewController.controller()
         detailsViewController.attachment = attachment
-        detailsViewController.onUpdate = { (alignment, size, url, alt) in
-            self.richTextView.edit(attachment) { updated in
-                if let alt = alt {
-                    updated.extraAttributes["alt"] = alt
-                }
-
-                updated.alignment = alignment
-                updated.size = size
-
-                updated.updateURL(url)
-            }
-        }
+		detailsViewController.onUpdate = { (alignment, size, url, linkURL, alt) in
+			self.richTextView.edit(attachment) { updated in
+				if let alt = alt {
+					updated.extraAttributes["alt"] = alt
+				}
+				
+				updated.alignment = alignment
+				updated.size = size
+				updated.linkURL = linkURL
+				
+				updated.updateURL(url)
+			}
+		}
 
         let navigationController = UINavigationController(rootViewController: detailsViewController)        
         present(navigationController, animated: true, completion: nil)

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -157,8 +157,6 @@ class EditorDemoController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-		
-		self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .play, target: self, action: #selector(printAttributedText))
 
         edgesForExtendedLayout = UIRectEdge()
         navigationController?.navigationBar.isTranslucent = false
@@ -187,34 +185,6 @@ class EditorDemoController: UIViewController {
         MediaAttachment.defaultAppearance.progressHeight = 2.0
         MediaAttachment.defaultAppearance.overlayColor = UIColor(white: 0.5, alpha: 0.5)
     }
-	
-	func printAttributedText() {
-		
-		if let imageAttachment = self.richTextView.attributedText.attribute(NSAttachmentAttributeName, at: 0, effectiveRange: nil) as? ImageAttachment {
-			
-			if let linkText = imageAttachment.linkURL?.absoluteString {
-				print("link for image attachment: \(linkText)")
-			} else {
-				print("link for image attachment: [NO LINK URL]")
-			}
-		} else {
-			print("link for image attachment: [NO IMAGE ATTACHMENT]")
-		}
-
-		
-		if let richAttributedText = self.richTextView.attributedText {
-			print("rich text view attributedText: \(richAttributedText)")
-		}
-		
-		/*
-		if let htmlAttributedText = self.htmlTextView.attributedText {
-			print("html text view attributedText: \(htmlAttributedText)")
-		}
-		*/
-		
-		// same output:
-		// print("textStorage: \(self.richTextView.textStorage)")
-	}
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)


### PR DESCRIPTION
This is the Aztec related work needed to implement [adding links to images in posts from its detail editor](https://github.com/wordpress-mobile/WordPress-iOS/issues/8045).

One small detail to note is that in the example app, the `linkURL` is automatically set to the same thing as the file URL after the image is added in EditorDemoController.

Doing it that way, rather than automatically setting it within ImageAttachment, leaves it up to the developer integrating AztecEditor into their app to decide whether or not they want to automatically link images to themselves.

To test:
1. run the example app and tap "Empty Editor Demo"
2. tap the text view to bring up the format bar
3. tap the "+" button in the lower left corner to add an image
4. once you've added the image, tap on it to show "Tap for options"
5. tap the image again, then tap "Media Details"
6. note that the link URL is shown (change it to something else if you want)
7. tap "Done"
8. bring up the format bar again and tap the `</>` button to show that the link URL is shown within the  HTML (with an `<a href></a>` containing the URL around the img tag)
9. if you want, edit the URL within the HTML
10. tap the `</>` button again to show that the HTML is properly converted back to an NSAttributedString... and that the image displays properly
11. bring up the image media details again, and observe that the link URL is still set (because it was set after converting back from HTML)