### PR TITLE
Avoiding to call ensureRemovalOfParagraphAttributesAfterSelectionChange method if TextView have marked text

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -224,9 +224,7 @@ open class TextView: UITextView {
     ///
     override open var typingAttributes: [String: Any] {
         get {
-            if markedTextRange == nil {
-                ensureRemovalOfParagraphAttributesAfterSelectionChange()
-            }
+            ensureRemovalOfParagraphAttributesAfterSelectionChange()
             return super.typingAttributes
         }
         set {
@@ -1644,6 +1642,7 @@ private extension TextView {
     private func mustRemoveParagraphAttributesAfterSelectionChange() -> Bool {
         return selectedRange.location == storage.length
             && storage.string.isEmptyParagraph(at: selectedRange.location)
+            && markedTextRange == nil
     }
 
     /// Removes the Paragraph Attributes [Blockquote, Pre, Lists] at the specified range. If the range

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -224,7 +224,9 @@ open class TextView: UITextView {
     ///
     override open var typingAttributes: [String: Any] {
         get {
-            ensureRemovalOfParagraphAttributesAfterSelectionChange()
+            if markedTextRange == nil {
+                ensureRemovalOfParagraphAttributesAfterSelectionChange()
+            }
             return super.typingAttributes
         }
         set {


### PR DESCRIPTION
Avoiding to call ensureRemovalOfParagraphAttributesAfterSelectionChange method if TextView have marked text

Fixes #801 

To test:

1. Add block-quote
2. Switch input method to Chinese
3. Input Chinese but do not confirm