### PR TITLE
Issue/787 fix deselection of images

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1706,7 +1706,15 @@ extension TextView: TextStorageAttachmentsDelegate {
         }
 
         let locationInTextView = touch.location(in: textView)
-        return textView.attachmentAtPoint(locationInTextView) != nil
+        let isAttachmentInLocation = textView.attachmentAtPoint(locationInTextView) != nil
+        if !isAttachmentInLocation {
+            if let selectedAttachment = currentSelectedAttachment {
+                textView.textAttachmentDelegate?.textView(textView, deselected: selectedAttachment, atPosition: locationInTextView)
+            }
+            currentSelectedAttachment = nil
+        }
+        return isAttachmentInLocation
+
     }
 
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1062,15 +1062,19 @@ extension EditorDemoController: TextViewAttachmentDelegate {
         deselected(textAttachment: attachment, atPosition: position)
     }
 
+    fileprivate func resetMediaAttachmentOverlay(_ mediaAttachment: MediaAttachment) {
+        if mediaAttachment is ImageAttachment {
+            mediaAttachment.overlayImage = nil
+        }
+        mediaAttachment.message = nil
+    }
+
     func selected(textAttachment attachment: MediaAttachment, atPosition position: CGPoint) {
         if (currentSelectedAttachment == attachment) {
             displayActions(forAttachment: attachment, position: position)
         } else {
             if let selectedAttachment = currentSelectedAttachment {
-                selectedAttachment.message = nil
-                if selectedAttachment is ImageAttachment {
-                    selectedAttachment.overlayImage = nil
-                }
+                self.resetMediaAttachmentOverlay(selectedAttachment)
                 richTextView.refresh(selectedAttachment)
             }
 
@@ -1088,7 +1092,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
     func deselected(textAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
         currentSelectedAttachment = nil
         if let mediaAttachment = attachment as? MediaAttachment {
-            mediaAttachment.message = nil
+            self.resetMediaAttachmentOverlay(mediaAttachment)
             richTextView.refresh(mediaAttachment)
         }
     }
@@ -1289,7 +1293,10 @@ private extension EditorDemoController
         let alertController = UIAlertController(title: title, message:message, preferredStyle: .actionSheet)
         let dismissAction = UIAlertAction(title: NSLocalizedString("Dismiss", comment: "User action to dismiss media options."),
                                           style: .cancel,
-                                          handler: nil
+                                          handler: { (action) in
+                                            self.resetMediaAttachmentOverlay(attachment)
+                                            self.richTextView.refresh(attachment)
+        }
         )
         alertController.addAction(dismissAction)
 


### PR DESCRIPTION
Fixes #787 

To test:
 - Open the demo app
 - Select an image
 - Tap outside the image on text or empty space
 - Check that image is deselected correctly
 - Tap again on an image
 - Now tap on another image
 - Check if original image is deselected and new one is selected correctly
 - Tap on a image again
 - Tap on it again
 - select dismiss
 - check if image selection is dismissed correctly.
