### PR TITLE
Linked Image Mechanism: Cleanup!

### DIFF
--- a/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
@@ -2,6 +2,15 @@ import Foundation
 import UIKit
 
 
+// MARK: - Constants
+//
+extension String {
+    /// String containing the NSTextAttachment Character
+    ///
+    static let textAttachment = String(UnicodeScalar(NSAttachmentCharacter)!)
+}
+
+
 // MARK: - NSAttributedString Extension for Attachments
 //
 extension NSAttributedString
@@ -9,11 +18,6 @@ extension NSAttributedString
     /// Indicates the Attributed String Length of a single TextAttachment
     ///
     static let lengthOfTextAttachment = NSAttributedString(attachment: NSTextAttachment()).length
-
-
-    /// String containing the NSTextAttachment Character
-    ///
-    static let textAttachmentString = String(UnicodeScalar(NSAttachmentCharacter)!)
 
 
 
@@ -24,7 +28,7 @@ extension NSAttributedString
         var attributesWithAttachment = attributes
         attributesWithAttachment[.attachment] = attachment
 
-        self.init(string: NSAttributedString.textAttachmentString, attributes: attributesWithAttachment)
+        self.init(string: .textAttachment, attributes: attributesWithAttachment)
     }
 
     /// Loads any NSTextAttachment's lazy file reference, into a UIImage instance, in memory.

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -234,21 +234,29 @@ public class ElementNode: Node {
     }
 
 
-    /// Returns the ElementNode instance, whenever there's a *single* child, of the specified nodeType (or nil otherwise).
+    /// If there's exactly just one child node, this method will return it's instance. Otherwise, nil will be returned
+    ///
+    func onlyChild() -> ElementNode? {
+        guard children.count == 1 else {
+            return nil
+        }
+
+        return children.first as? ElementNode
+    }
+
+
+    /// Returns the child ElementNode of the specified nodeType -whenever there's a *single* child-, or nil otherwise.
     ///
     /// - Parameter type: Type of the 'single child' node to be retrieved.
     ///
     /// - Returns: the requested children (if it's the only children in the collection, and if the type matches), or nil otherwise.
     ///
     func onlyChild(ofType type: StandardElementType) -> ElementNode? {
-        guard children.count == 1,
-            let onlyChild = children.first as? ElementNode,
-            onlyChild.isNodeType(type)
-        else {
+        guard let child = onlyChild(), child.isNodeType(type) else {
             return nil
         }
 
-        return onlyChild
+        return child
     }
 
 

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -249,7 +249,7 @@ public class ElementNode: Node {
     ///
     /// - Parameter type: Type of the 'single child' node to be retrieved.
     ///
-    /// - Returns: the requested children (if it's the only children in the collection, and if the type matches), or nil otherwise.
+    /// - Returns: the requested child (if it's the only children in the collection, and if the type matches), or nil otherwise.
     ///
     func onlyChild(ofType type: StandardElementType) -> ElementNode? {
         guard let child = onlyChild(), child.isNodeType(type) else {

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -234,9 +234,9 @@ public class ElementNode: Node {
     }
 
 
-    /// Returns the ElementNode instance, whenever there's a *single* children, of the specified nodeType (or nil otherwise).
+    /// Returns the ElementNode instance, whenever there's a *single* child, of the specified nodeType (or nil otherwise).
     ///
-    /// - Parameter type: Type of the 'single children' node to be retrieved.
+    /// - Parameter type: Type of the 'single child' node to be retrieved.
     ///
     /// - Returns: the requested children (if it's the only children in the collection, and if the type matches), or nil otherwise.
     ///

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -234,6 +234,24 @@ public class ElementNode: Node {
     }
 
 
+    /// Returns the ElementNode instance, whenever there's a *single* children, of the specified nodeType (or nil otherwise).
+    ///
+    /// - Parameter type: Type of the 'single children' node to be retrieved.
+    ///
+    /// - Returns: the requested children (if it's the only children in the collection, and if the type matches), or nil otherwise.
+    ///
+    func onlyChild(ofType type: StandardElementType) -> ElementNode? {
+        guard children.count == 1,
+            let onlyChild = children.first as? ElementNode,
+            onlyChild.isNodeType(type)
+        else {
+            return nil
+        }
+
+        return onlyChild
+    }
+
+
     /// Indicates whether the children of the specified node can be merged in, or not.
     ///
     /// - Parameters:

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -408,7 +408,7 @@ private extension AttributedStringSerializer {
     }
 
 
-    /// Whenever the `element`'s nodeType is `a` (link!), and there's a single children of the `.img` type, this method will return the
+    /// Whenever the `element`'s nodeType is `a` (link!), and there's a single child of the `.img` type, this method will return the
     /// NSAttributedString attributes representing the 'Linked Image' Element.
     ///
     /// - Parameters:

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -406,7 +406,7 @@ private extension AttributedStringSerializer {
 
         switch elementType {
         case .hr, .img, .video:
-            return NSAttributedString(string: String(UnicodeScalar(NSAttachmentCharacter)!), attributes: attributes)
+            return NSAttributedString(string: .textAttachment, attributes: attributes)
         case .br:
             return NSAttributedString(.lineSeparator, attributes: attributes)
         default:

--- a/AztecTests/HTML/Nodes/ElementNodeTests.swift
+++ b/AztecTests/HTML/Nodes/ElementNodeTests.swift
@@ -22,6 +22,7 @@ class ElementNodeTests: XCTestCase {
         XCTAssert(style1 == style1)
     }
 
+
     /// Verifies that two different ElementNode(s) instances, with the same name and the exact same Children array
     /// return true when equality is checked.
     ///
@@ -36,5 +37,35 @@ class ElementNodeTests: XCTestCase {
 
         XCTAssert(style1 == style2)
         XCTAssert(style1 !== style2)
+    }
+
+
+    /// Verifies that `onlyChildr` returns the receiver's only child, if it's type matches with the specified one.
+    ///
+    func testOnlyChildReturnsSingleChildrenIfItRepresentsAnImage() {
+        let image = ElementNode(type: .img)
+        let parent = ElementNode(type: .a, attributes: [], children: [image])
+
+        XCTAssertEqual(parent.onlyChild(ofType: .img), image)
+    }
+
+
+    /// Verifies that `onlyChild` returns nil, if there is more than one children, no matter if their type match with the specified one.
+    ///
+    func testOnlyChildReturnsNilIfThereIsMoreThanOneChild() {
+        let image = ElementNode(type: .img)
+        let parent = ElementNode(type: .a, attributes: [], children: [image, image])
+
+        XCTAssertNil(parent.onlyChild(ofType: .img))
+    }
+
+
+    /// Verifies that `onlyChild` returns nil, if there is at least one child, but with different type.
+    ///
+    func testOnlyChildReturnsNilIfThereIsNoMatchingChild() {
+        let image = ElementNode(type: .img)
+        let parent = ElementNode(type: .a, attributes: [], children: [image])
+
+        XCTAssertNil(parent.onlyChild(ofType: .b))
     }
 }

--- a/AztecTests/HTML/Nodes/ElementNodeTests.swift
+++ b/AztecTests/HTML/Nodes/ElementNodeTests.swift
@@ -40,7 +40,7 @@ class ElementNodeTests: XCTestCase {
     }
 
 
-    /// Verifies that `onlyChildr` returns the receiver's only child, if it's type matches with the specified one.
+    /// Verifies that `onlyChild` returns the receiver's only child, if it's type matches with the specified one.
     ///
     func testOnlyChildReturnsSingleChildrenIfItRepresentsAnImage() {
         let image = ElementNode(type: .img)


### PR DESCRIPTION
### Details:
This PR introduces no new functionality. We're:

1. Encapsulating the **linkedImage** parsing mechanism, into it's own method
2. Moving the `textAttachment` constant over to a String extension, for convenience
3. Adding a small method to ElementNode (and few unit tests!)

### To test:
1. Verify that the unit tests are green
2. Add a linked image `<a href="www.wordpress.com"><img src="www.something.com/img"></a>`
3. Try toggling back and forth, and verity that the HTML is preserved

Needs Review: @diegoreymendez 
Thanks in advance!

