### PR TITLE
Make sure VideoAttachment always have the play icon by default.

### DIFF
--- a/Aztec.xcodeproj/xcshareddata/xcschemes/Aztec.xcscheme
+++ b/Aztec.xcodeproj/xcshareddata/xcschemes/Aztec.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -55,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -70,11 +70,7 @@ open class VideoAttachment: MediaAttachment {
     ///
     open override var overlayImage: UIImage? {
         set(newValue) {
-            if newValue == nil {
-                super.overlayImage = Assets.playIcon
-            } else {
-                super.overlayImage = newValue
-            }
+            super.overlayImage = newValue ?? Assets.playIcon
         }
 
         get {

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -66,6 +66,21 @@ open class VideoAttachment: MediaAttachment {
         super.init(data: contentData, ofType: uti)
     }
 
+    /// An image to display overlaid on top of the media
+    ///
+    open override var overlayImage: UIImage? {
+        set(newValue) {
+            if newValue == nil {
+                super.overlayImage = Assets.playIcon
+            } else {
+                super.overlayImage = newValue
+            }
+        }
+
+        get {
+            return super.overlayImage
+        }
+    }
 
     // MARK: - NSCoder Support
 

--- a/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
+++ b/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
@@ -20,12 +20,27 @@
                ReferencedContainer = "container:AztecExample.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CC400F161E9EC04200859AB4"
+               BuildableName = "AztecUITests.xctest"
+               BlueprintName = "AztecUITests"
+               ReferencedContainer = "container:AztecExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -48,6 +63,16 @@
                ReferencedContainer = "container:AztecExample.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CC400F161E9EC04200859AB4"
+               BuildableName = "AztecUITests.xctest"
+               BlueprintName = "AztecUITests"
+               ReferencedContainer = "container:AztecExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -65,6 +90,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
+++ b/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
@@ -63,16 +63,6 @@
                ReferencedContainer = "container:AztecExample.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CC400F161E9EC04200859AB4"
-               BuildableName = "AztecUITests.xctest"
-               BlueprintName = "AztecUITests"
-               ReferencedContainer = "container:AztecExample.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1081,7 +1081,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
             }
 
             // and mark the newly tapped attachment
-            if (attachment.message == nil) {
+            if attachment.message == nil {
                 let message = NSLocalizedString("Options", comment: "Options to show when tapping on a media object on the post/page editor.")
                 attachment.message = NSAttributedString(string: message, attributes: mediaMessageAttributes)
             }
@@ -1094,7 +1094,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
     func deselected(textAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
         currentSelectedAttachment = nil
         if let mediaAttachment = attachment as? MediaAttachment {
-            self.resetMediaAttachmentOverlay(mediaAttachment)
+            resetMediaAttachmentOverlay(mediaAttachment)
             richTextView.refresh(mediaAttachment)
         }
     }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1067,9 +1067,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
     }
 
     fileprivate func resetMediaAttachmentOverlay(_ mediaAttachment: MediaAttachment) {
-        if mediaAttachment is ImageAttachment {
-            mediaAttachment.overlayImage = nil
-        }
+        mediaAttachment.overlayImage = nil
         mediaAttachment.message = nil
     }
 
@@ -1078,17 +1076,16 @@ extension EditorDemoController: TextViewAttachmentDelegate {
             displayActions(forAttachment: attachment, position: position)
         } else {
             if let selectedAttachment = currentSelectedAttachment {
-                self.resetMediaAttachmentOverlay(selectedAttachment)
+                resetMediaAttachmentOverlay(selectedAttachment)
                 richTextView.refresh(selectedAttachment)
             }
 
             // and mark the newly tapped attachment
-            let message = NSLocalizedString("Options", comment: "Options to show when tapping on a media object on the post/page editor.")
-            attachment.message = NSAttributedString(string: message, attributes: mediaMessageAttributes)
-            if attachment.overlayImage == nil {
-                attachment.overlayImage = Gridicon.iconOfType(.pencil).withRenderingMode(.alwaysTemplate)
-                attachment.overlayImage = Gridicon.iconOfType(.pencil, withSize: CGSize(width: 32.0, height: 32.0)).withRenderingMode(.alwaysTemplate)
+            if (attachment.message == nil) {
+                let message = NSLocalizedString("Options", comment: "Options to show when tapping on a media object on the post/page editor.")
+                attachment.message = NSAttributedString(string: message, attributes: mediaMessageAttributes)
             }
+            attachment.overlayImage = Gridicon.iconOfType(.pencil, withSize: CGSize(width: 32.0, height: 32.0)).withRenderingMode(.alwaysTemplate)
             richTextView.refresh(attachment)
             currentSelectedAttachment = attachment
         }


### PR DESCRIPTION
Fixes #813 

To test:
 - Start the empty demo app
 - Add a new media video object
 - Tap on it
 - Tap on another media
 - See that the icon on the video resets to the play button.
 - Activate the error mode by switch the `errorMode` variable to true on the `EditorDemoController`
 - Repeat the steps above.

