### PR TITLE
TextView: fix link range issue

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1442,7 +1442,7 @@ open class TextView: UITextView {
         let index = maxIndex(range.location)
         var effectiveRange = NSRange()
         guard index < storage.length,
-            storage.attribute(.link, at: index, effectiveRange: &effectiveRange) != nil
+            storage.attribute(.link, at: index, longestEffectiveRange: &effectiveRange, in: NSMakeRange(0, storage.length)) != nil
             else {
                 return nil
         }


### PR DESCRIPTION
Fixes #853 

To test:

1. Insert a link with title 你好 世界
2. Move caret to 你好 and edit the link