### PR TITLE
Fixing Unit Tests

### DIFF
--- a/Aztec/Classes/ElementConverters/Implementations/FigureElementConverter.swift
+++ b/Aztec/Classes/ElementConverters/Implementations/FigureElementConverter.swift
@@ -24,9 +24,7 @@ class FigureElementConverter: AttachmentElementConverter {
     
     func convert(_ element: ElementNode, inheriting attributes: [AttributedStringKey: Any]) -> (attachment: ImageAttachment, string: NSAttributedString) {
         assert(canConvert(element: element))
-        
-        let attributes = extraAttributes(for: element, inheriting: attributes)
-        
+
         // Extract the Image + Figcaption Elements
         //
         guard let imgElement = element.firstChild(ofType: .img),
@@ -48,14 +46,5 @@ class FigureElementConverter: AttachmentElementConverter {
         imageAttachment.caption = serializer.serialize(wrappedCaptionChildren, inheriting: attributes)
         
         return (imageAttachment, output)
-    }
-    
-    // MARK: - Extra attributes
-
-    private func extraAttributes(for element: ElementNode, inheriting attributes: [AttributedStringKey: Any]) -> [AttributedStringKey: Any] {
-        let elementRepresentation = HTMLElementRepresentation(element)
-        let representation = HTMLRepresentation(for: .element(elementRepresentation))
-        
-        return [.hrHtmlRepresentation: representation]
-    }
+    }    
 }

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -268,7 +268,7 @@ private extension AttributedStringSerializer {
 
         if let elementFormatter = formatter(for: element) {
             finalAttributes = elementFormatter.apply(to: finalAttributes, andStore: representation)
-        } else if element.standardName == .li || converter(for: element) != nil {
+        } else if element.standardName == .li || isAnySpecializedConverter(for: element) {
             finalAttributes = inheritedAttributes
         } else {
             finalAttributes = self.attributes(storing: elementRepresentation, in: finalAttributes)
@@ -380,15 +380,23 @@ private extension AttributedStringSerializer {
 
     // MARK: - Element Converters
 
-    /// Some element types have an implicit representation that doesn't really follow the standard
-    /// conversion logic.  Element Converters take care of that.
+    /// Some element types have an implicit representation that doesn't really follow the standard conversion logic.
+    /// Element Converters take care of that.
     ///
     func converter(for element: ElementNode) -> ElementConverter {
         let converter = elementConverters.first { converter in
             converter.canConvert(element: element)
         }
-        
+
         return converter ?? genericElementConverter
+    }
+
+    /// Indicates if there's a specialized converter (AKA anything but the default GenericConverter) that can handle a given element.
+    ///
+    func isAnySpecializedConverter(for element: ElementNode) -> Bool {
+        return elementConverters.contains { converter in
+            converter.canConvert(element: element)
+        }
     }
 }
 

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1438,7 +1438,7 @@ class TextViewTests: XCTestCase {
         let videoHTML = "<video src=\"newVideo.mp4\" poster=\"video.jpg\" data-wpvideopress=\"videopress\"></video>"
         let textView = createTextView(withHTML: videoHTML)
 
-        XCTAssertEqual(textView.getHTML(), "<p><video src=\"newVideo.mp4\" poster=\"video.jpg\" data-wpvideopress=\"videopress\"></video></p>")
+        XCTAssertEqual(textView.getHTML(), "<p><video src=\"newVideo.mp4\" data-wpvideopress=\"videopress\" poster=\"video.jpg\"></video></p>")
 
         guard let attachment = textView.storage.mediaAttachments.first as? VideoAttachment else {
             XCTFail("An video attachment should be present")
@@ -1448,7 +1448,7 @@ class TextViewTests: XCTestCase {
 
         attachment.extraAttributes["data-wpvideopress"] = "ABCDE"
 
-        XCTAssertEqual(textView.getHTML(), "<p><video src=\"newVideo.mp4\" poster=\"video.jpg\" data-wpvideopress=\"ABCDE\"></video></p>")
+        XCTAssertEqual(textView.getHTML(), "<p><video src=\"newVideo.mp4\" data-wpvideopress=\"ABCDE\" poster=\"video.jpg\"></video></p>")
     }
 
 


### PR DESCRIPTION
### Details:
In this PR we're fixing Aztec's Unit Tests:

- Patched Video HTML Tag 'Expected' parameter order.
- **FigureElementConverter** was storing a `hrHtmlRepresentation`. Probably slipped in the initial implementation.
- Patched our **UnsupportedHTML** mechanism, which wasn't running anymore, due to the new **generic element converter**.

### To test:
Verify that the unit tests are green again!

cc @diegoreymendez / @jklausa 
Thanks in advance gentlemen!


