### PR TITLE
Customizable Blockquote Style

### DIFF
--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -23,6 +23,10 @@ class LayoutManager: NSLayoutManager {
     ///
     var extraLineFragmentTypingAttributes: (() -> [String: Any])?
 
+    /// Blockquote's Left Border width
+    ///
+    var blockquoteBorderWidth: CGFloat = 2
+
 
     /// Draws the background, associated to a given Text Range
     ///
@@ -125,7 +129,7 @@ private extension LayoutManager {
         blockquoteBackgroundColor.setFill()
         context.fill(rect)
 
-        let borderRect = CGRect(origin: rect.origin, size: CGSize(width: 2, height: rect.height))
+        let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
         blockquoteBorderColor.setFill()
         context.fill(borderRect)
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -124,7 +124,7 @@ public protocol TextViewFormattingDelegate: class {
 //
 open class TextView: UITextView {
 
-    // MARK: - Properties: Attachments & Media
+    // MARK: - Aztec Delegates
 
     /// The media delegate takes care of providing remote media when requested by the `TextView`.
     /// If this is not set, all remove images will be left blank.
@@ -135,13 +135,15 @@ open class TextView: UITextView {
     ///
     fileprivate var textAttachmentImageProvider = [TextViewAttachmentImageProvider]()
 
-    // MARK: - Properties: Formatting
-
+    /// Formatting Delegate: to be used by the Edition's Format Bar.
+    ///
     open weak var formattingDelegate: TextViewFormattingDelegate?
+
 
     // MARK: - Properties: Text Lists
 
     var maximumListIndentationLevels = 7
+
 
     // MARK: - Properties: UI Defaults
 
@@ -154,6 +156,7 @@ open class TextView: UITextView {
                 NSParagraphStyleAttributeName: defaultParagraphStyle]
     }
 
+
     // MARK: - Properties: Processors
 
     /// This processor will be executed on any HTML you provide to the method `setHTML()` and
@@ -165,7 +168,8 @@ open class TextView: UITextView {
     ///
     public var outputProcessor: Processor?
 
-    // MARK: - Properties: Text Storage
+
+    // MARK: - TextKit Aztec Subclass'ess
 
     var storage: TextStorage {
         return textStorage as! TextStorage
@@ -204,6 +208,7 @@ open class TextView: UITextView {
         
         return textStorage.attributes(at: lastLocation, effectiveRange: nil)
     }
+
 
 
     // MARK: - Init & deinit
@@ -1126,9 +1131,6 @@ open class TextView: UITextView {
         toggle(formatter: formatter, atRange: range)
     }
 
-
-
-
     /// Removes the link, if any, at the specified range
     ///
     /// - Parameter range: range that contains the link to be removed.
@@ -1288,10 +1290,12 @@ open class TextView: UITextView {
     }
 
 
-    /// // Check if there is an attachment at the location we are moving. If there is one check if we want to move before or after the attachment based on the margins.
+    /// Check if there is an attachment at the location we are moving. If there is one check if we want to move before or after the
+    /// attachment based on the margins.
     ///
     /// - Parameter point: the point to check.
     /// - Returns: true if the point fall inside an attachment margin
+    ///
     open func isPointInsideAttachmentMargin(point: CGPoint) -> Bool {
         let index = layoutManager.characterIndex(for: point, in: textContainer, fractionOfDistanceBetweenInsertionPoints: nil)
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -169,7 +169,7 @@ open class TextView: UITextView {
     public var outputProcessor: Processor?
 
 
-    // MARK: - TextKit Aztec Subclass'ess
+    // MARK: - TextKit Aztec Subclasses
 
     var storage: TextStorage {
         return textStorage as! TextStorage
@@ -249,7 +249,6 @@ open class TextView: UITextView {
         
         return textStorage.attributes(at: lastLocation, effectiveRange: nil)
     }
-
 
 
     // MARK: - Init & deinit

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -175,6 +175,47 @@ open class TextView: UITextView {
         return textStorage as! TextStorage
     }
 
+    var layout: LayoutManager {
+        return layoutManager as! LayoutManager
+    }
+
+
+    // MARK: - Apparance Properties
+
+    /// Blockquote Blocks Border COlor.
+    ///
+    dynamic public var blockquoteBorderColor: UIColor {
+        get {
+            return layout.blockquoteBorderColor
+        }
+        set {
+            layout.blockquoteBorderColor = newValue
+        }
+    }
+
+    /// Blockquote Blocks Background Color.
+    ///
+    dynamic public var blockquoteBackgroundColor: UIColor {
+        get {
+            return layout.blockquoteBackgroundColor
+        }
+        set {
+            layout.blockquoteBackgroundColor = newValue
+        }
+    }
+
+    /// Pre Blocks Background Color.
+    ///
+    dynamic public var preBackgroundColor: UIColor {
+        get {
+            return layout.preBackgroundColor
+        }
+        set {
+            layout.preBackgroundColor = newValue
+        }
+    }
+
+
     // MARK: - Overwritten Properties
 
     /// Overwrites Typing Attributes:


### PR DESCRIPTION
### Description:
In this PR we're adding three new TextView properties:

- blockquoteBorderColor
- blockquoteBackgroundColor
- preBackgroundColor

### Details:
Because of the `dynamic` keyword, the three new properties are compatible with Apple's `UIAppearance()` mechanism. This allows us to do the following:


- Customize a specific instance:  `textView.blockquoteBackgroundColor = .green`
- Customize **all** of Aztec's instances: `TextView.appearance().blockquoteBackgroundColor = .green`

Apple's `appearance()` mechanism also allows for customization when contained in a specific ViewController, or define the UX for a specific set of traits.

### Testing:
1. Open `EditorDemoViewController.swift`
2. Paste this snippet in viewDidLoad `textView.blockquoteBackgroundColor = .green`
3. Launch Aztec
4. Insert a Blockquote

Verify that the blockquote is green.
