### PR TITLE
Try/refactor media attachment

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/ImageFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/ImageFormatter.swift
@@ -23,14 +23,13 @@ class ImageFormatter: StandardAttributeFormatter {
 
                 let url: URL?
 
-                if let urlString = element.attribute(named: "src")?.value.toString() {
-                    extraAttributes.removeValue(forKey: "src")
-                    url = URL(string: urlString)
+                if let srcString = element.attribute(named: "src")?.value.toString() {
+                    url = URL(string: srcString)
                 } else {
                     url = nil
                 }
 
-                let attachment = ImageAttachment(identifier: UUID().uuidString, url: url)
+                let attachment = ImageAttachment(identifier: UUID().uuidString, src: url)
                 attachment.extraAttributes = extraAttributes
                 attributeValue = attachment
             default:

--- a/Aztec/Classes/Formatters/Implementations/ImageFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/ImageFormatter.swift
@@ -30,32 +30,7 @@ class ImageFormatter: StandardAttributeFormatter {
                     url = nil
                 }
 
-                    let attachment = ImageAttachment(identifier: UUID().uuidString, url: url)
-
-                if let elementClass = element.attribute(named: "class")?.value.toString() {
-                    let classAttributes = elementClass.components(separatedBy: " ")
-                    var attributesToRemove = [String]()
-                    for classAttribute in classAttributes {
-                        if let alignment = ImageAttachment.Alignment.fromHTML(string: classAttribute) {
-                            attachment.alignment = alignment
-                            attributesToRemove.append(classAttribute)
-                        }
-                        if let size = ImageAttachment.Size.fromHTML(string: classAttribute) {
-                            attachment.size = size
-                            attributesToRemove.append(classAttribute)
-                        }
-                    }
-                    let otherAttributes = classAttributes.filter({ (value) -> Bool in
-                        return !attributesToRemove.contains(value)
-                    })
-                    let remainingClassAttributes = otherAttributes.joined(separator: " ")
-                    if remainingClassAttributes.isEmpty {
-                        extraAttributes.removeValue(forKey: "class")
-                    } else {
-                        extraAttributes["class"] = remainingClassAttributes
-                    }
-                }
-
+                let attachment = ImageAttachment(identifier: UUID().uuidString, url: url)
                 attachment.extraAttributes = extraAttributes
                 attributeValue = attachment
             default:

--- a/Aztec/Classes/Formatters/Implementations/VideoFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/VideoFormatter.swift
@@ -25,7 +25,6 @@ class VideoFormatter: StandardAttributeFormatter {
 
             if let urlString = element.attribute(named: "src")?.value.toString() {
                 srcURL = URL(string: urlString)
-                extraAttributes.removeValue(forKey: "src")
             } else {
                 srcURL = nil
             }
@@ -34,7 +33,6 @@ class VideoFormatter: StandardAttributeFormatter {
 
             if let urlString = element.attribute(named: "poster")?.value.toString() {
                 posterURL = URL(string: urlString)
-                extraAttributes.removeValue(forKey: "poster")
             } else {
                 posterURL = nil
             }

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -885,18 +885,8 @@ private extension AttributedStringParser {
             element.updateAttribute(named: attribute.name, value: attribute.value)
         }
 
-        if let attribute = imageClassAttribute(from: attachment) {
-            element.updateAttribute(named: attribute.name, value: attribute.value)
-        }
-
         for (key,value) in attachment.extraAttributes {
-            var finalValue = value
-            if key == "class", let baseValue = element.stringValueForAttribute(named: "class"){
-                let baseComponents = Set(baseValue.components(separatedBy: " "))
-                let extraComponents = Set(value.components(separatedBy: " "))
-                finalValue = baseComponents.union(extraComponents).joined(separator: " ")
-            }
-            element.updateAttribute(named: key, value: .string(finalValue))
+            element.updateAttribute(named: key, value: .string(value))
         }        
 
         return element
@@ -985,26 +975,5 @@ private extension AttributedStringParser {
         }
 
         return Attribute(name: "src", value: .string(source))
-    }
-
-
-    /// Extracts the class attribute from an ImageAttachment Instance.
-    ///
-    private func imageClassAttribute(from attachment: ImageAttachment) -> Attribute? {
-        var style = String()
-        if attachment.alignment != .center {
-            style += attachment.alignment.htmlString()
-        }
-        
-        if attachment.size != .none {
-            style += style.isEmpty ? String() : String(.space)
-            style += attachment.size.htmlString()
-        }
-
-        guard !style.isEmpty else {
-            return nil
-        }
-
-        return Attribute(name: "class", value: .string(style))
     }
 }

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -879,11 +879,7 @@ private extension AttributedStringParser {
             element = representationElement.toElementNode()
         } else {
             element = ElementNode(type: .img)
-        }
-
-        if let attribute = imageSourceAttribute(from: attachment) {
-            element.updateAttribute(named: attribute.name, value: attribute.value)
-        }
+        }        
 
         for (key,value) in attachment.extraAttributes {
             element.updateAttribute(named: key, value: .string(value))
@@ -908,15 +904,7 @@ private extension AttributedStringParser {
             element = representationElement.toElementNode()
         } else {
             element = ElementNode(type: .video)
-        }
-
-        if let attribute = videoSourceAttribute(from: attachment) {
-            element.updateAttribute(named: attribute.name, value: attribute.value)
-        }
-
-        if let attribute = videoPosterAttribute(from: attachment) {
-            element.updateAttribute(named: attribute.name, value: attribute.value)
-        }
+        }        
 
         for (key,value) in attachment.extraAttributes {
             element.updateAttribute(named: key, value: .string(value))
@@ -942,38 +930,5 @@ private extension AttributedStringParser {
         }
         
         return output
-    }
-
-
-    /// Extracts the Video Source Attribute from a VideoAttachment Instance.
-    ///
-    private func videoSourceAttribute(from attachment: VideoAttachment) -> Attribute? {
-        guard let source = attachment.srcURL?.absoluteString else {
-            return nil
-        }
-
-        return Attribute(name: "src", value: .string(source))
-    }
-
-
-    /// Extracts the Video Poster Attribute from a VideoAttachment Instance.
-    ///
-    private func videoPosterAttribute(from attachment: VideoAttachment) -> Attribute? {
-        guard let poster = attachment.posterURL?.absoluteString else {
-            return nil
-        }
-
-        return Attribute(name: "poster", value: .string(poster))
-    }
-
-
-    /// Extracts the src attribute from an ImageAttachment Instance.
-    ///
-    private func imageSourceAttribute(from attachment: ImageAttachment) -> Attribute? {
-        guard let source = attachment.url?.absoluteString else {
-            return nil
-        }
-
-        return Attribute(name: "src", value: .string(source))
     }
 }

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -6,88 +6,6 @@ import UIKit
 ///
 open class ImageAttachment: MediaAttachment {
 
-    /// Attachment Link URL
-    ///
-    open var linkURL: URL?
-
-    /// Attachment Alignment
-    ///
-    open var alignment: Alignment = .center {
-        willSet {
-            if newValue != alignment {
-                glyphImage = nil
-            }
-        }
-    }
-
-    /// Attachment Size
-    ///
-    open var size: Size = .none {
-        willSet {
-            if newValue != size {
-                glyphImage = nil
-            }
-        }
-    }
-
-
-    /// Creates a new attachment
-    ///
-    /// - Parameters:
-    ///   - identifier: An unique identifier for the attachment
-    ///   - url: the url that represents the image
-    ///
-    required public init(identifier: String, url: URL? = nil) {
-        super.init(identifier: identifier, url: url)
-    }
-
-
-    /// Required Initializer
-    ///
-    required public init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-
-        if aDecoder.containsValue(forKey: EncodeKeys.alignment.rawValue) {
-            let alignmentRaw = aDecoder.decodeInteger(forKey: EncodeKeys.alignment.rawValue)
-            if let alignment = Alignment(rawValue:alignmentRaw) {
-                self.alignment = alignment
-            }
-        }
-        if aDecoder.containsValue(forKey: EncodeKeys.size.rawValue) {
-            let sizeRaw = aDecoder.decodeInteger(forKey: EncodeKeys.size.rawValue)
-            if let size = Size(rawValue:sizeRaw) {
-                self.size = size
-            }
-        }
-
-        linkURL = aDecoder.decodeObject(forKey: EncodeKeys.linkURL.rawValue) as? URL
-    }
-
-    /// Required Initializer
-    ///
-    required public init(data contentData: Data?, ofType uti: String?) {
-        super.init(data: contentData, ofType: uti)
-    }
-
-
-    // MARK: - NSCoder Support
-
-    override open func encode(with aCoder: NSCoder) {
-        super.encode(with: aCoder)
-        aCoder.encode(alignment.rawValue, forKey: EncodeKeys.alignment.rawValue)
-        aCoder.encode(size.rawValue, forKey: EncodeKeys.size.rawValue)
-        if let linkURL = self.linkURL {
-            aCoder.encode(linkURL, forKey: EncodeKeys.linkURL.rawValue)
-        }
-    }
-
-    fileprivate enum EncodeKeys: String {
-        case alignment
-        case size
-        case linkURL
-    }
-
-
     // MARK: - Origin calculation
 
     override func xPosition(forContainerWidth containerWidth: CGFloat) -> CGFloat {
@@ -150,6 +68,62 @@ extension ImageAttachment {
 // MARL: - Nested Types
 //
 extension ImageAttachment {
+
+    /// Attachment Link URL
+    ///
+    open var linkURL: URL? {
+        get {
+            if let stringURL = extraAttributes["data_wp_link_url"], let url = URL(string: stringURL) {
+                return url
+            } else {
+                return nil
+            }
+        }
+
+        set {
+            extraAttributes["data_wp_link_url"] = newValue?.absoluteString
+        }
+    }
+
+    /// Attachment Alignment
+    ///
+    open var alignment: Alignment {
+        get {
+            if let classValue = extraAttributes["data_wp_class_align"], let value = Alignment.fromHTML(string: classValue) {
+                return value
+            } else {
+                return .center
+            }
+        }
+
+        set {
+            let currentValue = alignment
+            extraAttributes["data_wp_class_align"] = newValue.htmlString()
+            if newValue != currentValue {
+                glyphImage = nil
+            }
+        }
+    }
+
+    /// Attachment Size
+    ///
+    open var size: Size {
+        get {
+            if let classValue = extraAttributes["data_wp_class_size"], let value = Size.fromHTML(string: classValue) {
+                return value
+            } else {
+                return .none
+            }
+        }
+
+        set {
+            let currentValue = size
+            extraAttributes["data_wp_class_size"] = newValue.htmlString()
+            if newValue != currentValue {
+                glyphImage = nil
+            }
+        }
+    }
 
     /// Alignment
     ///

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -54,10 +54,7 @@ extension ImageAttachment {
     override public func copy(with zone: NSZone? = nil) -> Any {
         guard let clone = super.copy(with: nil) as? ImageAttachment else {
             fatalError()
-        }
-
-        clone.size = size
-        clone.alignment = alignment
+        }        
 
         return clone
     }
@@ -67,22 +64,6 @@ extension ImageAttachment {
 // MARL: - Nested Types
 //
 extension ImageAttachment {
-
-    /// Attachment Link URL
-    ///
-    open var linkURL: URL? {
-        get {
-            if let stringURL = extraAttributes["data_wp_link_url"], let url = URL(string: stringURL) {
-                return url
-            } else {
-                return nil
-            }
-        }
-
-        set {
-            extraAttributes["data_wp_link_url"] = newValue?.absoluteString
-        }
-    }
 
     /// Attachment Alignment
     ///

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -88,18 +88,39 @@ extension ImageAttachment {
     ///
     open var alignment: Alignment {
         get {
-            if let classValue = extraAttributes["data_wp_class_align"], let value = Alignment.fromHTML(string: classValue) {
-                return value
-            } else {
+            guard let elementClass = extraAttributes["class"] else {
                 return .center
             }
+            let classAttributes = elementClass.components(separatedBy: " ")            
+            for classAttribute in classAttributes {
+                if let alignment = ImageAttachment.Alignment.fromHTML(string: classAttribute) {
+                    return alignment
+                }
+            }
+            return .center
         }
 
         set {
-            let currentValue = alignment
-            extraAttributes["data_wp_class_align"] = newValue.htmlString()
-            if newValue != currentValue {
-                glyphImage = nil
+            if let elementClass = extraAttributes["class"] {
+                let classAttributes = elementClass.components(separatedBy: " ")
+                var attributesToRemove = [String]()
+                for classAttribute in classAttributes {
+                    if let _ = ImageAttachment.Alignment.fromHTML(string: classAttribute) {
+                        attributesToRemove.append(classAttribute)
+                    }
+                }
+                var otherAttributes = classAttributes.filter({ (value) -> Bool in
+                    return !attributesToRemove.contains(value)
+                })
+                otherAttributes.append(newValue.htmlString())
+                let newClassAttributes = otherAttributes.joined(separator: " ")
+                if newClassAttributes.isEmpty {
+                    extraAttributes.removeValue(forKey: "class")
+                } else {
+                    extraAttributes["class"] = newClassAttributes
+                }
+            } else {
+                extraAttributes["class"] = newValue.htmlString()
             }
         }
     }
@@ -108,18 +129,39 @@ extension ImageAttachment {
     ///
     open var size: Size {
         get {
-            if let classValue = extraAttributes["data_wp_class_size"], let value = Size.fromHTML(string: classValue) {
-                return value
-            } else {
+            guard let elementClass = extraAttributes["class"] else {
                 return .none
             }
+            let classAttributes = elementClass.components(separatedBy: " ")
+            for classAttribute in classAttributes {
+                if let alignment = ImageAttachment.Size.fromHTML(string: classAttribute) {
+                    return alignment
+                }
+            }
+            return .none
         }
 
         set {
-            let currentValue = size
-            extraAttributes["data_wp_class_size"] = newValue.htmlString()
-            if newValue != currentValue {
-                glyphImage = nil
+            if let elementClass = extraAttributes["class"] {
+                let classAttributes = elementClass.components(separatedBy: " ")
+                var attributesToRemove = [String]()
+                for classAttribute in classAttributes {
+                    if let _ = ImageAttachment.Size.fromHTML(string: classAttribute) {
+                        attributesToRemove.append(classAttribute)
+                    }
+                }
+                var otherAttributes = classAttributes.filter({ (value) -> Bool in
+                    return !attributesToRemove.contains(value)
+                })
+                otherAttributes.append(newValue.htmlString())
+                let newClassAttributes = otherAttributes.joined(separator: " ")
+                if newClassAttributes.isEmpty {
+                    extraAttributes.removeValue(forKey: "class")
+                } else {
+                    extraAttributes["class"] = newClassAttributes
+                }
+            } else {
+                extraAttributes["class"] = newValue.htmlString()
             }
         }
     }

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -6,6 +6,29 @@ import UIKit
 ///
 open class ImageAttachment: MediaAttachment {
 
+    required public init(identifier: String, src: URL? = nil) {
+        super.init(identifier: identifier)
+        self.src = src
+    }
+
+    /// Required Initializer
+    ///
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    /// Required Initializer
+    ///
+    required public init(identifier: String) {
+        super.init(identifier: identifier)
+    }
+
+    /// Required Initializer
+    ///
+    required public init(data contentData: Data?, ofType uti: String?) {
+        super.init(data: contentData, ofType: uti)
+    }
+
     // MARK: - Origin calculation
 
     override func xPosition(forContainerWidth containerWidth: CGFloat) -> CGFloat {
@@ -64,6 +87,17 @@ extension ImageAttachment {
 // MARL: - Nested Types
 //
 extension ImageAttachment {
+
+    open var src: URL? {
+        get {
+            return url
+        }
+
+        set {
+            extraAttributes["src"] = newValue?.absoluteString
+            updateURL(newValue)
+        }
+    }
 
     /// Attachment Alignment
     ///

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -132,6 +132,7 @@ open class MediaAttachment: NSTextAttachment {
 
         identifier = aDecoder.decodeObject(forKey: EncodeKeys.identifier.rawValue) as? String ?? identifier
         url = aDecoder.decodeObject(forKey: EncodeKeys.url.rawValue) as? URL
+        extraAttributes = aDecoder.decodeObject(forKey: EncodeKeys.attributes.rawValue) as? [String:String] ?? [String:String]()
     }
 
     /// Required Initializer
@@ -172,6 +173,7 @@ open class MediaAttachment: NSTextAttachment {
         if let url = self.url {
             aCoder.encode(url, forKey: EncodeKeys.url.rawValue)
         }
+        aCoder.encode(extraAttributes, forKey: EncodeKeys.attributes.rawValue)
     }
 
 
@@ -425,6 +427,7 @@ private extension MediaAttachment {
     enum EncodeKeys: String {
         case identifier
         case url
+        case attributes
     }
 
     /// Constants

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -108,10 +108,8 @@ open class MediaAttachment: NSTextAttachment {
     ///   - identifier: An unique identifier for the attachment
     ///   - url: the url that represents the image
     ///
-    required public init(identifier: String, url: URL? = nil) {
-        self.identifier = identifier
-        self.url = url
-
+    required public init(identifier: String) {
+        self.identifier = identifier        
         super.init(data: nil, ofType: nil)
     }
 
@@ -406,7 +404,7 @@ private extension MediaAttachment {
 extension MediaAttachment: NSCopying {
 
     public func copy(with zone: NSZone? = nil) -> Any {
-        let clone = type(of: self).init(identifier: identifier, url: url)
+        let clone = type(of: self).init(identifier: identifier)
         clone.image = image
         clone.extraAttributes = extraAttributes
         clone.url = url

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1263,7 +1263,7 @@ open class TextView: UITextView {
     ///
     @discardableResult
     open func replaceWithImage(at range: NSRange, sourceURL url: URL, placeHolderImage: UIImage?, identifier: String = UUID().uuidString) -> ImageAttachment {
-        let attachment = ImageAttachment(identifier: identifier, url: url)
+        let attachment = ImageAttachment(identifier: identifier, src: url)
         attachment.delegate = storage
         attachment.image = placeHolderImage
         replace(at: range, with: attachment)

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -15,31 +15,14 @@ protocol VideoAttachmentDelegate: class {
 ///
 open class VideoAttachment: MediaAttachment {
 
-    /// Attachment video URL
-    ///
-    open var srcURL: URL?
-
-    /// Video poster image to show, while the video is not played.
-    ///
-    open var posterURL: URL? {
-        get {
-            return self.url
-        }
-
-        set {
-            super.updateURL(newValue)
-        }
-    }    
-    
     /// Creates a new attachment
     ///
     /// - parameter identifier: An unique identifier for the attachment
     ///
     required public init(identifier: String, srcURL: URL? = nil, posterURL: URL? = nil) {
-        self.srcURL = srcURL
-        
-        super.init(identifier: identifier, url: posterURL)
-
+        super.init(identifier: identifier)
+        self.src = srcURL
+        self.poster = posterURL
         self.overlayImage = Assets.playIcon
     }
 
@@ -47,17 +30,12 @@ open class VideoAttachment: MediaAttachment {
     ///
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-
-        if aDecoder.containsValue(forKey: EncodeKeys.srcURL.rawValue) {
-            srcURL = aDecoder.decodeObject(forKey: EncodeKeys.srcURL.rawValue) as? URL
-        }
     }
 
     /// Required Initializer
     ///
-    required public init(identifier: String, url: URL?) {
-        self.srcURL = nil
-        super.init(identifier: identifier, url: url)
+    required public init(identifier: String) {
+        super.init(identifier: identifier)
     }
 
     /// Required Initializer
@@ -82,15 +60,7 @@ open class VideoAttachment: MediaAttachment {
 
     override open func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
-        if let url = self.srcURL {
-            aCoder.encode(url, forKey: EncodeKeys.srcURL.rawValue)
-        }
     }
-
-    fileprivate enum EncodeKeys: String {
-        case srcURL
-    }
-
 
     // MARK: - Origin calculation
 
@@ -125,14 +95,28 @@ open class VideoAttachment: MediaAttachment {
 //
 extension VideoAttachment {
 
-    override public func copy(with zone: NSZone? = nil) -> Any {
-        guard let clone = super.copy() as? VideoAttachment else {
-            fatalError()
+    open var poster: URL? {
+        get {
+            return url
         }
 
-        clone.srcURL = srcURL
-        clone.posterURL = posterURL
+        set {
+            extraAttributes["poster"] = newValue?.absoluteString
+            updateURL(newValue)
+        }
+    }
 
-        return clone
+    open var src: URL? {
+        get {
+            if let src = extraAttributes["src"] {
+                return URL(string: src)
+            } else {
+                return nil
+            }
+        }
+
+        set {
+            extraAttributes["src"] = newValue?.absoluteString
+        }
     }
 }

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -90,7 +90,7 @@ class TextStorageTests: XCTestCase {
     }
 
     func testDelegateCallbackWhenAttachmentRemoved() {
-        let attachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"test://")!)
+        let attachment = ImageAttachment(identifier: UUID().uuidString, src: URL(string:"test://")!)
         storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
 
         storage.replaceCharacters(in: NSRange(location: 0, length: 1) , with: NSAttributedString(string:""))
@@ -128,7 +128,7 @@ class TextStorageTests: XCTestCase {
     }    
 
     func testInsertImage() {
-        let attachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"https://wordpress.com")!)
+        let attachment = ImageAttachment(identifier: UUID().uuidString, src: URL(string:"https://wordpress.com")!)
         storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
 
         let html = storage.getHTML(serializer: serializer)
@@ -142,7 +142,7 @@ class TextStorageTests: XCTestCase {
     ///
     func testEditingImageAttachmentAfterItHasBeenInsertedCausesItsAttributesToProperlySerialize() {
         let url = URL(string: "https://wordpress.com")!
-        let attachment = ImageAttachment(identifier: UUID().uuidString, url: url)
+        let attachment = ImageAttachment(identifier: UUID().uuidString, src: url)
 
         storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
 
@@ -311,10 +311,10 @@ class TextStorageTests: XCTestCase {
     /// This test check if the insertion of two images one after the other works correctly and to img tag are inserted
     ///
     func testInsertOneImageAfterTheOther() {
-        let firstAttachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"https://wordpress.com")!)
+        let firstAttachment = ImageAttachment(identifier: UUID().uuidString, src: URL(string:"https://wordpress.com")!)
         storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: firstAttachment))
 
-        let secondAttachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"https://wordpress.org")!)
+        let secondAttachment = ImageAttachment(identifier: UUID().uuidString, src: URL(string:"https://wordpress.org")!)
         storage.replaceCharacters(in: NSRange(location:1, length: 0), with: NSAttributedString(attachment: secondAttachment))
 
         let html = storage.getHTML(serializer: serializer)
@@ -327,10 +327,10 @@ class TextStorageTests: XCTestCase {
     /// This test check if the insertion of two images one after the other works correctly and to img tag are inserted
     ///
     func testInsertSameImageAfterTheOther() {
-        let firstAttachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"https://wordpress.com")!)
+        let firstAttachment = ImageAttachment(identifier: UUID().uuidString, src: URL(string:"https://wordpress.com")!)
         storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: firstAttachment))
 
-        let secondAttachment = ImageAttachment(identifier: UUID().uuidString, url: URL(string:"https://wordpress.com")!)
+        let secondAttachment = ImageAttachment(identifier: UUID().uuidString, src: URL(string:"https://wordpress.com")!)
         storage.replaceCharacters(in: NSRange(location:1, length: 0), with: NSAttributedString(attachment: secondAttachment))
         let html = storage.getHTML(serializer: serializer)
 
@@ -352,7 +352,7 @@ class TextStorageTests: XCTestCase {
 
         for _ in 0 ..< count {
             let sourceURL = URL(string:"test://")!
-            let attachment = ImageAttachment(identifier: UUID().uuidString, url: sourceURL)
+            let attachment = ImageAttachment(identifier: UUID().uuidString, src: sourceURL)
             storage.replaceCharacters(in: NSRange(location:0, length: 0), with: NSAttributedString(attachment: attachment))
 
             identifiers.append(attachment.identifier)

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1428,7 +1428,7 @@ class TextViewTests: XCTestCase {
             fatalError()
         }
 
-        videoAttachment.srcURL = URL(string:"newVideo.mp4")!
+        videoAttachment.src = URL(string:"newVideo.mp4")!
         textView.refresh(videoAttachment)
 
         XCTAssertEqual(textView.getHTML(), "<p><video src=\"newVideo.mp4\" poster=\"video.jpg\" alt=\"The video\"></video></p>")

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1576,7 +1576,7 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(attachment.extraAttributes["title"], "Title", "Title Property should be available")
 
         attachment.extraAttributes["alt"] = "Changed Alt"
-        attachment.extraAttributes["class"] = "wp-image-169"
+        attachment.extraAttributes["class"] = (attachment.extraAttributes["class"] ?? "") + " wp-image-169"
 
         XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone wp-image-169\" title=\"Title\" alt=\"Changed Alt\"></p>")
     }

--- a/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
+++ b/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
@@ -64,7 +64,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CC400F161E9EC04200859AB4"

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1276,7 +1276,7 @@ private extension EditorDemoController
             timer.invalidate()
             attachment.progress = nil
             if let videoAttachment = attachment as? VideoAttachment, let videoURL = progress.userInfo[MediaProgressKey.videoURL] as? URL {
-                videoAttachment.srcURL = videoURL
+                videoAttachment.src = videoURL
             }
         }
         richTextView.refresh(attachment)
@@ -1320,7 +1320,7 @@ private extension EditorDemoController
                                                 self.displayDetailsForAttachment(imageAttachment, position: position)
             })
             alertController.addAction(detailsAction)
-        } else if let videoAttachment = attachment as? VideoAttachment, let videoURL = videoAttachment.srcURL {
+        } else if let videoAttachment = attachment as? VideoAttachment, let videoURL = videoAttachment.src {
             let detailsAction = UIAlertAction(title:NSLocalizedString("Play Video", comment: "User action to play video."),
                                               style: .default,
                                               handler: { (action) in


### PR DESCRIPTION
This PR changes the way attributes for MediaAttachment are implemented, instead of having custom properties directly implemented in the ImageAttachment and VideoAttachment, all the properties are stored and accessed through the use of `extraAttributes` property, and are calculated variables implemented in extensions.

In my point of view this has the following advantages:

- Simpler parser and serialiser, because we don't need to do extra steps for the specific properties
- Allows expansibility of properties by the users of the library.
- Still allows to create specific enums for properties to make it easier to use.

To test:
 - Check if the project compile and unit test are ok.
 - Start the app, check interactions with image and video are working ok.
