### PR TITLE
Adds partial support for RTL languages.

### DIFF
--- a/Aztec/Classes/Formatters/Base/ParagraphAttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/Base/ParagraphAttributeFormatter.swift
@@ -37,19 +37,12 @@ extension ParagraphAttributeFormatter {
         let rangeToApply = applicationRange(for: range, in: text)
 
         text.replaceOcurrences(of: String(.paragraphSeparator), with: String(.lineFeed), within: rangeToApply)
-
+        
         text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, stop) in
             let currentAttributes = text.attributes(at: range.location, effectiveRange: nil)
             let attributes = remove(from: currentAttributes)
-
-            let currentKeys = Set(currentAttributes.keys)
-            let newKeys = Set(attributes.keys)
-            let removedKeys = currentKeys.subtracting(newKeys)
-            for key in removedKeys {
-                text.removeAttribute(key, range: range)
-            }
-
-            text.addAttributes(attributes, range: range)
+            
+            text.setAttributes(attributes, range: range)
         }
 
         return rangeToApply

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -402,7 +402,7 @@ private extension TextStorage {
         let newLevel = newStyle?.headers.last?.level ?? .none
         let oldLevel = oldStyle?.headers.last?.level ?? .none
 
-        guard oldLevel != newLevel else {
+        guard oldLevel != newLevel && newLevel != .none else {
             return attrs
         }
         

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -243,7 +243,7 @@ class TextStorageTests: XCTestCase {
 
         html = storage.getHTML(serializer: serializer)
 
-        XCTAssertEqual(html, "Apply a header")
+        XCTAssertEqual(html, "<p>Apply a header</p>")
     }
 
     /// This test verifies that after merging two lines with different Header Format, the Font Size will


### PR DESCRIPTION
## Description:

Addresses a first part of #861 .

Outputs the writing direction to HTML.

## Testing:

1. Add the Arabic keyboard to your device.
2. Launch the editor.
3. Type a line in Arabic - make sure it's recognized as right-to-left text in visual mode.
4. Switch to HTML mode.

Make sure the paragraph or block level element has a `dir="rtl"` attribute.

Important: the conversion back to visual mode is not supported yet.



