### PR TITLE
TextView: blockquoteBorderWidth Property

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -182,7 +182,18 @@ open class TextView: UITextView {
 
     // MARK: - Apparance Properties
 
-    /// Blockquote Blocks Border COlor.
+    /// Blockquote Blocks Background Color.
+    ///
+    dynamic public var blockquoteBackgroundColor: UIColor {
+        get {
+            return layout.blockquoteBackgroundColor
+        }
+        set {
+            layout.blockquoteBackgroundColor = newValue
+        }
+    }
+
+    /// Blockquote Blocks Border Color.
     ///
     dynamic public var blockquoteBorderColor: UIColor {
         get {
@@ -193,14 +204,14 @@ open class TextView: UITextView {
         }
     }
 
-    /// Blockquote Blocks Background Color.
+    /// Blockquote's Left Border Width.
     ///
-    dynamic public var blockquoteBackgroundColor: UIColor {
+    dynamic public var blockquoteBorderWidth: CGFloat {
         get {
-            return layout.blockquoteBackgroundColor
+            return layout.blockquoteBorderWidth
         }
         set {
-            layout.blockquoteBackgroundColor = newValue
+            layout.blockquoteBorderWidth = newValue
         }
     }
 


### PR DESCRIPTION
### Details:
This PR exposes the LayoutManager's **blockquoteBorderWidth** property, which i've missed in my last "Blockquote Customization" PR.

### To test:
1. Open `EditorDemoController` and find the **viewDidLoad** method
2. Add the following snippet: `richTextView.blockquoteBorderWidth = 50`
3. Launch Aztec 
4. Add a blockquote

Verify that the left border has 50pt width.

cc @diegoreymendez 

Thanks in advance!

--

@azone apologies about missing this property, we'll get this in soon. Thanks!