### PR TITLE
Make testLongTitle UI test font size agnostic

### DIFF
--- a/Example/AztecUITests/HighPriorityIssuesTests.swift
+++ b/Example/AztecUITests/HighPriorityIssuesTests.swift
@@ -25,6 +25,7 @@ class HighPriorityIssuesTests: XCTestCase {
     
     // Github issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/385
     func testLongTitle() {
+        let longTitle = "long title in a galaxy not so far away"
         // Title heigh contains of actual textfield height + bottom line.
         // 16px - is the height of that bottom line. Its not changing with different font sizes
         let titleTextView = app.textViews[elementStringIDs.titleTextField]
@@ -34,13 +35,13 @@ class HighPriorityIssuesTests: XCTestCase {
         
         // TODO: Move it into EditorPage
         if isIPhone() {
-            titleTextView.typeText("very very very very very very long title in a galaxy not so far away")
+            titleTextView.typeText(String(repeating: "very ", count: 6) + longTitle)
         } else {
-            titleTextView.typeText("very very very very very very long title in a galaxy not so far away very very very very very very long title in a galaxy not so far away")
+            titleTextView.typeText(String(repeating: "very ", count: 20) + longTitle)
         }
         
         let twoLineTitleHeight = titleTextView.frame.height
-        XCTAssert(twoLineTitleHeight - oneLineTitleHeight == titleLineHeight )
+        XCTAssert(twoLineTitleHeight - oneLineTitleHeight >= titleLineHeight )
     }
     
     // Github issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/675

--- a/Example/AztecUITests/HighPriorityIssuesTests.swift
+++ b/Example/AztecUITests/HighPriorityIssuesTests.swift
@@ -25,12 +25,12 @@ class HighPriorityIssuesTests: XCTestCase {
     
     // Github issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/385
     func testLongTitle() {
-        //    Title line height is about 22px, so it might be useing for comparing the height difference should make it precise.
-        //    But may be fragile due to different font sizes etc
-        let titleLineHeight = 22
+        // Title heigh contains of actual textfield height + bottom line.
+        // 16px - is the height of that bottom line. Its not changing with different font sizes
         let titleTextView = app.textViews[elementStringIDs.titleTextField]
+        let titleLineHeight = titleTextView.frame.height - 16
+        let oneLineTitleHeight = titleTextView.frame.height
         titleTextView.tap()
-        let oneLineTitleHeight = Int(titleTextView.frame.height)
         
         // TODO: Move it into EditorPage
         if isIPhone() {
@@ -39,7 +39,7 @@ class HighPriorityIssuesTests: XCTestCase {
             titleTextView.typeText("very very very very very very long title in a galaxy not so far away very very very very very very long title in a galaxy not so far away")
         }
         
-        let twoLineTitleHeight = Int(titleTextView.frame.height)
+        let twoLineTitleHeight = titleTextView.frame.height
         XCTAssert(twoLineTitleHeight - oneLineTitleHeight == titleLineHeight )
     }
     

--- a/Example/AztecUITests/Pages/BasePage.swift
+++ b/Example/AztecUITests/Pages/BasePage.swift
@@ -11,13 +11,20 @@ class BasePage {
         app = XCUIApplication() // appInstance
         expectedElement = element
         waitTimeout = 20
-        waitForPage()
+        _ = waitForPage()
     }
     
     func waitForPage() -> BasePage {
-        expectedElement.waitForExistence(timeout: waitTimeout)
+        _ = expectedElement.waitForExistence(timeout: waitTimeout)
         Logger.log(message: "Page \(self) is loaded", event: .i)
         return self
+    }
+    
+    func waitFor(element: XCUIElement, predicate: String, timeout: Int? = nil) {
+        let timeoutValue = timeout ?? 5
+        
+        let elementPredicate = XCTNSPredicateExpectation(predicate: NSPredicate(format: predicate), object: element)
+        _ = XCTWaiter.wait(for: [elementPredicate], timeout: TimeInterval(timeoutValue))
     }
     
     func isLoaded() -> Bool {

--- a/Example/AztecUITests/Pages/EditorPage.swift
+++ b/Example/AztecUITests/Pages/EditorPage.swift
@@ -203,7 +203,7 @@ class EditorPage: BasePage {
     func addImageByOrder(id: Int) -> EditorPage {
         toolbarButtonTap(locator: elementStringIDs.mediaButton)
         let cameraRollButton = XCUIApplication().otherElements.cells["Camera Roll"]
-        _ = cameraRollButton.waitForExistence(timeout: waitTimeout)
+        waitFor(element: cameraRollButton, predicate: "isEnabled == true && isHittable == true")
         cameraRollButton.tap()
 
         // Wait for the Camera Roll Animation


### PR DESCRIPTION
This test was relying on a hardcoded textfield height which is changing with different font sizes. Now it passing on all font sizes configurations.