### PR TITLE
MediaAttachment overlay design updates

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		599F25521D8BC9A1002871D6 /* MediaAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25301D8BC9A1002871D6 /* MediaAttachment.swift */; };
 		599F25531D8BC9A1002871D6 /* TextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25311D8BC9A1002871D6 /* TextStorage.swift */; };
 		599F25541D8BC9A1002871D6 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25321D8BC9A1002871D6 /* TextView.swift */; };
+		74EEC71B1FAB6EC900B989E3 /* UIImage+Resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74EEC71A1FAB6EC900B989E3 /* UIImage+Resize.swift */; };
 		B50CE7321F1FA6260018CAA1 /* NSAttributedString+Strip.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50CE7311F1FA6260018CAA1 /* NSAttributedString+Strip.swift */; };
 		B50CE7341F1FABA00018CAA1 /* content.html in Resources */ = {isa = PBXBuildFile; fileRef = B50CE7331F1FABA00018CAA1 /* content.html */; };
 		B52220D31F86A05400D7E092 /* TextViewStubDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52220D21F86A05400D7E092 /* TextViewStubDelegate.swift */; };
@@ -205,6 +206,7 @@
 		599F25581D8BCA01002871D6 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		59FEA06B1D8BDFA700D138DF /* InAttributeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAttributeConverterTests.swift; sourceTree = "<group>"; };
 		59FEA06D1D8BDFA700D138DF /* InNodeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InNodeConverterTests.swift; sourceTree = "<group>"; };
+		74EEC71A1FAB6EC900B989E3 /* UIImage+Resize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resize.swift"; sourceTree = "<group>"; };
 		B50CE7311F1FA6260018CAA1 /* NSAttributedString+Strip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Strip.swift"; sourceTree = "<group>"; };
 		B50CE7331F1FABA00018CAA1 /* content.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = content.html; path = Example/Example/SampleContent/content.html; sourceTree = SOURCE_ROOT; };
 		B52220D21F86A05400D7E092 /* TextViewStubDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TextViewStubDelegate.swift; path = TextKit/TextViewStubDelegate.swift; sourceTree = "<group>"; };
@@ -511,6 +513,7 @@
 				B5C99D3E1E72E2E700335355 /* UIStackView+Helpers.swift */,
 				F1DE83D41EF20493009269E6 /* UIColor+Parsers.swift */,
 				B5AB79F71F5F3E0B00DF26F5 /* String+Paragraph.swift */,
+				74EEC71A1FAB6EC900B989E3 /* UIImage+Resize.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1050,6 +1053,7 @@
 				599F254D1D8BC9A1002871D6 /* FormatBar.swift in Sources */,
 				F1FA0E881E6EF514009D98EE /* TextNode.swift in Sources */,
 				599F253A1D8BC9A1002871D6 /* InNodeConverter.swift in Sources */,
+				74EEC71B1FAB6EC900B989E3 /* UIImage+Resize.swift in Sources */,
 				F17BC8941F4E4BA500398E2B /* UnsupportedHTML.swift in Sources */,
 				F12F586F1EF20394008AE298 /* PreFormatter.swift in Sources */,
 				B50CE7321F1FA6260018CAA1 /* NSAttributedString+Strip.swift in Sources */,

--- a/Aztec/Classes/Extensions/UIImage+Resize.swift
+++ b/Aztec/Classes/Extensions/UIImage+Resize.swift
@@ -1,0 +1,74 @@
+import Foundation
+import UIKit
+
+extension UIImage {
+
+    /// Resizes an image so it fits within rectSize and will not exceed the height or width
+    /// of the maxImageSize. The aspect ratio is maintained.
+    ///
+    /// - Parameters:
+    ///     - rectSize: The CGSize that the image will be fit into. *Note*, this is NOT the returned image size.
+    ///     - maxImageSize: The maximum height and width of the new image. The returned image will always be smaller in *both* dimensions.
+    ///     - color: Optional UIColor. If provided, the color will be set when drawing the new image.
+    ///
+    /// - Returns: A new UIImage that is contained within rectSize, but no larger than maxImageSize in either dimension.
+    ///
+    func resizedImageWithinRect(rectSize: CGSize, maxImageSize: CGSize, color: UIColor? = nil) -> UIImage {
+        let smallerWidthThanMax = rectSize.width < maxImageSize.width
+        let smallerHeightThanMax = rectSize.height < maxImageSize.height
+
+        if smallerWidthThanMax && smallerHeightThanMax {
+            return resizedImageWithinRect(rectSize: rectSize, color: color)
+        } else if smallerWidthThanMax && !smallerHeightThanMax {
+            return resizedImageWithinRect(rectSize: CGSize(width: rectSize.width, height: maxImageSize.height), color: color)
+        } else if !smallerWidthThanMax && smallerHeightThanMax {
+            return resizedImageWithinRect(rectSize: CGSize(width: maxImageSize.width, height: rectSize.height), color: color)
+        } else {
+            return resizedImageWithinRect(rectSize: CGSize(width: maxImageSize.width, height: maxImageSize.height), color: color)
+        }
+    }
+
+    /// Resizes an image so it fits within rectSize. The aspect ratio is maintained.
+    ///
+    /// - Parameters:
+    ///     - rectSize: The CGSize that the image will be fit into. *Note*, this is NOT the returned image size.
+    ///     - color: Optional UIColor. If provided, the color will be set when drawing the new image.
+    ///
+    /// - Returns: A new UIImage that is contained within rectSize.
+    ///
+    func resizedImageWithinRect(rectSize: CGSize, color: UIColor? = nil) -> UIImage {
+        let widthRatio = size.width / rectSize.width
+        let heightRatio = size.height / rectSize.height
+        var resizeRatio = widthRatio
+        if size.height > size.width {
+            resizeRatio = heightRatio
+        }
+
+        let newSize = CGSize(width: size.width / resizeRatio, height: size.height / resizeRatio)
+        return resizedImage(newSize: newSize, color: color)
+    }
+
+    /// Resizes the image so it fills newSize.
+    ///
+    /// - Parameters:
+    ///     - newSize: The CGSize that the image will be fit into. *Note*, this is NOT the returned image size.
+    ///     - color: Optional UIColor. If provided, the color will be set when drawing the new image.
+    ///
+    /// - Returns: A new UIImage that fills newSize.
+    ///
+    func resizedImage(newSize: CGSize, color: UIColor?) -> UIImage {
+        guard size != newSize else {
+            return self
+        }
+        
+        UIGraphicsBeginImageContextWithOptions(newSize, false, 0.0);
+        let rect = CGRect(x: 0, y: 0, width: newSize.width, height: newSize.height)
+        if let color = color {
+            color.set()
+        }
+        draw(in: rect)
+        let resizedImage: UIImage = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+        return resizedImage
+    }
+}

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -234,9 +234,11 @@ open class MediaAttachment: NSTextAttachment {
         var imagePadding: CGFloat = 0
         if let overlayImage = overlayImage {
             UIColor.white.set()
+            let sizeInsideBorder = CGSize(width: size.width - appearance.overlayBorderWidth, height: size.height - appearance.overlayBorderWidth)
+            let newImage = overlayImage.resizedImageWithinRect(rectSize: sizeInsideBorder, maxImageSize: overlayImage.size, color: UIColor.white)
             let center = CGPoint(x: round(origin.x + (size.width / 2.0)), y: round(origin.y + (size.height / 2.0)))
-            overlayImage.draw(at: CGPoint(x: round(center.x - (overlayImage.size.width / 2.0)), y: round(center.y - (overlayImage.size.height / 2.0))))
-            imagePadding += overlayImage.size.height
+            newImage.draw(at: CGPoint(x: round(center.x - (newImage.size.width / 2.0)), y: round(center.y - (newImage.size.height / 2.0))))
+            imagePadding += newImage.size.height
         }
 
         if let message = message {

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -235,11 +235,8 @@ open class MediaAttachment: NSTextAttachment {
         if let overlayImage = overlayImage {
             UIColor.white.set()
             let center = CGPoint(x: round(origin.x + (size.width / 2.0)), y: round(origin.y + (size.height / 2.0)))
-            let radius = round(overlayImage.size.width * 2.0/3.0)
-            let path = UIBezierPath(arcCenter: center, radius: radius, startAngle: 0, endAngle: CGFloat.pi * 2, clockwise: true)
-            path.stroke()
             overlayImage.draw(at: CGPoint(x: round(center.x - (overlayImage.size.width / 2.0)), y: round(center.y - (overlayImage.size.height / 2.0))))
-            imagePadding += radius * 2;
+            imagePadding += overlayImage.size.height
         }
 
         if let message = message {
@@ -249,7 +246,11 @@ open class MediaAttachment: NSTextAttachment {
                 y = origin.y + ((size.height + imagePadding) / 2.0)
             }
             let textPosition = CGPoint(x: origin.x, y: y)
-            message.draw(in: CGRect(origin: textPosition , size: CGSize(width:size.width, height:textRect.size.height)))
+
+            // Check to see if the message will fit within the image. If not, skip it.
+            if (textPosition.y + textRect.height) < mediaBounds.height {
+                message.draw(in: CGRect(origin: textPosition, size: CGSize(width:size.width, height:textRect.size.height)))
+            }
         }
 
         let result = UIGraphicsGetImageFromCurrentImageContext()

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -228,6 +228,7 @@ open class MediaAttachment: NSTextAttachment {
         image.draw(in: mediaBounds)
 
         drawOverlayBackground(at: origin, size: size)
+        drawOverlayBorder(at: origin, size: size)
         drawProgress(at: origin, size: size)
 
         var imagePadding: CGFloat = 0
@@ -263,9 +264,17 @@ open class MediaAttachment: NSTextAttachment {
         let rect = CGRect(origin: origin, size: size)
         let path = UIBezierPath(rect: rect)
         appearance.overlayColor.setFill()
-        appearance.overlayBorderColor.setStroke()
         path.fill()
-        path.lineWidth = (appearance.overlayBorderWidth * 2)
+    }
+
+    private func drawOverlayBorder(at origin: CGPoint, size:CGSize) {
+        guard appearance.overlayBorderWidth > 0, progress == nil && message != nil else {
+            return
+        }
+        let rect = CGRect(origin: origin, size: size)
+        let path = UIBezierPath(rect: rect)
+        appearance.overlayBorderColor.setStroke()
+        path.lineWidth = (appearance.overlayBorderWidth * 2.0)
         path.addClip()
         path.stroke()
     }

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -433,7 +433,12 @@ private extension MediaAttachment {
         static let maxRetryCount = 3
 
         /// Top margin for message text
+        ///
         static let messageTextTopMargin = CGFloat(2.0)
+
+        /// Default color for the overlay background (dark grey with 60% alpha).
+        ///
+        static let defaultOverlayColor = UIColor(red: CGFloat(46.0/255.0), green: CGFloat(69.0/255.0), blue: CGFloat(83.0/255.0), alpha: 0.6)
     }
 }
 
@@ -446,7 +451,7 @@ extension MediaAttachment {
 
         /// The color to use when drawing the background overlay for messages, icons, and progress
         ///
-        public var overlayColor = UIColor(white: 0.6, alpha: 0.6)
+        public var overlayColor = Constants.defaultOverlayColor
 
         /// The border width to use when drawing the background overlay for messages, icons, and progress. Defauls to 0.
         ///
@@ -454,7 +459,7 @@ extension MediaAttachment {
 
         /// The color to use when drawing the background overlay border for messages, icons, and progress
         ///
-        public var overlayBorderColor = UIColor(white: 0.6, alpha: 0.6)
+        public var overlayBorderColor = Constants.defaultOverlayColor
 
         /// The height of the progress bar for progress indicators
         ///

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -255,7 +255,7 @@ open class MediaAttachment: NSTextAttachment {
             let textRect = message.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
             var y =  origin.y + ((size.height - textRect.height) / 2.0)
             if imagePadding != 0 {
-                y = origin.y + ((size.height + imagePadding) / 2.0)
+                y = origin.y + Constants.messageTextTopMargin + ((size.height + imagePadding) / 2.0)
             }
             let textPosition = CGPoint(x: origin.x, y: y)
 
@@ -431,6 +431,9 @@ private extension MediaAttachment {
         /// Maximum number of times to retry downloading the asset, upon error
         ///
         static let maxRetryCount = 3
+
+        /// Top margin for message text
+        static let messageTextTopMargin = CGFloat(2.0)
     }
 }
 

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -81,6 +81,16 @@ open class MediaAttachment: NSTextAttachment {
         }
     }
 
+    /// Setting this to true will always hide the border on the overlay
+    ///
+    open var shouldHideBorder: Bool = false {
+        willSet {
+            if newValue != shouldHideBorder {
+                glyphImage = nil
+            }
+        }
+    }
+
     /// Image to be displayed: Contains the actual Asset + the overlays (if any), embedded
     ///
     internal var glyphImage: UIImage?
@@ -271,8 +281,11 @@ open class MediaAttachment: NSTextAttachment {
     }
 
     private func drawOverlayBorder(at origin: CGPoint, size:CGSize) {
-        guard appearance.overlayBorderWidth > 0, progress == nil && message != nil else {
-            return
+        // Don't display the border if the border width is 0, we are force-hiding it, or message is set with no progress
+        guard appearance.overlayBorderWidth > 0,
+            shouldHideBorder == false,
+            progress == nil && message != nil else {
+                return
         }
         let rect = CGRect(origin: origin, size: size)
         let path = UIBezierPath(rect: rect)

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -260,16 +260,14 @@ open class MediaAttachment: NSTextAttachment {
         guard message != nil || progress != nil else {
             return
         }
-
-        let box = UIBezierPath()
-        box.move(to: CGPoint(x:origin.x, y:origin.y))
-        box.addLine(to: CGPoint(x: origin.x + size.width, y: origin.y))
-        box.addLine(to: CGPoint(x: origin.x + size.width, y: origin.y + size.height))
-        box.addLine(to: CGPoint(x: origin.x, y: origin.y + size.height))
-        box.addLine(to: CGPoint(x: origin.x, y: origin.y))
-        box.lineWidth = 2.0
+        let rect = CGRect(origin: origin, size: size)
+        let path = UIBezierPath(rect: rect)
         appearance.overlayColor.setFill()
-        box.fill()
+        appearance.overlayBorderColor.setStroke()
+        path.fill()
+        path.lineWidth = (appearance.overlayBorderWidth * 2)
+        path.addClip()
+        path.stroke()
     }
 
     private func drawProgress(at origin: CGPoint, size:CGSize) {
@@ -421,6 +419,14 @@ extension MediaAttachment {
         /// The color to use when drawing the background overlay for messages, icons, and progress
         ///
         public var overlayColor = UIColor(white: 0.6, alpha: 0.6)
+
+        /// The border width to use when drawing the background overlay for messages, icons, and progress. Defauls to 0.
+        ///
+        public var overlayBorderWidth = CGFloat(0.0)
+
+        /// The color to use when drawing the background overlay border for messages, icons, and progress
+        ///
+        public var overlayBorderColor = UIColor(white: 0.6, alpha: 0.6)
 
         /// The height of the progress bar for progress indicators
         ///

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -161,7 +161,7 @@ class EditorDemoController: UIViewController {
         MediaAttachment.defaultAppearance.progressColor = UIColor.blue
         MediaAttachment.defaultAppearance.progressBackgroundColor = UIColor.lightGray
         MediaAttachment.defaultAppearance.progressHeight = 2.0
-        MediaAttachment.defaultAppearance.overlayColor = UIColor(white: 0.5, alpha: 0.5)
+        MediaAttachment.defaultAppearance.overlayColor = UIColor(red: CGFloat(46.0/255.0), green: CGFloat(69.0/255.0), blue: CGFloat(83.0/255.0), alpha: 0.6)
         // Uncomment to add a border
         // MediaAttachment.defaultAppearance.overlayBorderWidth = 3.0
         // MediaAttachment.defaultAppearance.overlayBorderColor = UIColor(red: CGFloat(0.0/255.0), green: CGFloat(135.0/255.0), blue: CGFloat(190.0/255.0), alpha: 0.8)

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -158,6 +158,13 @@ class EditorDemoController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        MediaAttachment.defaultAppearance.progressColor = UIColor.blue
+        MediaAttachment.defaultAppearance.progressBackgroundColor = UIColor.lightGray
+        MediaAttachment.defaultAppearance.progressHeight = 2.0
+        MediaAttachment.defaultAppearance.overlayColor = UIColor(white: 0.5, alpha: 0.5)
+        MediaAttachment.defaultAppearance.overlayBorderWidth = 3.0
+        MediaAttachment.defaultAppearance.overlayBorderColor = UIColor.blue
+
         edgesForExtendedLayout = UIRectEdge()
         navigationController?.navigationBar.isTranslucent = false
 
@@ -179,11 +186,6 @@ class EditorDemoController: UIViewController {
         }
 
         setHTML(html)
-
-        MediaAttachment.defaultAppearance.progressColor = UIColor.blue
-        MediaAttachment.defaultAppearance.progressBackgroundColor = UIColor.lightGray
-        MediaAttachment.defaultAppearance.progressHeight = 2.0
-        MediaAttachment.defaultAppearance.overlayColor = UIColor(white: 0.5, alpha: 0.5)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -162,8 +162,9 @@ class EditorDemoController: UIViewController {
         MediaAttachment.defaultAppearance.progressBackgroundColor = UIColor.lightGray
         MediaAttachment.defaultAppearance.progressHeight = 2.0
         MediaAttachment.defaultAppearance.overlayColor = UIColor(white: 0.5, alpha: 0.5)
-        MediaAttachment.defaultAppearance.overlayBorderWidth = 3.0
-        MediaAttachment.defaultAppearance.overlayBorderColor = UIColor(red: CGFloat(0.0/255.0), green: CGFloat(135.0/255.0), blue: CGFloat(190.0/255.0), alpha: 0.8)
+        // Uncomment to add a border
+        // MediaAttachment.defaultAppearance.overlayBorderWidth = 3.0
+        // MediaAttachment.defaultAppearance.overlayBorderColor = UIColor(red: CGFloat(0.0/255.0), green: CGFloat(135.0/255.0), blue: CGFloat(190.0/255.0), alpha: 0.8)
 
         edgesForExtendedLayout = UIRectEdge()
         navigationController?.navigationBar.isTranslucent = false

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -163,7 +163,7 @@ class EditorDemoController: UIViewController {
         MediaAttachment.defaultAppearance.progressHeight = 2.0
         MediaAttachment.defaultAppearance.overlayColor = UIColor(white: 0.5, alpha: 0.5)
         MediaAttachment.defaultAppearance.overlayBorderWidth = 3.0
-        MediaAttachment.defaultAppearance.overlayBorderColor = UIColor.blue
+        MediaAttachment.defaultAppearance.overlayBorderColor = UIColor(red: CGFloat(0.0/255.0), green: CGFloat(135.0/255.0), blue: CGFloat(190.0/255.0), alpha: 0.8)
 
         edgesForExtendedLayout = UIRectEdge()
         navigationController?.navigationBar.isTranslucent = false

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1081,10 +1081,11 @@ extension EditorDemoController: TextViewAttachmentDelegate {
             }
 
             // and mark the newly tapped attachment
-            let message = NSLocalizedString("Tap for options", comment: "Options to show when tapping on a media object on the post/page editor.")
+            let message = NSLocalizedString("Options", comment: "Options to show when tapping on a media object on the post/page editor.")
             attachment.message = NSAttributedString(string: message, attributes: mediaMessageAttributes)
             if attachment.overlayImage == nil {
                 attachment.overlayImage = Gridicon.iconOfType(.pencil).withRenderingMode(.alwaysTemplate)
+                attachment.overlayImage = Gridicon.iconOfType(.pencil, withSize: CGSize(width: 32.0, height: 32.0)).withRenderingMode(.alwaysTemplate)
             }
             richTextView.refresh(attachment)
             currentSelectedAttachment = attachment
@@ -1278,13 +1279,9 @@ private extension EditorDemoController
     var mediaMessageAttributes: [String: Any] {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
-        let shadow = NSShadow()
-        shadow.shadowOffset = CGSize(width: 1, height: 1)
-        shadow.shadowColor = UIColor(white: 0, alpha: 0.6)
-        let attributes: [String:Any] = [NSFontAttributeName: UIFont.boldSystemFont(ofSize: 16),
+        let attributes: [String:Any] = [NSFontAttributeName: UIFont.systemFont(ofSize: 15, weight: UIFontWeightSemibold),
                                         NSParagraphStyleAttributeName: paragraphStyle,
-                                        NSForegroundColorAttributeName: UIColor.white,
-                                        NSShadowAttributeName: shadow]
+                                        NSForegroundColorAttributeName: UIColor.white]
         return attributes
     }
 

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -102,23 +102,23 @@ Master cleanse Intelligentsia butcher Brooklyn Tumblr. Etsy lo-fi Marfa bicycle 
 Block Quote:
 <blockquote>Kale chips Schlitz forage irony, kogi Tumblr Carles chillwave Etsy pug photo booth YOLO biodiesel tote bag actually. PBR Portland yr pickled, bespoke meggings selvage letterpress kitsch plaid before they sold out put a bird on it you probably haven't heard of them. Yr master cleanse slow-carb crucifix, sustainable keytar Helvetica Tumblr High Life mumblecore narwhal cornhole deep v craft beer. Portland forage hashtag locavore, before they sold out put a bird on it irony hella. Godard kale chips street art tote bag cardigan. Church-key next level seitan keytar meggings Portland. Keffiyeh flexitarian post-ironic drinking vinegar wayfarers.</blockquote>
 </p>
+<h4>Image:</h4>
 <p>
-Image:<br/><br/>
-
 <img src="https://httpbin.org/image/jpeg" alt="Coyote" />
 </p>
+<h4>Image with caption:</h4>
 <p>
-Image with caption:<br/><br/>
-
 [caption id="attachment_6" align="alignright" width="300"]<img src="https://httpbin.org/image/jpeg" alt="Coyote" />Ahoi![/caption]
+</p>
+<h4>Video:</h4>
 <p>
-Video:<br/><br/>
-
 <video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://i2.wp.com/videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg?ssl=1" alt="Video about bunnies" />
-<br/>
-Video with Shortcode:<br/><br/>
+</p>
+<h4>Video with Shortcode:</h4>
+<p>
 [video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://i2.wp.com/videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg?ssl=1" alt="Another video with bunnies"/]
 </p>
+<h4>Overlay on Media:</h4>
 <p>
 20px Wide Image:
 <img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,20px,20px" alt="Plane"/><br/><br/>

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -128,6 +128,10 @@ Video with Shortcode:<br/><br/>
 <img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,70px,70px" alt="Plane"/><br/><br/>
 90px Wide Image:
 <img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,90px,90px" alt="Plane"/><br/><br/>
+120px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,120px,120px" alt="Plane"/><br/><br/>
+200px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,200px,200px" alt="Plane"/><br/><br/>
 300px Wide Image:
 <img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,300px,300px" alt="Plane"/>
 </p>

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -119,7 +119,18 @@ Video:<br/><br/>
 Video with Shortcode:<br/><br/>
 [video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://i2.wp.com/videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg?ssl=1" alt="Another video with bunnies"/]
 </p>
-
+<p>
+20px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,20px,20px" alt="Plane"/><br/><br/>
+50px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,50px,50px" alt="Plane"/><br/><br/>
+70px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,70px,70px" alt="Plane"/><br/><br/>
+90px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,90px,90px" alt="Plane"/><br/><br/>
+300px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,300px,300px" alt="Plane"/>
+</p>
 <p>
 Fanny pack Odd Future Intelligentsia lo-fi semiotics whatever. Selvage keffiyeh mustache sustainable ethnic, chambray mumblecore McSweeney's biodiesel Pitchfork four loko disrupt post-ironic art party American Apparel. Kitsch umami beard salvia, Vice before they sold out vegan tousled lomo jean shorts pickled PBR&amp;B. Tousled Wes Anderson Shoreditch flannel, 90's XOXO quinoa whatever mumblecore cliche Truffaut stumptown. Photo booth crucifix plaid Brooklyn. Authentic letterpress PBR&amp;B, sustainable VHS master cleanse ethnic High Life. Messenger bag umami pug flannel.
 </p>


### PR DESCRIPTION
## Discussion
This PR contains changes needed to address https://github.com/wordpress-mobile/WordPress-iOS/issues/8063 (also see [this comment](https://github.com/wordpress-mobile/WordPress-iOS/issues/8063#issuecomment-340917766)).

The following things are what is changing here:
* There is no longer a circle drawn around the `overlayImage`
* Borders can now be drawn around overlays (_default is off_). The `Appearance ` struct now contains `overlayBorderWidth` and `overlayBorderColor` which, when set, will draw borders around the image along with the standard overlay.
* The `shouldHideBorder` property was added so borders can be turned completely off even if the Border `Appearance` values are set. This is useful for the times you want to display an overlay but no border...e.g. failed uploads or other error conditions:

<img width="321" alt="screen shot 2017-11-02 at 3 25 46 pm" src="https://user-images.githubusercontent.com/154014/32349820-502606bc-bfe6-11e7-8b7f-d59f49c381ee.png">

* The `overlayImage` is now resized to fit within an image. If borders are turned on it will fit inside the borders.
* The `message` text is now measured and only displayed if it will reasonably fit within the media attachment bounds (taking into account if the `overlayImage` is set or not).

<img width="454" alt="napkin 54 11-02-17 3 55 11 pm" src="https://user-images.githubusercontent.com/154014/32349905-a0506466-bfe6-11e7-9ddc-ff70990e7857.png">

* `content.html` has been updated to display a series of images at different sizes to help test this stuff out.

### Note
This PR does not account for positioning of the overlay image on the outside of the media attachment bounds like:

<img width="106" alt="screen shot 2017-11-02 at 4 06 42 pm" src="https://user-images.githubusercontent.com/154014/32350249-d7ad1ade-bfe7-11e7-9c18-df6a0bc9f343.png">

This will be accomplished in a later PR.

## To Test
1. Run the Aztec demo and verify the overlays still work as expected on images.  The overlay icon should always fit inside the image and the `message` text should disappear if it doesn't reasonably fit within the image with the icon.
2. Try turning on the the border [here](https://github.com/wordpress-mobile/AztecEditor-iOS/blob/63a2c373843f5bbe3c652981a10849ff778f064f/Example/Example/EditorDemoController.swift#L165-L167) and testing the overlays again. The icons should now fit inside of the border.
3. When the progress bar is displayed during upload, the border should not even if it is turned on. Verify this is the case.
4. There is a WPiOS branch that uses this feature branch [here](https://github.com/wordpress-mobile/WordPress-iOS/tree/feature/8063-new-media-overlay). Run it and try out media attachments (uploads, failed uploads, tapping now brings up the action sheet immediately, etc).

Try to test image and video media attachment types to make sure everything works as expected.

## Review
@SergioEstevao would you mind taking this for a thorough spin.  
