### PR TITLE
Refactor implementation of  links on image

### DIFF
--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -897,15 +897,7 @@ private extension AttributedStringParser {
                 finalValue = baseComponents.union(extraComponents).joined(separator: " ")
             }
             element.updateAttribute(named: key, value: .string(finalValue))
-        }
-
-        if let linkText = attachment.linkURL?.absoluteString {
-            let hrefValue = Attribute.Value(withString: linkText)
-            let hrefAttribute = Attribute(name: HTMLLinkAttribute.Href.rawValue, value: hrefValue)
-            let linkElement = ElementNode(type: .a, attributes: [hrefAttribute], children: [element])
-
-            return linkElement
-        }
+        }        
 
         return element
     }

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -376,19 +376,6 @@ private extension AttributedStringSerializer {
         guard let elementType = element.standardName else {
             return nil
         }
-        
-        if let imgElement = linkedImageElement(for: element) {
-            var attributesWithoutLink = attributes
-            attributesWithoutLink[.link] = nil
-            attributesWithoutLink[.linkHtmlRepresentation] = nil
-
-            let imgAttributes = self.attributes(for: imgElement, inheriting: attributesWithoutLink)
-            let attachment = imgAttributes[.attachment] as! ImageAttachment
-            let linkText = element.stringValueForAttribute(named: HTMLLinkAttribute.Href.rawValue) ?? ""
-            attachment.linkURL = URL(string: linkText)
-            
-            return implicitRepresentation(for: imgElement, inheriting: imgAttributes)!
-        }
 
         return implicitRepresentation(for: elementType, inheriting: attributes)
     }

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -5,11 +5,7 @@ import UIKit
 /// Custom text attachment.
 ///
 open class ImageAttachment: MediaAttachment {
-
-    /// Attachment Link URL
-    ///
-    open var linkURL: URL?
-
+    
     /// Attachment Alignment
     ///
     open var alignment: Alignment = .center {
@@ -59,8 +55,6 @@ open class ImageAttachment: MediaAttachment {
                 self.size = size
             }
         }
-
-        linkURL = aDecoder.decodeObject(forKey: EncodeKeys.linkURL.rawValue) as? URL
     }
 
     /// Required Initializer
@@ -76,15 +70,11 @@ open class ImageAttachment: MediaAttachment {
         super.encode(with: aCoder)
         aCoder.encode(alignment.rawValue, forKey: EncodeKeys.alignment.rawValue)
         aCoder.encode(size.rawValue, forKey: EncodeKeys.size.rawValue)
-        if let linkURL = self.linkURL {
-            aCoder.encode(linkURL, forKey: EncodeKeys.linkURL.rawValue)
-        }
     }
 
     fileprivate enum EncodeKeys: String {
         case alignment
-        case size
-        case linkURL
+        case size        
     }
 
 
@@ -140,7 +130,6 @@ extension ImageAttachment {
 
         clone.size = size
         clone.alignment = alignment
-        clone.linkURL = linkURL
 
         return clone
     }

--- a/Example/Example/AttachmentDetailsViewController.swift
+++ b/Example/Example/AttachmentDetailsViewController.swift
@@ -11,6 +11,7 @@ class AttachmentDetailsViewController: UITableViewController
     @IBOutlet var altTextField: UITextField!
 
     var attachment: ImageAttachment?
+    var linkURL: URL?
     var onUpdate: ((_ alignment: ImageAttachment.Alignment, _ size: ImageAttachment.Size, _ imageURL: URL, _ linkURL: URL?, _ altText: String?) -> Void)?
 
 
@@ -45,7 +46,7 @@ class AttachmentDetailsViewController: UITableViewController
 
         sourceURLTextField.text = attachment.url?.absoluteString
 
-        linkURLTextField.text = attachment.linkURL?.absoluteString
+        linkURLTextField.text = linkURL?.absoluteString
 
         altTextField.text = attachment.extraAttributes["alt"]
     }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -47,6 +47,7 @@ class EditorDemoController: UIViewController {
 
         if #available(iOS 11, *) {
             textView.smartDashesType = .no
+            textView.smartQuotesType = .no
         }
 
         return textView
@@ -73,6 +74,7 @@ class EditorDemoController: UIViewController {
 
         if #available(iOS 11, *) {
             textView.smartDashesType = .no
+            textView.smartQuotesType = .no
         }
 
         return textView

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1228,7 +1228,9 @@ private extension EditorDemoController
         
         let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange, sourceURL: fileURL, placeHolderImage: image)
         attachment.size = .full
-        attachment.linkURL = fileURL
+        if let attachmentRange = richTextView.textStorage.ranges(forAttachment: attachment).first {
+            richTextView.setLink(fileURL, inRange: attachmentRange)
+        }
         let imageID = attachment.identifier
         let progress = Progress(parent: nil, userInfo: [MediaProgressKey.mediaID: imageID])
         progress.totalUnitCount = 100
@@ -1336,8 +1338,19 @@ private extension EditorDemoController
     }
 
     func displayDetailsForAttachment(_ attachment: ImageAttachment, position:CGPoint) {
+        guard let attachmentRange = richTextView.textStorage.ranges(forAttachment: attachment).first else {
+            return
+        }
         let detailsViewController = AttachmentDetailsViewController.controller()
         detailsViewController.attachment = attachment
+        var oldURL: URL?
+        if let linkRange = richTextView.linkFullRange(forRange: attachmentRange),
+           let url = richTextView.linkURL(forRange: attachmentRange),
+           attachmentRange == linkRange {
+           oldURL = url
+           detailsViewController.linkURL = url
+        }
+        
         detailsViewController.onUpdate = { (alignment, size, url, linkURL, alt) in
             self.richTextView.edit(attachment) { updated in
                 if let alt = alt {
@@ -1346,9 +1359,14 @@ private extension EditorDemoController
 
                 updated.alignment = alignment
                 updated.size = size
-                updated.linkURL = linkURL
 
                 updated.updateURL(url)
+            }
+            // Update associated link
+            if let updatedURL = linkURL {
+                self.richTextView.setLink(updatedURL, inRange: attachmentRange)
+            } else if oldURL != nil && linkURL == nil {
+                self.richTextView.removeLink(inRange: attachmentRange)
             }
         }
 

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -106,6 +106,10 @@ Block Quote:
 <p>
 <img src="https://httpbin.org/image/jpeg" alt="Coyote" />
 </p>
+<h4>Image with link:</h4>
+<p>
+<a href="www.automattic.com"><img src="https://httpbin.org/image/jpeg" alt="Coyote" /></a>
+</p>
 <h4>Image with caption:</h4>
 <p>
 [caption id="attachment_6" align="alignright" width="300"]<img src="https://httpbin.org/image/jpeg" alt="Coyote" />Ahoi![/caption]


### PR DESCRIPTION
This PR, refactor the implementation of links on images.

Instead of using a custom property on ImageAttachment and doing some special parsing, this kept the parsing clean, just parsing the elements normally.

Then when tapping on the img it detects if a link is surrounding just the image and edits that link if available.

To test:
 - Start the demo app
 - Open the empty demo
 - Insert an image
 - Switch to html and see if link is there
 - Switch back to Visual mode
 - Tap on the image
 - Change the link
