### PR TITLE
Swift 3.2: Removing .characters references

### DIFF
--- a/Aztec/Classes/Extensions/String+EndOfLine.swift
+++ b/Aztec/Classes/Extensions/String+EndOfLine.swift
@@ -37,7 +37,7 @@ extension String {
     /// - Returns: `true` if the specified offset is in an empty paragraph, `false` otherwise.
     ///
     func isEmptyLineAtEndOfFile(at offset: Int) -> Bool {
-        return offset == characters.count && isEmptyLine(at: offset)
+        return offset == count && isEmptyLine(at: offset)
     }
 
     /// This methods verifies if the receiver string is an end-of-line character.

--- a/Aztec/Classes/Extensions/String+RangeConversion.swift
+++ b/Aztec/Classes/Extensions/String+RangeConversion.swift
@@ -125,7 +125,7 @@ public extension String {
     /// Returns a NSRange with a starting location at the very end of the string
     ///
     func endOfStringNSRange() -> NSRange {
-        return NSRange(location: characters.count, length: 0)
+        return NSRange(location: count, length: 0)
     }
 
     func indexFromLocation(_ location: Int) -> String.Index? {

--- a/Aztec/Classes/Extensions/UIColor+Parsers.swift
+++ b/Aztec/Classes/Extensions/UIColor+Parsers.swift
@@ -13,7 +13,7 @@ extension UIColor {
             return nil
         }
         let a, r, g, b: UInt32
-        switch hex.characters.count {
+        switch hex.count {
         case 3: // RGB (12-bit)
             (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
         case 6: // RGB (24-bit)

--- a/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/CSSParser.swift
@@ -14,7 +14,7 @@ class CSSParser {
     ///
     func parse(_ css: String) -> [CSSAttribute] {
 
-        guard css.characters.count > 0 else {
+        guard css.count > 0 else {
             return []
         }
 
@@ -36,7 +36,7 @@ class CSSParser {
 
             let trimmedAttribute = cssAttribute.trimmingCharacters(in: .whitespacesAndNewlines)
 
-            guard trimmedAttribute.characters.count > 0 else {
+            guard trimmedAttribute.count > 0 else {
                 return nil
             }
 

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -26,7 +26,7 @@ public class TextNode: Node {
     /// Node length.
     ///
     func length() -> Int {
-        return contents.characters.count
+        return contents.count
     }
 
     // MARK: - Node

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -60,7 +60,7 @@ class AttributedStringSerializer {
 
         let text = sanitizeText(from: node)
         
-        guard text.characters.count > 0 else {
+        guard text.count > 0 else {
             return NSAttributedString()
         }
         

--- a/Aztec/Classes/TextKit/HTMLStorage.swift
+++ b/Aztec/Classes/TextKit/HTMLStorage.swift
@@ -95,7 +95,7 @@ open class HTMLStorage: NSTextStorage {
         beginEditing()
 
         textStore.replaceCharacters(in: range, with: str)
-        edited([.editedAttributes, .editedCharacters], range: range, changeInLength: string.characters.count - range.length)
+        edited([.editedAttributes, .editedCharacters], range: range, changeInLength: string.count - range.length)
 
         endEditing()
     }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -239,7 +239,7 @@ open class TextStorage: NSTextStorage {
         detectAttachmentRemoved(in: range)
         textStore.replaceCharacters(in: range, with: str)
 
-        edited(.editedCharacters, range: range, changeInLength: str.characters.count - range.length)
+        edited(.editedCharacters, range: range, changeInLength: str.count - range.length)
         
         endEditing()
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -261,7 +261,7 @@ open class TextView: UITextView {
             return defaultAttributes
         }
         
-        let lastLocation = max(string.characters.count - 1, 0)
+        let lastLocation = max(string.count - 1, 0)
         
         return textStorage.attributes(at: lastLocation, effectiveRange: nil)
     }
@@ -1129,7 +1129,7 @@ open class TextView: UITextView {
         }
         
         let document = textStorage.string
-        guard selectedRange.location == document.characters.count, document.characters.count > 0 else {
+        guard selectedRange.location == document.count, document.count > 0 else {
             block()
             return
         }

--- a/AztecTests/Extensions/StringParagraphTests.swift
+++ b/AztecTests/Extensions/StringParagraphTests.swift
@@ -24,7 +24,7 @@ class StringParagraphTests: XCTestCase {
     func testIsStartOfParagraphReturnsFalseAtAnyPositionThatIsNotTheFirstOne() {
         let sample = "Sample"
 
-        for location in 1 ..< sample.characters.count {
+        for location in 1 ..< sample.count {
             let index = sample.indexFromLocation(location)!
             XCTAssertFalse(sample.isStartOfParagraph(at: index))
         }
@@ -69,7 +69,7 @@ class StringParagraphTests: XCTestCase {
     func testIsEmptyParagraphReturnsFalseOnNonEmptyParagraphs() {
         let sample = "Sample"
 
-        for i in 0 ..< sample.characters.count {
+        for i in 0 ..< sample.count {
             XCTAssertFalse(sample.isEmptyParagraph(at: i))
         }
     }
@@ -79,7 +79,7 @@ class StringParagraphTests: XCTestCase {
     func testIsEmptyParagraphReturnsFalseOnEmptyLinesThatBelongToABiggerParagraph() {
         let sample = "Sample" + String(.lineSeparator)
 
-        XCTAssertFalse(sample.isEmptyParagraph(at: sample.characters.count - 1))
+        XCTAssertFalse(sample.isEmptyParagraph(at: sample.count - 1))
     }
 
     /// Verifies that isEmptyParagraph(at:) returns true on empty lines, that do not belong to the previous paragraph.
@@ -87,6 +87,6 @@ class StringParagraphTests: XCTestCase {
     func testIsEmptyParagraphReturnsTrueOnEmptyLinesThatDoNotBelongToABiggerParagraph() {
         let sample = "Sample" + String(.lineFeed)
 
-        XCTAssertTrue(sample.isEmptyParagraph(at: sample.characters.count))
+        XCTAssertTrue(sample.isEmptyParagraph(at: sample.count))
     }
 }

--- a/AztecTests/StringRangeConversionTests.swift
+++ b/AztecTests/StringRangeConversionTests.swift
@@ -248,6 +248,6 @@ class StringRangeConversionTests: XCTestCase {
         let endingRange = string.endOfStringNSRange()
 
         XCTAssert(endingRange.length == 0)
-        XCTAssert(endingRange.location == string.characters.count)
+        XCTAssert(endingRange.location == string.count)
     }
 }

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -114,7 +114,7 @@ class TextViewTests: XCTestCase {
 
         textView.text = "foo"
 
-        let count = textView.text!.characters.count
+        let count = textView.text!.count
         let maxIndex = count - 1
 
         // Test upper and lower bounds
@@ -127,7 +127,7 @@ class TextViewTests: XCTestCase {
 
         textView.text = "foobarbaz"
 
-        let count = textView.text!.characters.count
+        let count = textView.text!.count
         let maxIndex = count - 1
 
         // Test upper and lower bounds.
@@ -242,7 +242,7 @@ class TextViewTests: XCTestCase {
 
     func testToggleBlockquote() {
         let textView = createTextViewWithContent()
-        let length = textView.text.characters.count
+        let length = textView.text.count
         let range = NSRange(location: 0, length: length)
 
         textView.toggleBlockquote(range: range)
@@ -258,7 +258,7 @@ class TextViewTests: XCTestCase {
 
     func testToggleOrderedList() {
         let textView = createTextViewWithContent()
-        let length = textView.text.characters.count
+        let length = textView.text.count
         let range = NSRange(location: 0, length: length)
 
         textView.toggleOrderedList(range: range)
@@ -274,7 +274,7 @@ class TextViewTests: XCTestCase {
 
     func testToggleUnorderedList() {
         let textView = createTextViewWithContent()
-        let length = textView.text.characters.count
+        let length = textView.text.count
         let range = NSRange(location: 0, length: length)
 
         textView.toggleUnorderedList(range: range)
@@ -354,7 +354,7 @@ class TextViewTests: XCTestCase {
     func testBlockquoteSpansRange() {
         let textView = createTextViewWithContent()
         let range = NSRange(location: 0, length: 1)
-        let length = "Lorem ipsum dolar sit amet.\n".characters.count
+        let length = "Lorem ipsum dolar sit amet.\n".count
 
         textView.toggleBlockquote(range: range)
 
@@ -621,7 +621,7 @@ class TextViewTests: XCTestCase {
         let html = "<h1>Header</h1><br>"
         let textView = createTextView(withHTML: html)
 
-        let range = NSRange(location: textView.text.characters.count, length:0)
+        let range = NSRange(location: textView.text.count, length:0)
         textView.selectedRange = range
         textView.deleteBackward()
 
@@ -749,7 +749,7 @@ class TextViewTests: XCTestCase {
         textView.toggleHeader(.h1, range: .zero)
         textView.insertText("Header Header")
 
-        textView.selectedRange = NSMakeRange("Header".characters.count, 0)
+        textView.selectedRange = NSMakeRange("Header".count, 0)
         textView.insertText("\n")
 
         let identifiers = textView.formatIdentifiersAtIndex(textView.selectedRange.location)
@@ -768,7 +768,7 @@ class TextViewTests: XCTestCase {
     func testBoldWithUnicodeCharacter() {
         let string = "Hello 🌎!"
         let textView = createTextView(withHTML: string)
-        let swiftRange = NSRange(location: 0, length: string.characters.count)
+        let swiftRange = NSRange(location: 0, length: string.count)
         let utf16Range = string.utf16NSRange(from: swiftRange)
 
         textView.toggleBold(range: utf16Range)
@@ -837,11 +837,11 @@ class TextViewTests: XCTestCase {
         textView.selectedTextRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
 
         // Insert Newline
-        var expectedLength = textView.text.characters.count
+        var expectedLength = textView.text.count
         textView.insertText(newline)
-        expectedLength += newline.characters.count
+        expectedLength += newline.count
 
-        XCTAssertEqual(textView.text.characters.count, expectedLength)
+        XCTAssertEqual(textView.text.count, expectedLength)
     }
 
     /// Verifies that New List Items do get their bullet, even when the ending `\n` character was deleted.
@@ -872,8 +872,8 @@ class TextViewTests: XCTestCase {
         textView.insertText(newline + Constants.sampleText1)
 
         // Verify it's still present
-        let secondLineIndex = Constants.sampleText0.characters.count + newline.characters.count
-        let secondLineRange = NSRange(location: secondLineIndex, length: Constants.sampleText1.characters.count)
+        let secondLineIndex = Constants.sampleText0.count + newline.count
+        let secondLineRange = NSRange(location: secondLineIndex, length: Constants.sampleText1.count)
 
         let formatter = TextListFormatter(style: .ordered)
         let present = formatter.present(in: textView.storage, at: secondLineRange)
@@ -1100,11 +1100,11 @@ class TextViewTests: XCTestCase {
         textView.toggleBlockquote(range: .zero)
         textView.selectedTextRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
 
-        var expectedLength = textView.text.characters.count
+        var expectedLength = textView.text.count
         textView.insertText(newline)
-        expectedLength += newline.characters.count
+        expectedLength += newline.count
 
-        XCTAssertEqual(textView.text.characters.count, expectedLength)
+        XCTAssertEqual(textView.text.count, expectedLength)
     }
 
     /// Verifies that New Blockquote Lines do get their style, even when the ending `\n` character was deleted.
@@ -1133,8 +1133,8 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
 
         // Verify it's still present
-        let secondLineIndex = Constants.sampleText0.characters.count + newline.characters.count
-        let secondLineRange = NSRange(location: secondLineIndex, length: Constants.sampleText1.characters.count)
+        let secondLineIndex = Constants.sampleText0.count + newline.count
+        let secondLineRange = NSRange(location: secondLineIndex, length: Constants.sampleText1.count)
 
         let formatter = BlockquoteFormatter()
         let present = formatter.present(in: textView.storage, at: secondLineRange)
@@ -1286,11 +1286,11 @@ class TextViewTests: XCTestCase {
         textView.togglePre(range: .zero)
         textView.selectedTextRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
 
-        var expectedLength = textView.text.characters.count
+        var expectedLength = textView.text.count
         textView.insertText(newline)
-        expectedLength += newline.characters.count
+        expectedLength += newline.count
 
-        XCTAssertEqual(textView.text.characters.count, expectedLength)
+        XCTAssertEqual(textView.text.count, expectedLength)
     }
 
     /// Verifies that New Pre Lines do get their style, even when the ending `\n` character was deleted.
@@ -1319,8 +1319,8 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
 
         // Verify it's still present
-        let secondLineIndex = Constants.sampleText0.characters.count + newline.characters.count
-        let secondLineRange = NSRange(location: secondLineIndex, length: Constants.sampleText1.characters.count)
+        let secondLineIndex = Constants.sampleText0.count + newline.count
+        let secondLineRange = NSRange(location: secondLineIndex, length: Constants.sampleText1.count)
 
         let formatter = PreFormatter()
         let present = formatter.present(in: textView.storage, at: secondLineRange)


### PR DESCRIPTION
### Details:
In this PR we're removing all of the `String` **.characters** references.

### To test:
- Verify that the unit tests are green
- Verify that the Swift 3.2 warnings are gone

cc @diegoreymendez + @SergioEstevao 

Thanks in advance!

