### PR TITLE
TextView: fix undo issue for H1~6, block-quote, ordered list and unordered list

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -757,12 +757,12 @@ open class TextView: UITextView {
 
         let applicationRange = formatter.applicationRange(for: range, in: textStorage)
         let originalString = storage.attributedSubstring(from: applicationRange)
-
-        storage.toggle(formatter: formatter, at: range)
-
+        
         undoManager?.registerUndo(withTarget: self, handler: { [weak self] target in
             self?.undoTextReplacement(of: originalString, finalRange: applicationRange)
         })
+
+        storage.toggle(formatter: formatter, at: range)
 
         if applicationRange.length == 0 {
             typingAttributesSwifted = formatter.toggle(in: typingAttributesSwifted)


### PR DESCRIPTION
Fixes #812

To test:

1. enter one line characters
2. enter another line characters
3. set line one to heading 1~6, block-quote or list
4. shake device and undo
5. loop step 4