### PR TITLE
Sample App: Single Title Line

### DIFF
--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -92,30 +92,17 @@ class EditorDemoController: UIViewController {
         return textView
     }()
 
-    fileprivate(set) lazy var titleTextField: UITextView = {        
-        let textField = UITextView()
-
+    fileprivate(set) lazy var titleTextField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = NSLocalizedString("Enter title here", comment: "Label for the title of the post field. Should be the same as WP core.")
+        
         textField.accessibilityLabel = NSLocalizedString("Title", comment: "Post title")
         textField.delegate = self
         textField.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.headline)
         textField.returnKeyType = .next
-        textField.textColor = UIColor.darkText
+        textField.textColor = .darkText
         textField.translatesAutoresizingMaskIntoConstraints = false
-        textField.isScrollEnabled = false
         textField.backgroundColor = .clear
-
-        return textField
-    }()
-
-    fileprivate(set) lazy var titlePlaceholderLabel: UILabel = {
-        let placeholderText = NSLocalizedString("Enter title here", comment: "Label for the title of the post field. Should be the same as WP core.")
-        let textField = UILabel()
-
-        textField.attributedText = NSAttributedString(string: placeholderText,
-                                                      attributes: [.foregroundColor: UIColor.lightGray,
-                                                                   .font: UIFont.preferredFont(forTextStyle: UIFontTextStyle.headline)])
-        textField.sizeToFit()
-        textField.translatesAutoresizingMaskIntoConstraints = false
 
         return textField
     }()
@@ -202,7 +189,6 @@ class EditorDemoController: UIViewController {
         view.addSubview(richTextView)
         view.addSubview(htmlTextView)
         view.addSubview(titleTextField)
-        view.addSubview(titlePlaceholderLabel)
         view.addSubview(separatorView)
         configureConstraints()
         registerAttachmentImageProviders()
@@ -244,28 +230,11 @@ class EditorDemoController: UIViewController {
     // MARK: - Title and Title placeholder position methods
     func updateTitlePosition() {
         let referenceView: UIScrollView = editingMode == .richText ? richTextView : htmlTextView
-        titleTopConstraint.constant = -(referenceView.contentOffset.y+referenceView.contentInset.top)
+        titleTopConstraint.constant = -(referenceView.contentOffset.y + referenceView.contentInset.top) + 5
 
         var contentInset = referenceView.contentInset
-        contentInset.top = (titleHeightConstraint.constant + separatorView.frame.height)
+        contentInset.top = titleHeightConstraint.constant - 10
         referenceView.contentInset = contentInset
-    }
-    
-    func updateTitleHeight() {
-        let referenceView: UIScrollView = editingMode == .richText ? richTextView : htmlTextView
-        let layoutMargins = view.layoutMargins
-        let insets = titleTextField.textContainerInset
-        let sizeThatShouldFitTheContent = titleTextField.sizeThatFits(CGSize(width:view.frame.width - (insets.left + insets.right + layoutMargins.left + layoutMargins.right), height: CGFloat.greatestFiniteMagnitude))
-        titleHeightConstraint.constant = max(sizeThatShouldFitTheContent.height, titleTextField.font!.lineHeight + insets.top + insets.bottom)
-
-        var contentInset = referenceView.contentInset
-        contentInset.top = (titleHeightConstraint.constant + separatorView.frame.height)
-        referenceView.contentInset = contentInset
-        referenceView.setContentOffset(CGPoint(x:0, y: -contentInset.top), animated: false)
-    }
-
-    func updateTitlePlaceholderVisibility() {
-        self.titlePlaceholderLabel.isHidden = !titleTextField.text.isEmpty
     }
 
     // MARK: - Configuration Methods
@@ -281,24 +250,17 @@ class EditorDemoController: UIViewController {
     private func configureConstraints() {
 
         titleHeightConstraint = titleTextField.heightAnchor.constraint(equalToConstant: titleTextField.font!.lineHeight)
-        titleTopConstraint = titleTextField.topAnchor.constraint(equalTo: view.topAnchor, constant: -richTextView.contentOffset.y)
-        updateTitleHeight()
+        titleTopConstraint = titleTextField.topAnchor.constraint(equalTo: view.topAnchor, constant: 5)
         let layoutGuide = view.layoutMarginsGuide
 
         NSLayoutConstraint.activate([
             titleTextField.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 0),
             titleTextField.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: 0),
             titleTopConstraint,
-            titleHeightConstraint
+            titleTextField.bottomAnchor.constraint(equalTo: separatorView.topAnchor,
+                                                   constant: -titleTopConstraint.constant)
             ])
 
-        let insets = titleTextField.textContainerInset
-        NSLayoutConstraint.activate([
-            titlePlaceholderLabel.leadingAnchor.constraint(equalTo: titleTextField.leadingAnchor, constant: insets.left + titleTextField.textContainer.lineFragmentPadding),
-            titlePlaceholderLabel.trailingAnchor.constraint(equalTo: titleTextField.trailingAnchor, constant: -insets.right),
-            titlePlaceholderLabel.topAnchor.constraint(equalTo: titleTextField.topAnchor, constant: insets.top),
-            titlePlaceholderLabel.heightAnchor.constraint(equalToConstant: titleTextField.font!.lineHeight)
-            ])
         NSLayoutConstraint.activate([
             separatorView.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: 0),
             separatorView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: 0),
@@ -309,7 +271,7 @@ class EditorDemoController: UIViewController {
         NSLayoutConstraint.activate([
             richTextView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             richTextView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            richTextView.topAnchor.constraint(equalTo: layoutGuide.topAnchor, constant: 0),
+            richTextView.topAnchor.constraint(equalTo: separatorView.bottomAnchor, constant: 0),
             richTextView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: 0)
             ])
 
@@ -459,9 +421,6 @@ extension EditorDemoController : UITextViewDelegate {
 
     func textViewDidChange(_ textView: UITextView) {
         switch textView {
-        case titleTextField:
-            updateTitleHeight()
-            updateTitlePlaceholderVisibility()
         case richTextView:
             updateFormatBar()
         default:

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -230,10 +230,10 @@ class EditorDemoController: UIViewController {
     // MARK: - Title and Title placeholder position methods
     func updateTitlePosition() {
         let referenceView: UIScrollView = editingMode == .richText ? richTextView : htmlTextView
-        titleTopConstraint.constant = -(referenceView.contentOffset.y + referenceView.contentInset.top) + 5
+        titleTopConstraint.constant = -(referenceView.contentOffset.y + referenceView.contentInset.top) + Constants.titleInsets.top
 
         var contentInset = referenceView.contentInset
-        contentInset.top = titleHeightConstraint.constant - 10
+        contentInset.top = titleHeightConstraint.constant - (Constants.titleInsets.top + Constants.titleInsets.bottom)
         referenceView.contentInset = contentInset
     }
 
@@ -250,7 +250,7 @@ class EditorDemoController: UIViewController {
     private func configureConstraints() {
 
         titleHeightConstraint = titleTextField.heightAnchor.constraint(equalToConstant: titleTextField.font!.lineHeight)
-        titleTopConstraint = titleTextField.topAnchor.constraint(equalTo: view.topAnchor, constant: 5)
+        titleTopConstraint = titleTextField.topAnchor.constraint(equalTo: view.topAnchor, constant: Constants.titleInsets.top)
         let layoutGuide = view.layoutMarginsGuide
 
         NSLayoutConstraint.activate([
@@ -1364,6 +1364,7 @@ extension EditorDemoController {
         static let headers              = [Header.HeaderType.none, .h1, .h2, .h3, .h4, .h5, .h6]
         static let lists                = [TextList.Style.unordered, .ordered]        
         static let moreAttachmentText   = "more"
+        static let titleInsets          = UIEdgeInsets(top: 5, left: 0, bottom: 5, right: 0)
     }
 
     struct MediaProgressKey {


### PR DESCRIPTION
### Details:
Limit the title to one line by using UITextField instead of UITextView. Also there is no need to have a separate UILabel for the placeholder text. We can make use of UITextField’s placeholder attribute.

Fixes #821

### To test:
1. Launch the Sample App
2. Verify that the Title Field is not multiline
