### PR TITLE
Resolves some issues with Chinese characters in the editor.

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -42,12 +42,15 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         } else {
             newParagraphStyle.replaceProperty(ofType: Header.self, with: header)
         }
-
-        let targetFontSize = headerFontSize(for: headerLevel, defaultSize: defaultSize)
+ 
+        let targetFontSize = CGFloat(headerFontSize(for: headerLevel, defaultSize: defaultSize))
         var resultingAttributes = attributes
+        
+        let newDescriptor = font.fontDescriptor.addingAttributes([.size: targetFontSize])
+        
         resultingAttributes[.paragraphStyle] = newParagraphStyle
-        resultingAttributes[.font] = font.withSize(CGFloat(targetFontSize))
-
+        resultingAttributes[.font] = UIFont(descriptor: newDescriptor, size: targetFontSize)
+        
         return resultingAttributes
     }
 

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -267,18 +267,16 @@ open class TextStorage: NSTextStorage {
 
         edited([.editedAttributes, .editedCharacters], range: range, changeInLength: attrString.length - range.length)
 
-        let invalidateRange = NSMakeRange(range.location, attrString.length)
-        invalidateAttributes(in: invalidateRange)
-
         endEditing()
     }
 
     override open func setAttributes(_ attrs: [AttributedStringKey: Any]?, range: NSRange) {
         beginEditing()
 
-        let fixedAttributes = ensureMatchingFontAndParagraphHeaderStyles(beforeApplying: attrs ?? [:], at: range)
+        //let fixedAttributes = ensureMatchingFontAndParagraphHeaderStyles(beforeApplying: attrs ?? [:], at: range)
 
-        textStore.setAttributes(fixedAttributes, range: range)
+        //textStore.setAttributes(fixedAttributes, range: range)
+        textStore.setAttributes(attrs, range: range)
         edited(.editedAttributes, range: range, changeInLength: 0)
         
         endEditing()

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -273,10 +273,9 @@ open class TextStorage: NSTextStorage {
     override open func setAttributes(_ attrs: [AttributedStringKey: Any]?, range: NSRange) {
         beginEditing()
 
-        //let fixedAttributes = ensureMatchingFontAndParagraphHeaderStyles(beforeApplying: attrs ?? [:], at: range)
+        let fixedAttributes = ensureMatchingFontAndParagraphHeaderStyles(beforeApplying: attrs ?? [:], at: range)
 
-        //textStore.setAttributes(fixedAttributes, range: range)
-        textStore.setAttributes(attrs, range: range)
+        textStore.setAttributes(fixedAttributes, range: range)
         edited(.editedAttributes, range: range, changeInLength: 0)
         
         endEditing()
@@ -406,7 +405,7 @@ private extension TextStorage {
         guard oldLevel != newLevel else {
             return attrs
         }
-
+        
         return fixFontAttribute(in: attrs, headerLevel: newLevel)
     }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -248,7 +248,6 @@ open class TextView: UITextView {
         }
     }
 
-
     /// Returns the collection of Typing Attributes, with all of the available 'String' keys properly converted into
     /// NSAttributedStringKey. Also known as: what you would expect from the SDK.
     ///
@@ -598,6 +597,13 @@ open class TextView: UITextView {
         caretRect.size.height = usedLineFragment.size.height
 
         return caretRect
+    }
+    
+    // This is only overridden due to iOS 11 issues since it's losing styles.
+    override open func unmarkText() {
+        preserveTypingAttributesForInsertion {
+            super.unmarkText()
+        }
     }
 
     // MARK: - HTML Interaction

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -599,7 +599,14 @@ open class TextView: UITextView {
         return caretRect
     }
     
-    // This is only overridden due to iOS 11 issues since it's losing styles.
+    /// When typing with the Chinese keyboard, the text is automatically marked in the editor.
+    /// You have to press ENTER once to confirm your chosen input.  The problem is that in iOS 11
+    /// the typing attributes are lost when the text is unmarked, causing the font to be lost.
+    /// Since localized characters need specific fonts to be rendered, this causes some characters
+    /// to stop rendering completely.
+    ///
+    /// Reference: https://github.com/wordpress-mobile/AztecEditor-iOS/issues/811
+    ///
     override open func unmarkText() {
         preserveTypingAttributesForInsertion {
             super.unmarkText()


### PR DESCRIPTION
## Description

Fixes #811 
Alternative solution to #820 

Resolves a workaround and improves the code used to change the font size to make it more resilient.

## Testing

### Test 1

1. Launch the editor
2. Press enter
3. Activate H1
4. Type something with the Chinese keyboard
5. Press enter to accept the marked text
6. Press enter again to go to the next line
7. Type something else.
8. Backspace just before what you wrote in point 7, so it goes up to the H1 line.

Make sure the H1 font is applied to the line you just moved up.

### Test 2

1. Launch the editor
2. Press enter
3. Activate H1
4. Type something with the Chinese keyboard
5. Press enter to accept the marked text
6. Keep writing.

Make sure all new characters are still visible.

