### PR TITLE
Rendering Figcaptions!

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		B5D575881F2288E2003A62F6 /* TextViewStubAttachmentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D575851F2288E2003A62F6 /* TextViewStubAttachmentDelegate.swift */; };
 		B5D575891F2288E2003A62F6 /* TextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D575861F2288E2003A62F6 /* TextViewTests.swift */; };
 		B5DA1C1D1EBD1CCE000AAB45 /* HTMLSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DA1C1C1EBD1CCE000AAB45 /* HTMLSerializer.swift */; };
+		B5E583B31FEC366D00F25C7C /* captions.html in Resources */ = {isa = PBXBuildFile; fileRef = B5E583B21FEC366D00F25C7C /* captions.html */; };
 		B5E607331DA56EC700C8A389 /* TextListFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E607321DA56EC700C8A389 /* TextListFormatterTests.swift */; };
 		B5E94D101FE01335000E7C20 /* FigureElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E94D0F1FE01334000E7C20 /* FigureElementConverter.swift */; };
 		B5F84B611E70595B0089A76C /* NSAttributedString+Analyzers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5F84B601E70595B0089A76C /* NSAttributedString+Analyzers.swift */; };
@@ -256,6 +257,7 @@
 		B5D575851F2288E2003A62F6 /* TextViewStubAttachmentDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextViewStubAttachmentDelegate.swift; path = TextKit/TextViewStubAttachmentDelegate.swift; sourceTree = "<group>"; };
 		B5D575861F2288E2003A62F6 /* TextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TextViewTests.swift; path = TextKit/TextViewTests.swift; sourceTree = "<group>"; };
 		B5DA1C1C1EBD1CCE000AAB45 /* HTMLSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLSerializer.swift; sourceTree = "<group>"; };
+		B5E583B21FEC366D00F25C7C /* captions.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = captions.html; path = Example/Example/SampleContent/captions.html; sourceTree = SOURCE_ROOT; };
 		B5E607321DA56EC700C8A389 /* TextListFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextListFormatterTests.swift; sourceTree = "<group>"; };
 		B5E94D0F1FE01334000E7C20 /* FigureElementConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FigureElementConverter.swift; sourceTree = "<group>"; };
 		B5F84B601E70595B0089A76C /* NSAttributedString+Analyzers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Analyzers.swift"; sourceTree = "<group>"; };
@@ -659,6 +661,7 @@
 			isa = PBXGroup;
 			children = (
 				B50CE7331F1FABA00018CAA1 /* content.html */,
+				B5E583B21FEC366D00F25C7C /* captions.html */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -1022,6 +1025,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B50CE7341F1FABA00018CAA1 /* content.html in Resources */,
+				B5E583B31FEC366D00F25C7C /* captions.html in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -99,7 +99,7 @@ open class ImageAttachment: MediaAttachment {
             return super.onScreenHeight(for: containerWidth)
         }
 
-        return mediaHeight(for: containerWidth) + appearance.imageMargin * 2 +
+        return  appearance.imageInsets.top + mediaHeight(for: containerWidth) + appearance.imageInsets.bottom +
                 appearance.captionInsets.top + captionSize.height + appearance.captionInsets.bottom
     }
 
@@ -159,7 +159,7 @@ open class ImageAttachment: MediaAttachment {
             return
         }
 
-        let messageY = mediaBounds.maxY + appearance.imageMargin + appearance.captionInsets.top
+        let messageY = mediaBounds.maxY + appearance.imageInsets.bottom + appearance.captionInsets.top
         let messageRect = CGRect(x: 0, y: messageY, width: bounds.width, height: captionSize.height)
 
         caption.draw(in: messageRect)

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -167,8 +167,7 @@ open class ImageAttachment: MediaAttachment {
             return .zero
         }
 
-        let captionWidth = imageWidth(for: containerWidth)
-        let containerSize = CGSize(width: captionWidth, height: .greatestFiniteMagnitude)
+        let containerSize = CGSize(width: containerWidth, height: .greatestFiniteMagnitude)
         return caption.boundingRect(with: containerSize, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).size
     }
 
@@ -207,11 +206,15 @@ private extension ImageAttachment {
             return nil
         }
 
-        let captionAttributes = [AttributedStringKey.foregroundColor: appearance.captionColor]
-        let fullRange = updatedCaption.rangeOfEntireString
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = alignment.textAlignment()
 
-        updatedCaption.addAttributes(captionAttributes, range: fullRange)
+        let captionAttributes: [AttributedStringKey: Any] = [
+            .foregroundColor: appearance.captionColor,
+            .paragraphStyle: paragraphStyle
+        ]
 
+        updatedCaption.addAttributes(captionAttributes, range: updatedCaption.rangeOfEntireString)
         return updatedCaption
     }
 }
@@ -257,6 +260,19 @@ extension ImageAttachment {
                     return "alignright"
                 case .none:
                     return "alignnone"
+            }
+        }
+
+        func textAlignment() -> NSTextAlignment {
+            switch self {
+            case .center:
+                return .center
+            case .left:
+                return .left
+            case .right:
+                return .right
+            case .none:
+                return .natural
             }
         }
 

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -99,7 +99,7 @@ open class ImageAttachment: MediaAttachment {
             return super.onScreenHeight(for: containerWidth)
         }
 
-        return  appearance.imageInsets.top + mediaHeight(for: containerWidth) + appearance.imageInsets.bottom +
+        return  appearance.imageInsets.top + imageHeight(for: containerWidth) + appearance.imageInsets.bottom +
                 appearance.captionInsets.top + captionSize.height + appearance.captionInsets.bottom
     }
 
@@ -108,7 +108,7 @@ open class ImageAttachment: MediaAttachment {
 
     /// Returns the x position for the image, for the specified container width.
     ///
-    override func mediaPositionX(for containerWidth: CGFloat) -> CGFloat {
+    override func imagePositionX(for containerWidth: CGFloat) -> CGFloat {
         let imageWidth = onScreenWidth(for: containerWidth)
 
         switch alignment {
@@ -124,7 +124,7 @@ open class ImageAttachment: MediaAttachment {
 
     /// Returns the Image Width, for the specified container width.
     ///
-    override func mediaWidth(for containerWidth: CGFloat) -> CGFloat {
+    override func imageWidth(for containerWidth: CGFloat) -> CGFloat {
         guard let image = image else {
             return 0
         }

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -153,14 +153,13 @@ open class ImageAttachment: MediaAttachment {
 
     /// Draws ImageAttachment specific fields, within the specified bounds.
     ///
-    override func drawCustomElements(in bounds: CGRect) {
+    override func drawCustomElements(in bounds: CGRect, mediaBounds: CGRect) {
         guard let caption = caption, let captionSize = captionSize(for: bounds.width) else {
             return
         }
 
-        let mediaBoundz = mediaBounds(for: bounds)
-        let messageY = mediaBoundz.maxY + appearance.captionMargin
-        let messageRect = CGRect(x: bounds.minX, y: messageY, width: bounds.width, height: captionSize.height)
+        let messageY = mediaBounds.maxY + appearance.imageMargin + appearance.captionMargin
+        let messageRect = CGRect(x: 0, y: messageY, width: bounds.width, height: captionSize.height)
 
         caption.draw(in: messageRect)
     }

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -59,6 +59,12 @@ open class ImageAttachment: MediaAttachment {
                 self.size = size
             }
         }
+        if aDecoder.containsValue(forKey: EncodeKeys.size.rawValue),
+            let caption = aDecoder.decodeObject(forKey: EncodeKeys.size.rawValue) as? NSAttributedString
+        {
+            self.caption = caption
+        }
+
     }
 
     /// Required Initializer
@@ -74,11 +80,13 @@ open class ImageAttachment: MediaAttachment {
         super.encode(with: aCoder)
         aCoder.encode(alignment.rawValue, forKey: EncodeKeys.alignment.rawValue)
         aCoder.encode(size.rawValue, forKey: EncodeKeys.size.rawValue)
+        aCoder.encode(caption, forKey: EncodeKeys.caption.rawValue)
     }
 
-    fileprivate enum EncodeKeys: String {
+    private enum EncodeKeys: String {
         case alignment
-        case size        
+        case size
+        case caption
     }
 
 
@@ -170,6 +178,7 @@ extension ImageAttachment {
 
         clone.size = size
         clone.alignment = alignment
+        clone.caption = caption
 
         return clone
     }

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -153,7 +153,8 @@ open class ImageAttachment: MediaAttachment {
             return nil
         }
 
-        let containerSize = CGSize(width: containerWidth, height: .greatestFiniteMagnitude)
+        let captionWidth = imageWidth(for: containerWidth)
+        let containerSize = CGSize(width: captionWidth, height: .greatestFiniteMagnitude)
         return caption.boundingRect(with: containerSize, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).size
     }
 
@@ -183,8 +184,9 @@ open class ImageAttachment: MediaAttachment {
             return
         }
 
+        let messageX = imagePositionX(for: bounds.width)
         let messageY = mediaBounds.maxY + appearance.imageInsets.bottom + appearance.captionInsets.top
-        let messageRect = CGRect(x: 0, y: messageY, width: bounds.width, height: captionSize.height)
+        let messageRect = CGRect(x: messageX, y: messageY, width: captionSize.width, height: captionSize.height)
 
         styledCaption.draw(in: messageRect)
     }

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -87,7 +87,7 @@ open class ImageAttachment: MediaAttachment {
     override func xPosition(for containerWidth: CGFloat) -> CGFloat {
         let imageWidth = onScreenWidth(for: containerWidth)
 
-        switch (alignment) {
+        switch alignment {
         case .center:
             return CGFloat(floor((containerWidth - imageWidth) / 2))
         case .right:
@@ -113,12 +113,30 @@ open class ImageAttachment: MediaAttachment {
             return 0
         }
 
-        switch (size) {
+        switch size {
         case .full, .none:
             return floor(min(image.size.width, containerWidth))
         default:
             return floor(min(min(image.size.width,size.width), containerWidth))
         }
+    }
+
+
+    // MARK: - Drawing
+
+    /// Draws ImageAttachment specific fields, within the specified bounds.
+    ///
+    override func drawCustomElements(in bounds: CGRect) {
+        guard let caption = caption else {
+            return
+        }
+
+        let textRect = caption.boundingRect(with: bounds.size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
+        let messageY = bounds.maxY + appearance.captionMargin
+
+        // Check to see if the message will fit within the image. If not, skip it.
+        let messageRect = CGRect(x: bounds.minX, y: messageY, width: bounds.width, height: textRect.height)
+        caption.draw(in: messageRect)
     }
 }
 

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -10,7 +10,7 @@ open class ImageAttachment: MediaAttachment {
     ///
     open var caption: NSAttributedString? {
         didSet {
-            styledCaption = applyCaptionAppearance(to: caption)
+            styledCaptionCache = nil
         }
     }
 
@@ -20,6 +20,7 @@ open class ImageAttachment: MediaAttachment {
         willSet {
             if newValue != alignment {
                 glyphImage = nil
+                styledCaptionCache = nil
             }
         }
     }
@@ -36,7 +37,18 @@ open class ImageAttachment: MediaAttachment {
 
     /// Attachment's Caption String, with MediaAttachment's appearance attributes applied.
     ///
-    private var styledCaption: NSAttributedString?
+    private var styledCaptionCache: NSAttributedString?
+
+    /// Returns the cached caption (with our custom attributes applied), or regenerates the Styled Caption, if needed.
+    ///
+    private var styledCaption: NSAttributedString? {
+        if let caption = styledCaptionCache {
+            return caption
+        }
+
+        styledCaptionCache = applyCaptionAppearance(to: caption)
+        return styledCaptionCache
+    }
 
 
     /// Creates a new attachment
@@ -190,6 +202,7 @@ open class ImageAttachment: MediaAttachment {
         guard let styledCaption = styledCaption else {
             return
         }
+        
 
         let styledBounds = captionBounds(containerBounds: bounds, mediaBounds: mediaBounds)
         styledCaption.draw(in: styledBounds)

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -8,7 +8,11 @@ open class ImageAttachment: MediaAttachment {
 
     /// Attachment's Caption String
     ///
-    open var caption: NSAttributedString?
+    open var caption: NSAttributedString? {
+        didSet {
+            styledCaption = applyCaptionAppearance(to: caption)
+        }
+    }
 
     /// Attachment Alignment
     ///
@@ -29,6 +33,10 @@ open class ImageAttachment: MediaAttachment {
             }
         }
     }
+
+    /// Attachment's Caption String, with MediaAttachment's appearance attributes applied.
+    ///
+    private var styledCaption: NSAttributedString?
 
 
     /// Creates a new attachment
@@ -99,7 +107,7 @@ open class ImageAttachment: MediaAttachment {
             return super.onScreenHeight(for: containerWidth)
         }
 
-        return  appearance.imageInsets.top + imageHeight(for: containerWidth) + appearance.imageInsets.bottom +
+        return appearance.imageInsets.top + imageHeight(for: containerWidth) + appearance.imageInsets.bottom +
                 appearance.captionInsets.top + captionSize.height + appearance.captionInsets.bottom
     }
 
@@ -150,19 +158,35 @@ open class ImageAttachment: MediaAttachment {
     }
 
 
+    // MARK: - Private Methods
+    //
+    private func applyCaptionAppearance(to caption: NSAttributedString?) -> NSAttributedString? {
+        guard let updatedCaption = caption?.mutableCopy() as? NSMutableAttributedString else {
+            return nil
+        }
+
+        let captionAttributes = [AttributedStringKey.foregroundColor: appearance.captionColor]
+        let fullRange = updatedCaption.rangeOfEntireString
+
+        updatedCaption.addAttributes(captionAttributes, range: fullRange)
+
+        return updatedCaption
+    }
+
+
     // MARK: - Drawing
 
     /// Draws ImageAttachment specific fields, within the specified bounds.
     ///
     override func drawCustomElements(in bounds: CGRect, mediaBounds: CGRect) {
-        guard let caption = caption, let captionSize = captionSize(for: bounds.width) else {
+        guard let styledCaption = styledCaption, let captionSize = captionSize(for: bounds.width) else {
             return
         }
 
         let messageY = mediaBounds.maxY + appearance.imageInsets.bottom + appearance.captionInsets.top
         let messageRect = CGRect(x: 0, y: messageY, width: bounds.width, height: captionSize.height)
 
-        caption.draw(in: messageRect)
+        styledCaption.draw(in: messageRect)
     }
 }
 

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -99,7 +99,8 @@ open class ImageAttachment: MediaAttachment {
             return super.onScreenHeight(for: containerWidth)
         }
 
-        return mediaHeight(for: containerWidth) + appearance.imageMargin * 2 + appearance.captionMargin * 2 + captionSize.height
+        return mediaHeight(for: containerWidth) + appearance.imageMargin * 2 +
+                appearance.captionInsets.top + captionSize.height + appearance.captionInsets.bottom
     }
 
 
@@ -158,7 +159,7 @@ open class ImageAttachment: MediaAttachment {
             return
         }
 
-        let messageY = mediaBounds.maxY + appearance.imageMargin + appearance.captionMargin
+        let messageY = mediaBounds.maxY + appearance.imageMargin + appearance.captionInsets.top
         let messageRect = CGRect(x: 0, y: messageY, width: bounds.width, height: captionSize.height)
 
         caption.draw(in: messageRect)

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -84,8 +84,8 @@ open class ImageAttachment: MediaAttachment {
 
     // MARK: - Origin calculation
 
-    override func xPosition(forContainerWidth containerWidth: CGFloat) -> CGFloat {
-        let imageWidth = onScreenWidth(containerWidth)
+    override func xPosition(for containerWidth: CGFloat) -> CGFloat {
+        let imageWidth = onScreenWidth(for: containerWidth)
 
         switch (alignment) {
         case .center:
@@ -97,18 +97,18 @@ open class ImageAttachment: MediaAttachment {
         }
     }
 
-    override func onScreenHeight(_ containerWidth: CGFloat) -> CGFloat {
+    override func onScreenHeight(for containerWidth: CGFloat) -> CGFloat {
         guard let image = image else {
             return 0
         }
 
-        let targetWidth = onScreenWidth(containerWidth)
+        let targetWidth = onScreenWidth(for: containerWidth)
         let scale = targetWidth / image.size.width
 
         return floor(image.size.height * scale) + (appearance.imageMargin * 2)
     }
 
-    override func onScreenWidth(_ containerWidth: CGFloat) -> CGFloat {
+    override func onScreenWidth(for containerWidth: CGFloat) -> CGFloat {
         guard let image = image else {
             return 0
         }

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -180,7 +180,7 @@ open class MediaAttachment: NSTextAttachment {
     /// Returns the Attachment's Onscreen Height: should include any margins!
     ///
     func onScreenHeight(for containerWidth: CGFloat) -> CGFloat {
-        return mediaHeight(for: containerWidth) + appearance.imageMargin * 2
+        return mediaHeight(for: containerWidth) + appearance.imageInsets.top + appearance.imageInsets.bottom
     }
 
     /// Returns the Attachment's Onscreen Width: should include any margins!
@@ -224,7 +224,7 @@ open class MediaAttachment: NSTextAttachment {
     /// Returns the Image Bounds, for the specified container bounds.
     ///
     func mediaBounds(for bounds: CGRect) -> CGRect {
-        let origin = CGPoint(x: mediaPositionX(for: bounds.width), y: appearance.imageMargin)
+        let origin = CGPoint(x: mediaPositionX(for: bounds.width), y: appearance.imageInsets.top)
         let size = CGSize(width: mediaWidth(for: bounds.width), height: mediaHeight(for: bounds.width))
 
         return CGRect(origin: origin, size: size)
@@ -562,7 +562,7 @@ extension MediaAttachment {
 
         /// The margin apply to the images being displayed. This is to avoid that two images in a row get glued together.
         ///
-        public var imageMargin = CGFloat(10.0)
+        public var imageInsets = UIEdgeInsets(top: 10.0, left: 0.0, bottom: 10.0, right: 0.0)
 
         /// The Insets to be applied to the Caption text (if any).. Note that this property is actually used by a subclass. Revisit when possible!
         ///

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -175,13 +175,32 @@ open class MediaAttachment: NSTextAttachment {
     }
 
 
-    // MARK: - Position and size calculation
+    // MARK: - OnScreen Metrics
 
-    func xPosition(for containerWidth: CGFloat) -> CGFloat {
+    /// Returns the Attachment's Onscreen Height: should include any margins!
+    ///
+    func onScreenHeight(for containerWidth: CGFloat) -> CGFloat {
+        return mediaHeight(for: containerWidth) + appearance.imageMargin * 2
+    }
+
+    /// Returns the Attachment's Onscreen Width: should include any margins!
+    ///
+    func onScreenWidth(for containerWidth: CGFloat) -> CGFloat {
+        return mediaWidth(for: containerWidth)
+    }
+
+
+    // MARK: - Image Sizing + Positioning
+
+    /// Returns the Media's Position X, for the specified container width.
+    ///
+    func mediaPositionX(for containerWidth: CGFloat) -> CGFloat {
         return 0
     }
 
-    func onScreenHeight(for containerWidth: CGFloat) -> CGFloat {
+    /// Returns the Image Height, for the specified container width.
+    ///
+    func mediaHeight(for containerWidth: CGFloat) -> CGFloat {
         guard let image = image else {
             return 0
         }
@@ -189,10 +208,12 @@ open class MediaAttachment: NSTextAttachment {
         let targetWidth = onScreenWidth(for: containerWidth)
         let scale = targetWidth / image.size.width
 
-        return floor(image.size.height * scale) + (appearance.imageMargin * 2)
+        return floor(image.size.height * scale)
     }
 
-    func onScreenWidth(for containerWidth: CGFloat) -> CGFloat {
+    /// Returns the Image Width, for the specified container width.
+    ///
+    func mediaWidth(for containerWidth: CGFloat) -> CGFloat {
         guard let image = image else {
             return 0
         }
@@ -200,9 +221,11 @@ open class MediaAttachment: NSTextAttachment {
         return floor(min(image.size.width, containerWidth))
     }
 
+    /// Returns the Image Bounds, for the specified container bounds.
+    ///
     func mediaBounds(for bounds: CGRect) -> CGRect {
-        let origin = CGPoint(x: xPosition(for: bounds.width), y: appearance.imageMargin)
-        let size = CGSize(width: onScreenWidth(for: bounds.width), height: onScreenHeight(for: bounds.width) - appearance.imageMargin * 2)
+        let origin = CGPoint(x: mediaPositionX(for: bounds.width), y: appearance.imageMargin)
+        let size = CGSize(width: mediaWidth(for: bounds.width), height: mediaHeight(for: bounds.width))
 
         return CGRect(origin: origin, size: size)
     }
@@ -281,7 +304,6 @@ extension MediaAttachment {
     func glyph(for image: UIImage, in bounds: CGRect) -> UIImage? {
 
         UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0)
-
         let mediaBounds = self.mediaBounds(for: bounds)
 
         image.draw(in: mediaBounds)

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -564,9 +564,9 @@ extension MediaAttachment {
         ///
         public var imageMargin = CGFloat(10.0)
 
-        /// The margin apply to the caption being displayed. Note that this property is actually used by a subclass. Revisit when possible!
+        /// The Insets to be applied to the Caption text (if any).. Note that this property is actually used by a subclass. Revisit when possible!
         ///
-        public var captionMargin = CGFloat(10.0)
+        public var captionInsets = UIEdgeInsets(top: 5.0, left: 0.0, bottom: 5.0, right: 0.0)
     }
 }
 

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -208,6 +208,15 @@ open class MediaAttachment: NSTextAttachment {
     }
 
 
+    // MARK: - Stub Methods
+
+    /// Draws custom elements onscreen: Subclasses should implement this method, on a need-to basis.
+    ///
+    func drawCustomElements(in bounds: CGRect) {
+        // NO-OP
+    }
+
+
     // MARK: - NSTextAttachmentContainer
 
     override open func image(forBounds imageBounds: CGRect, textContainer: NSTextContainer?, characterIndex charIndex: Int) -> UIImage? {
@@ -284,6 +293,7 @@ extension MediaAttachment {
         drawOverlayMessage(in: mediaBounds, paddingY: overlayImageSize.height)
 
         drawProgress(in: mediaBounds)
+        drawCustomElements(in: mediaBounds)
 
         let result = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -539,6 +539,10 @@ extension MediaAttachment {
         /// The margin apply to the images being displayed. This is to avoid that two images in a row get glued together.
         ///
         public var imageMargin = CGFloat(10.0)
+
+        /// The margin apply to the caption being displayed. Note that this property is actually used by a subclass. Revisit when possible!
+        ///
+        public var captionMargin = CGFloat(10.0)
     }
 }
 

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -180,27 +180,27 @@ open class MediaAttachment: NSTextAttachment {
     /// Returns the Attachment's Onscreen Height: should include any margins!
     ///
     func onScreenHeight(for containerWidth: CGFloat) -> CGFloat {
-        return mediaHeight(for: containerWidth) + appearance.imageInsets.top + appearance.imageInsets.bottom
+        return imageHeight(for: containerWidth) + appearance.imageInsets.top + appearance.imageInsets.bottom
     }
 
     /// Returns the Attachment's Onscreen Width: should include any margins!
     ///
     func onScreenWidth(for containerWidth: CGFloat) -> CGFloat {
-        return mediaWidth(for: containerWidth)
+        return imageWidth(for: containerWidth)
     }
 
 
     // MARK: - Image Sizing + Positioning
 
-    /// Returns the Media's Position X, for the specified container width.
+    /// Returns the Image's Position X, for the specified container width.
     ///
-    func mediaPositionX(for containerWidth: CGFloat) -> CGFloat {
+    func imagePositionX(for containerWidth: CGFloat) -> CGFloat {
         return 0
     }
 
     /// Returns the Image Height, for the specified container width.
     ///
-    func mediaHeight(for containerWidth: CGFloat) -> CGFloat {
+    func imageHeight(for containerWidth: CGFloat) -> CGFloat {
         guard let image = image else {
             return 0
         }
@@ -213,7 +213,7 @@ open class MediaAttachment: NSTextAttachment {
 
     /// Returns the Image Width, for the specified container width.
     ///
-    func mediaWidth(for containerWidth: CGFloat) -> CGFloat {
+    func imageWidth(for containerWidth: CGFloat) -> CGFloat {
         guard let image = image else {
             return 0
         }
@@ -223,9 +223,9 @@ open class MediaAttachment: NSTextAttachment {
 
     /// Returns the Image Bounds, for the specified container bounds.
     ///
-    func mediaBounds(for bounds: CGRect) -> CGRect {
-        let origin = CGPoint(x: mediaPositionX(for: bounds.width), y: appearance.imageInsets.top)
-        let size = CGSize(width: mediaWidth(for: bounds.width), height: mediaHeight(for: bounds.width))
+    func imageBounds(for bounds: CGRect) -> CGRect {
+        let origin = CGPoint(x: imagePositionX(for: bounds.width), y: appearance.imageInsets.top)
+        let size = CGSize(width: imageWidth(for: bounds.width), height: imageHeight(for: bounds.width))
 
         return CGRect(origin: origin, size: size)
     }
@@ -304,7 +304,7 @@ extension MediaAttachment {
     func glyph(for image: UIImage, in bounds: CGRect) -> UIImage? {
 
         UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0)
-        let mediaBounds = self.mediaBounds(for: bounds)
+        let mediaBounds = self.imageBounds(for: bounds)
 
         image.draw(in: mediaBounds)
 

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -190,7 +190,7 @@ open class MediaAttachment: NSTextAttachment {
     }
 
 
-    // MARK: - Image Sizing + Positioning
+    // MARK: - Image Metrics
 
     /// Returns the Image's Position X, for the specified container width.
     ///

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -567,6 +567,11 @@ extension MediaAttachment {
         /// The Insets to be applied to the Caption text (if any).. Note that this property is actually used by a subclass. Revisit when possible!
         ///
         public var captionInsets = UIEdgeInsets(top: 5.0, left: 0.0, bottom: 5.0, right: 0.0)
+
+        /// The color to use when drawing ImageAttachment's caption (if any). Note that this property is actually used by a subclass.
+        /// Revisit when possible!
+        ///
+        public var captionColor = UIColor.darkGray
     }
 }
 

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -177,22 +177,22 @@ open class MediaAttachment: NSTextAttachment {
 
     // MARK: - Position and size calculation
 
-    func xPosition(forContainerWidth containerWidth: CGFloat) -> CGFloat {
+    func xPosition(for containerWidth: CGFloat) -> CGFloat {
         return 0
     }
 
-    func onScreenHeight(_ containerWidth: CGFloat) -> CGFloat {
+    func onScreenHeight(for containerWidth: CGFloat) -> CGFloat {
         guard let image = image else {
             return 0
         }
 
-        let targetWidth = onScreenWidth(containerWidth)
+        let targetWidth = onScreenWidth(for: containerWidth)
         let scale = targetWidth / image.size.width
 
         return floor(image.size.height * scale) + (appearance.imageMargin * 2)
     }
 
-    func onScreenWidth(_ containerWidth: CGFloat) -> CGFloat {
+    func onScreenWidth(for containerWidth: CGFloat) -> CGFloat {
         guard let image = image else {
             return 0
         }
@@ -201,8 +201,8 @@ open class MediaAttachment: NSTextAttachment {
     }
 
     func mediaBounds(for bounds: CGRect) -> CGRect {
-        let origin = CGPoint(x: xPosition(forContainerWidth: bounds.width), y: appearance.imageMargin)
-        let size = CGSize(width: onScreenWidth(bounds.width), height: onScreenHeight(bounds.width) - appearance.imageMargin * 2)
+        let origin = CGPoint(x: xPosition(for: bounds.width), y: appearance.imageMargin)
+        let size = CGSize(width: onScreenWidth(for: bounds.width), height: onScreenHeight(for: bounds.width) - appearance.imageMargin * 2)
 
         return CGRect(origin: origin, size: size)
     }
@@ -259,7 +259,7 @@ open class MediaAttachment: NSTextAttachment {
         }
 
         let width = floor(lineFrag.width - padding)
-        let size = CGSize(width: width, height: onScreenHeight(width))
+        let size = CGSize(width: width, height: onScreenHeight(for: width))
 
         return CGRect(origin: CGPoint.zero, size: size)
     }

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -235,7 +235,7 @@ open class MediaAttachment: NSTextAttachment {
 
     /// Draws custom elements onscreen: Subclasses should implement this method, on a need-to basis.
     ///
-    func drawCustomElements(in bounds: CGRect) {
+    func drawCustomElements(in bounds: CGRect, mediaBounds: CGRect) {
         // NO-OP
     }
 
@@ -317,7 +317,7 @@ extension MediaAttachment {
         drawProgress(in: mediaBounds)
 
         // Subclass Drawing Hook: Pass along the actual container bounds
-        drawCustomElements(in: bounds)
+        drawCustomElements(in: bounds, mediaBounds: mediaBounds)
 
         let result = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -315,7 +315,9 @@ extension MediaAttachment {
         drawOverlayMessage(in: mediaBounds, paddingY: overlayImageSize.height)
 
         drawProgress(in: mediaBounds)
-        drawCustomElements(in: mediaBounds)
+
+        // Subclass Drawing Hook: Pass along the actual container bounds
+        drawCustomElements(in: bounds)
 
         let result = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1401,7 +1401,9 @@ open class TextView: UITextView {
         if let attachment = attachmentAtPoint(point) as? MediaAttachment {
             let glyphRange = layoutManager.glyphRange(forCharacterRange: NSRange(location: index, length: 1), actualCharacterRange: nil)
             let rect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
-            if point.y >= rect.origin.y && point.y <= (rect.origin.y + (2 * attachment.appearance.imageMargin)) {
+            let imageInsets = attachment.appearance.imageInsets
+
+            if point.y >= rect.origin.y && point.y <= (rect.origin.y + (imageInsets.top + imageInsets.bottom)) {
                 return true
             }
         }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1357,7 +1357,7 @@ open class TextView: UITextView {
         }
 
         // Correct the bounds taking in account the dimesion of the media image being used
-        let mediaBounds = mediaAttachment.mediaBounds(for: bounds)
+        let mediaBounds = mediaAttachment.imageBounds(for: bounds)
 
         bounds.origin.x += mediaBounds.origin.x
         bounds.origin.y += mediaBounds.origin.y

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -105,7 +105,7 @@ open class VideoAttachment: MediaAttachment {
             let targetWidth = onScreenWidth(for: containerWidth)
             let scale = targetWidth / image.size.width
 
-            return floor(image.size.height * scale) + (appearance.imageMargin * 2)
+            return floor(image.size.height * scale) + appearance.imageInsets.top + appearance.imageInsets.bottom
         } else {
             return 0
         }

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -94,15 +94,15 @@ open class VideoAttachment: MediaAttachment {
 
     // MARK: - Origin calculation
 
-    override func xPosition(forContainerWidth containerWidth: CGFloat) -> CGFloat {
-        let imageWidth = onScreenWidth(containerWidth)
+    override func xPosition(for containerWidth: CGFloat) -> CGFloat {
+        let imageWidth = onScreenWidth(for: containerWidth)
 
         return CGFloat(floor((containerWidth - imageWidth) / 2))
     }
 
-    override func onScreenHeight(_ containerWidth: CGFloat) -> CGFloat {
+    override func onScreenHeight(for containerWidth: CGFloat) -> CGFloat {
         if let image = image {
-            let targetWidth = onScreenWidth(containerWidth)
+            let targetWidth = onScreenWidth(for: containerWidth)
             let scale = targetWidth / image.size.width
 
             return floor(image.size.height * scale) + (appearance.imageMargin * 2)
@@ -111,7 +111,7 @@ open class VideoAttachment: MediaAttachment {
         }
     }
 
-    override func onScreenWidth(_ containerWidth: CGFloat) -> CGFloat {
+    override func onScreenWidth(for containerWidth: CGFloat) -> CGFloat {
         if let image = image {
             return floor(min(image.size.width, containerWidth))
         } else {

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -94,7 +94,7 @@ open class VideoAttachment: MediaAttachment {
 
     // MARK: - Origin calculation
 
-    override func xPosition(for containerWidth: CGFloat) -> CGFloat {
+    override func mediaPositionX(for containerWidth: CGFloat) -> CGFloat {
         let imageWidth = onScreenWidth(for: containerWidth)
 
         return CGFloat(floor((containerWidth - imageWidth) / 2))

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -94,7 +94,7 @@ open class VideoAttachment: MediaAttachment {
 
     // MARK: - Origin calculation
 
-    override func mediaPositionX(for containerWidth: CGFloat) -> CGFloat {
+    override func imagePositionX(for containerWidth: CGFloat) -> CGFloat {
         let imageWidth = onScreenWidth(for: containerWidth)
 
         return CGFloat(floor((containerWidth - imageWidth) / 2))

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		B570B1CC1E82D343008CF41E /* CommentAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B570B1CB1E82D343008CF41E /* CommentAttachmentRenderer.swift */; };
 		B5AF89341E93ECE60051EFDB /* HTMLAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF89331E93ECE60051EFDB /* HTMLAttachmentRenderer.swift */; };
 		B5DB1C371EC630E10005E623 /* UnknownEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */; };
+		B5FB212A1FEC38470067D597 /* captions.html in Resources */ = {isa = PBXBuildFile; fileRef = B5FB21271FEC37DB0067D597 /* captions.html */; };
 		BE2672F31FC6E5A80026107E /* EditorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2672F21FC6E5A80026107E /* EditorPage.swift */; };
 		BE2672F51FC6F2E90026107E /* FormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2672F41FC6F2E90026107E /* FormattingTests.swift */; };
 		BE2B4E8E1FD587D3007AE3E4 /* ImagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2B4E8D1FD587D3007AE3E4 /* ImagesTests.swift */; };
@@ -126,6 +127,7 @@
 		B570B1CB1E82D343008CF41E /* CommentAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B5AF89331E93ECE60051EFDB /* HTMLAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnknownEditorViewController.swift; sourceTree = "<group>"; };
+		B5FB21271FEC37DB0067D597 /* captions.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = captions.html; sourceTree = "<group>"; };
 		BE2672F21FC6E5A80026107E /* EditorPage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorPage.swift; sourceTree = "<group>"; };
 		BE2672F41FC6F2E90026107E /* FormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattingTests.swift; sourceTree = "<group>"; };
 		BE2B4E8D1FD587D3007AE3E4 /* ImagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesTests.swift; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				59280F281D47CAF40083FB59 /* content.html */,
+				B5FB21271FEC37DB0067D597 /* captions.html */,
 				59280F291D47CAF40083FB59 /* SampleText.rtf */,
 			);
 			path = SampleContent;
@@ -469,6 +472,7 @@
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
 				59280F2A1D47CAF40083FB59 /* content.html in Resources */,
+				B5FB212A1FEC38470067D597 /* captions.html in Resources */,
 				59280F2B1D47CAF40083FB59 /* SampleText.rtf in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
 				FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */,

--- a/Example/Example/SampleContent/captions.html
+++ b/Example/Example/SampleContent/captions.html
@@ -1,0 +1,60 @@
+<h4>Image with caption [Left Aligned]:</h4>
+<p>
+<figure custom-figure-attribute>
+    <img src="https://httpbin.org/image/jpeg" alt="Coyote" class="alignleft"/>
+    <figcaption custom-figcaption-attribute>I'm a very, very, very long figcaption, written in a galaxy far, far, far away. Moo to you!</figcaption>
+</figure>
+</p>
+
+<hr>
+
+<h4>Image with caption [Right Aligned]:</h4>
+<p>
+<figure custom-figure-attribute>
+    <img src="https://httpbin.org/image/jpeg" alt="Coyote" class="alignright"/>
+    <figcaption custom-figcaption-attribute>This is a uper long figcaption string, that should be right aligned!</figcaption>
+</figure>
+</p>
+
+<hr>
+
+<h4>Image with caption [Centered!]:</h4>
+<p>
+<figure custom-figure-attribute>
+    <img src="https://httpbin.org/image/jpeg" alt="Coyote" />
+    <figcaption custom-figcaption-attribute>Very very very very long figcaption snippet, left aligned, for our visual awesome test!</figcaption>
+</figure>
+</p>
+
+<hr>
+
+<h4>Image with caption [Left Aligned]:</h4>
+<p>
+<figure custom-figure-attribute>
+    <img src="https://httpbin.org/image/jpeg" alt="Coyote" class="alignleft"/>
+    <figcaption custom-figcaption-attribute>Caption!</figcaption>
+</figure>
+</p>
+
+<hr>
+
+<h4>Image with caption [Right Aligned]:</h4>
+<p>
+<figure custom-figure-attribute>
+    <img src="https://httpbin.org/image/jpeg" alt="Coyote" class="alignright"/>
+    <figcaption custom-figcaption-attribute>Caption!</figcaption>
+</figure>
+</p>
+
+<hr>
+
+<h4>Image with caption [Centered!]:</h4>
+<p>
+<figure custom-figure-attribute>
+    <img src="https://httpbin.org/image/jpeg" alt="Coyote" />
+    <figcaption custom-figcaption-attribute>Caption!</figcaption>
+</figure>
+</p>
+
+<hr>
+

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -110,11 +110,27 @@ Block Quote:
 <p>
 <a href="www.automattic.com"><img src="https://httpbin.org/image/jpeg" alt="Coyote" /></a>
 </p>
-<h4>Image with caption:</h4>
+<h4>Image with caption [Left Aligned]:</h4>
+<p>
+<figure custom-figure-attribute>
+    <img src="https://httpbin.org/image/jpeg" alt="Coyote" class="alignleft"/>
+    <figcaption custom-figcaption-attribute>I'm a very, very, very long figcaption, written in a galaxy far, far, far away. Moo to you!</figcaption>
+</figure>
+</p>
+<h4>Image with caption [Right Aligned]:</h4>
+<p>
+<h4>Right:</h4>
+<p>
+<figure custom-figure-attribute>
+    <img src="https://httpbin.org/image/jpeg" alt="Coyote" class="alignright"/>
+    <figcaption custom-figcaption-attribute>This is a uper long figcaption string, that should be right aligned!</figcaption>
+</figure>
+</p>
+<h4>Image with caption [Centered!]:</h4>
 <p>
 <figure custom-figure-attribute>
     <img src="https://httpbin.org/image/jpeg" alt="Coyote" />
-    <figcaption custom-figcaption-attribute>I'm a very, very, very long figcaption, written in a galaxy far, far, far away. Moo to you!</figcaption>
+    <figcaption custom-figcaption-attribute>Very very very very long figcaption snippet, left aligned, for our visual awesome test!</figcaption>
 </figure>
 </p>
 <h4>Video:</h4>

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -119,8 +119,6 @@ Block Quote:
 </p>
 <h4>Image with caption [Right Aligned]:</h4>
 <p>
-<h4>Right:</h4>
-<p>
 <figure custom-figure-attribute>
     <img src="https://httpbin.org/image/jpeg" alt="Coyote" class="alignright"/>
     <figcaption custom-figcaption-attribute>This is a uper long figcaption string, that should be right aligned!</figcaption>

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -110,25 +110,11 @@ Block Quote:
 <p>
 <a href="www.automattic.com"><img src="https://httpbin.org/image/jpeg" alt="Coyote" /></a>
 </p>
-<h4>Image with caption [Left Aligned]:</h4>
-<p>
-<figure custom-figure-attribute>
-    <img src="https://httpbin.org/image/jpeg" alt="Coyote" class="alignleft"/>
-    <figcaption custom-figcaption-attribute>I'm a very, very, very long figcaption, written in a galaxy far, far, far away. Moo to you!</figcaption>
-</figure>
-</p>
-<h4>Image with caption [Right Aligned]:</h4>
-<p>
-<figure custom-figure-attribute>
-    <img src="https://httpbin.org/image/jpeg" alt="Coyote" class="alignright"/>
-    <figcaption custom-figcaption-attribute>This is a uper long figcaption string, that should be right aligned!</figcaption>
-</figure>
-</p>
-<h4>Image with caption [Centered!]:</h4>
+<h4>Image with caption:</h4>
 <p>
 <figure custom-figure-attribute>
     <img src="https://httpbin.org/image/jpeg" alt="Coyote" />
-    <figcaption custom-figcaption-attribute>Very very very very long figcaption snippet, left aligned, for our visual awesome test!</figcaption>
+    <figcaption custom-figcaption-attribute>I'm a very, very, very long figcaption, written in a galaxy far, far, far away. Moo to you!</figcaption>
 </figure>
 </p>
 <h4>Video:</h4>

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -114,7 +114,7 @@ Block Quote:
 <p>
 <figure custom-figure-attribute>
     <img src="https://httpbin.org/image/jpeg" alt="Coyote" />
-    <figcaption custom-figcaption-attribute>Moooooo</figcaption>
+    <figcaption custom-figcaption-attribute>I'm a very, very, very long figcaption, written in a galaxy far, far, far away. Moo to you!</figcaption>
 </figure>
 </p>
 <h4>Video:</h4>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -14,19 +14,20 @@ class ViewController: UITableViewController
         super.viewDidLoad()
 
         rows = [
-            DemoRow(title: "Editor Demo", action: { self.showEditorDemo() }),
-            DemoRow(title: "Empty Editor Demo", action: { self.showEditorDemo(loadSampleHTML: false) }),
+            DemoRow(title: "Editor Demo", action: { self.showEditorDemo(filename: "content") }),
+            DemoRow(title: "Captions Demo", action: { self.showEditorDemo(filename: "captions") }),
+            DemoRow(title: "Empty Editor Demo", action: { self.showEditorDemo() }),
         ]
     }
 
     // MARK: Actions
 
-    func showEditorDemo(loadSampleHTML: Bool = true) {
+    func showEditorDemo(filename: String? = nil) {
         let controller: EditorDemoController
             
-        if loadSampleHTML {
-            let sampleHTML = getSampleHTML(fromHTMLFileNamed: "content")
-            
+        if let filename = filename {
+            let sampleHTML = getSampleHTML(fromHTMLFileNamed: filename)
+
             controller = EditorDemoController(withSampleHTML: sampleHTML)
         } else {
             controller = EditorDemoController()


### PR DESCRIPTION
### Description:
In this PR we're adding `figcaption` rendering capabilities.

Needs Review: @diegoreymendez 

Closes #723

### Details:
- **ImageAttachment** will, now, also serialize the `caption` field (NSCoder implementation).
- Updated **MediaAttachment** / **ImageAttachment** bounds calculation methods
- New **MediaAttachment.Appearance** property
- And of course, the actual Caption rendering mechanisms!


### Alignment / Sizing:
Our goal is for the figcaption to render as follows:
<img width="878" alt="screen shot 2017-12-21 at 13 26 00" src="https://user-images.githubusercontent.com/1195260/34267400-6da7dbca-e65b-11e7-9d1b-bcedc68b226c.png">


--

### Testing:
1. Launch the Demo App
2. Open the `Captions Demo`

Verify that all of the captions look as expected!
