### PR TITLE
Basic Dynamic Type support

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
@@ -18,7 +18,15 @@ open class PreFormatter: ParagraphAttributeFormatter {
     /// Designated Initializer
     ///
     init(monospaceFont: UIFont = UIFont(descriptor:UIFontDescriptor(name: "Courier", size: 12), size:12), placeholderAttributes: [AttributedStringKey : Any]? = nil) {
-        self.monospaceFont = monospaceFont
+        let font: UIFont
+
+        if #available(iOS 11.0, *) {
+            font = UIFontMetrics.default.scaledFont(for: monospaceFont)
+        } else {
+            font = monospaceFont
+        }
+
+        self.monospaceFont = font
         self.placeholderAttributes = placeholderAttributes
     }
 

--- a/Aztec/Classes/TextKit/ParagraphProperty/Header.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/Header.swift
@@ -32,7 +32,13 @@ open class Header: ParagraphProperty {
         }()
 
         public var fontSize: Float {
-            return HeaderType.fontSizeMap[self] ?? Constants.defaultFontSize
+            let fontSize = HeaderType.fontSizeMap[self] ?? Constants.defaultFontSize
+
+            if #available(iOS 11.0, *) {
+                return Float(UIFontMetrics.default.scaledValue(for: CGFloat(fontSize)))
+            } else {
+                return fontSize
+            }
         }
     }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -152,20 +152,14 @@ open class TextView: UITextView {
     var defaultMissingImage: UIImage
     
     fileprivate var defaultAttributes: [AttributedStringKey: Any] {
-        var attributes: [AttributedStringKey: Any] = [.paragraphStyle: defaultParagraphStyle]
+        var attributes: [AttributedStringKey: Any] = [
+            .font: defaultFont,
+            .paragraphStyle: defaultParagraphStyle
+        ]
 
         if let textColor = textColor {
             attributes[.foregroundColor] = textColor
         }
-
-        let font: UIFont
-
-        if #available(iOS 11.0, *) {
-            font = UIFontMetrics.default.scaledFont(for: defaultFont)
-        } else {
-            font = defaultFont
-        }
-        attributes[.font] = font
 
         return attributes
     }
@@ -312,8 +306,12 @@ open class TextView: UITextView {
         defaultFont: UIFont,
         defaultParagraphStyle: ParagraphStyle = ParagraphStyle.default,
         defaultMissingImage: UIImage) {
-        
-        self.defaultFont = defaultFont
+
+        if #available(iOS 11.0, *) {
+            self.defaultFont = UIFontMetrics.default.scaledFont(for: defaultFont)
+        } else {
+            self.defaultFont = defaultFont
+        }
         self.defaultParagraphStyle = defaultParagraphStyle
         self.defaultMissingImage = defaultMissingImage
 
@@ -330,8 +328,13 @@ open class TextView: UITextView {
     }
 
     required public init?(coder aDecoder: NSCoder) {
+        let font = UIFont.systemFont(ofSize: 14)
+        if #available(iOS 11.0, *) {
+            self.defaultFont = UIFontMetrics.default.scaledFont(for: font)
+        } else {
+            self.defaultFont = font
+        }
 
-        defaultFont = UIFont.systemFont(ofSize: 14)
         defaultParagraphStyle = ParagraphStyle.default
         defaultMissingImage = Assets.imageIcon
         

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -152,11 +152,20 @@ open class TextView: UITextView {
     var defaultMissingImage: UIImage
     
     fileprivate var defaultAttributes: [AttributedStringKey: Any] {
-        var attributes: [AttributedStringKey: Any] = [.font: defaultFont,
-                                                      .paragraphStyle: defaultParagraphStyle]
+        var attributes: [AttributedStringKey: Any] = [.paragraphStyle: defaultParagraphStyle]
+
         if let textColor = textColor {
             attributes[.foregroundColor] = textColor
         }
+
+        let font: UIFont
+
+        if #available(iOS 11.0, *) {
+            font = UIFontMetrics.default.scaledFont(for: defaultFont)
+        } else {
+            font = defaultFont
+        }
+        attributes[.font] = font
 
         return attributes
     }
@@ -332,6 +341,9 @@ open class TextView: UITextView {
 
     private func commonInit() {
         allowsEditingTextAttributes = true
+        if #available(iOS 10.0, *) {
+            adjustsFontForContentSizeCategory = true
+        }
         storage.attachmentsDelegate = self
         font = defaultFont
         linkTextAttributesSwifted = [.underlineStyle: NSNumber(value: NSUnderlineStyle.styleSingle.rawValue), .foregroundColor: self.tintColor]

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -54,7 +54,15 @@ class EditorDemoController: UIViewController {
     }()
 
     fileprivate(set) lazy var htmlTextView: UITextView = {
-        let storage = HTMLStorage(defaultFont: Constants.defaultContentFont)
+        let defaultFont: UIFont
+
+        if #available(iOS 11, *) {
+            defaultFont = UIFontMetrics.default.scaledFont(for: Constants.defaultContentFont)
+        } else {
+            defaultFont = Constants.defaultContentFont
+        }
+
+        let storage = HTMLStorage(defaultFont: defaultFont)
         let layoutManager = NSLayoutManager()
         let container = NSTextContainer()
 
@@ -71,6 +79,10 @@ class EditorDemoController: UIViewController {
         textView.accessibilityIdentifier = "HTMLContentView"
         textView.autocorrectionType = .no
         textView.autocapitalizationType = .none
+
+        if #available(iOS 10, *) {
+            textView.adjustsFontForContentSizeCategory = true
+        }
 
         if #available(iOS 11, *) {
             textView.smartDashesType = .no


### PR DESCRIPTION
This PR adds basic support for Dynamic Type — using the new API introduced in iOS 11. 
Supporting this without using iOS 11 specific API is a rather large pain in the butt — there isn't a good way to programatically get correct metrics for arbitrary font — so we'd have to hardcode scaling factors for the system fonts and have clients provide those too, if they want to specify a custom font.

I'm not sure if clients should be able to opt out of this behavior by setting some property — I'd say being accessible by default is the correct thing to do, but that's open to discussion.

Fixes #478.

Before:
![simulator screen shot - iphone 8 plus - 2017-12-13 at 12 11 48](https://user-images.githubusercontent.com/1594081/33936210-15cd635a-dfff-11e7-9f92-baa0a8db8fe8.png)


![simulator screen shot - iphone 8 plus - 2017-12-13 at 12 11 55](https://user-images.githubusercontent.com/1594081/33936209-15ab6570-dfff-11e7-8280-ec6779306287.png)

After (with the biggest Accesiblity size enabled): 

![simulator screen shot - iphone 8 plus - 2017-12-13 at 12 09 50](https://user-images.githubusercontent.com/1594081/33936221-20785f6c-dfff-11e7-9cab-683edc47df93.png)
![simulator screen shot - iphone 8 plus - 2017-12-13 at 12 09 39](https://user-images.githubusercontent.com/1594081/33936222-2099bdb0-dfff-11e7-9b5a-d310f95e1f7e.png)




