### PR TITLE
TextView: Customizable default text color

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -152,8 +152,13 @@ open class TextView: UITextView {
     var defaultMissingImage: UIImage
     
     fileprivate var defaultAttributes: [AttributedStringKey: Any] {
-        return [.font: defaultFont,
-                .paragraphStyle: defaultParagraphStyle]
+        var attributes: [AttributedStringKey: Any] = [.font: defaultFont,
+                                                      .paragraphStyle: defaultParagraphStyle]
+        if let textColor = textColor {
+            attributes[.foregroundColor] = textColor
+        }
+
+        return attributes
     }
 
 


### PR DESCRIPTION
Customize default text color

To test:

1. Change `textView.textColor = UIColor.darkText` to `textView.textColor = UIColor.red` in demo
2. Run the demo
