### PR TITLE
Fixed Chinese input issue in header 1~6

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -254,6 +254,9 @@ open class TextStorage: NSTextStorage {
         textStore.replaceCharacters(in: range, with: preprocessedString)
         edited([.editedAttributes, .editedCharacters], range: range, changeInLength: attrString.length - range.length)
 
+        let invalidateRange = NSMakeRange(range.location, attrString.length)
+        invalidateAttributes(in: invalidateRange)
+
         endEditing()
     }
 


### PR DESCRIPTION
Fixes #811 

To test:

1. Open editor
2. Press return
3. Turn Heading on (h1 or h2, ...)
4. Input any Chinese characters and confirm
5. Continue input Chinese characters and confirm