### PR TITLE
Disable animations when running UI tests

### DIFF
--- a/Example/AztecUITests/AztecUITests.swift
+++ b/Example/AztecUITests/AztecUITests.swift
@@ -13,6 +13,7 @@ class AztecSimpleTextFormattingTests: XCTestCase {
         // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
         XCUIDevice.shared().orientation = .portrait
         app = XCUIApplication()
+        app.launchArguments = ["NoAnimations"]
         app.launch()
 
         let blogsPage = BlogsPage.init()

--- a/Example/AztecUITests/FormattingTests.swift
+++ b/Example/AztecUITests/FormattingTests.swift
@@ -11,7 +11,9 @@ class FormattingTests: XCTestCase {
         continueAfterFailure = false
         // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
         XCUIDevice.shared().orientation = .portrait
-        XCUIApplication().launch()
+        let app = XCUIApplication()
+        app.launchArguments = ["NoAnimations"]
+        app.launch()
         
         let blogsPage = BlogsPage.init()
         richEditorPage = blogsPage.gotoEmptyDemo()

--- a/Example/AztecUITests/HighPriorityIssuesTests.swift
+++ b/Example/AztecUITests/HighPriorityIssuesTests.swift
@@ -12,6 +12,7 @@ class HighPriorityIssuesTests: XCTestCase {
         // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
         XCUIDevice.shared().orientation = .portrait
         app = XCUIApplication()
+        app.launchArguments = ["NoAnimations"]
         app.launch()
         
         let blogsPage = BlogsPage.init()

--- a/Example/AztecUITests/ImagesTests.swift
+++ b/Example/AztecUITests/ImagesTests.swift
@@ -11,7 +11,9 @@ class ImagesTests: XCTestCase {
         continueAfterFailure = false
         // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
         XCUIDevice.shared().orientation = .portrait
-        XCUIApplication().launch()
+        let app = XCUIApplication()
+        app.launchArguments = ["NoAnimations"]
+        app.launch()
         
         let blogsPage = BlogsPage.init()
         richEditorPage = blogsPage.gotoEmptyDemo()

--- a/Example/AztecUITests/LinkTests.swift
+++ b/Example/AztecUITests/LinkTests.swift
@@ -11,7 +11,9 @@ class LinkTests: XCTestCase {
         continueAfterFailure = false
         // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
         XCUIDevice.shared().orientation = .portrait
-        XCUIApplication().launch()
+        let app = XCUIApplication()
+        app.launchArguments = ["NoAnimations"]
+        app.launch()
         
         let blogsPage = BlogsPage.init()
         richEditorPage = blogsPage.gotoEmptyDemo()

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -7,6 +7,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        let args = ProcessInfo().arguments
+        
+        for arg in args {
+            if arg == "NoAnimations" {
+                UIView.setAnimationsEnabled(false)
+                application.windows.first?.layer.speed = MAXFLOAT
+
+            }
+        }
         // Override point for customization after application launch.
         return true
     }


### PR DESCRIPTION
Attempt to disable animations to speed-up UI tests runs. Previous build time (on Travis) was ~28-35min.  

Some background: https://stackoverflow.com/a/40400175/712306

