### PR TITLE
Figcaption Shortcode Support

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		B5AF89321E93CFC80051EFDB /* RenderableAttachmentDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF89311E93CFC80051EFDB /* RenderableAttachmentDelegate.swift */; };
 		B5B86D371DA3EC250083DB3F /* NSRange+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */; };
 		B5B96DAB1E01B2F300791315 /* UIPasteboard+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B96DAA1E01B2F300791315 /* UIPasteboard+Helpers.swift */; };
+		B5B988D81FF4185400C0280D /* HTMLAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B988D71FF4185400C0280D /* HTMLAttributesTests.swift */; };
 		B5BC4FEE1DA2C17800614582 /* NSAttributedString+Lists.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BC4FED1DA2C17800614582 /* NSAttributedString+Lists.swift */; };
 		B5BC4FF21DA2D17000614582 /* NSAttributedStringListsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BC4FF11DA2D17000614582 /* NSAttributedStringListsTests.swift */; };
 		B5C16A631F4DF77300B113CF /* HeaderFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C16A621F4DF77300B113CF /* HeaderFormatterTests.swift */; };
@@ -249,6 +250,7 @@
 		B5AB79F91F5F403C00DF26F5 /* StringParagraphTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StringParagraphTests.swift; path = Extensions/StringParagraphTests.swift; sourceTree = "<group>"; };
 		B5AF89311E93CFC80051EFDB /* RenderableAttachmentDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RenderableAttachmentDelegate.swift; sourceTree = "<group>"; };
 		B5B96DAA1E01B2F300791315 /* UIPasteboard+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIPasteboard+Helpers.swift"; sourceTree = "<group>"; };
+		B5B988D71FF4185400C0280D /* HTMLAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLAttributesTests.swift; sourceTree = "<group>"; };
 		B5BC4FED1DA2C17800614582 /* NSAttributedString+Lists.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Lists.swift"; sourceTree = "<group>"; };
 		B5BC4FF11DA2D17000614582 /* NSAttributedStringListsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSAttributedStringListsTests.swift; path = Extensions/NSAttributedStringListsTests.swift; sourceTree = "<group>"; };
 		B5C16A621F4DF77300B113CF /* HeaderFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderFormatterTests.swift; sourceTree = "<group>"; };
@@ -898,6 +900,7 @@
 		FF20D6451EDC3B3900294B78 /* Processor */ = {
 			isa = PBXGroup;
 			children = (
+				B5B988D71FF4185400C0280D /* HTMLAttributesTests.swift */,
 				FF20D6461EDC3B3900294B78 /* HTMLProcessorTests.swift */,
 			);
 			path = Processor;
@@ -1178,6 +1181,7 @@
 				F18733C81DA09737005AEB80 /* NSRangeComparisonTests.swift in Sources */,
 				B5E607331DA56EC700C8A389 /* TextListFormatterTests.swift in Sources */,
 				FF20D6471EDC3B3900294B78 /* HTMLProcessorTests.swift in Sources */,
+				B5B988D81FF4185400C0280D /* HTMLAttributesTests.swift in Sources */,
 				594C9D731D8BE6C300D74542 /* InAttributeConverterTests.swift in Sources */,
 				B5D575831F22820A003A62F6 /* HTMLRepresentationTests.swift in Sources */,
 				B5D575871F2288E2003A62F6 /* TextStorageTests.swift in Sources */,

--- a/Aztec/Classes/Libxml2/Converters/In/HTMLParser.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/HTMLParser.swift
@@ -2,11 +2,16 @@ import Foundation
 import libxml2
 
 
-class HTMLParser {
+open class HTMLParser {
     
     enum Error: String, Swift.Error {
         case NoRootNode = "No root node"
     }
+
+    /// Public initializer
+    ///
+    public init() { }
+
 
     /// Parses HTML data into an HTML Node representing the same data.
     ///
@@ -15,7 +20,7 @@ class HTMLParser {
     ///
     /// - Returns: the HTML root node.
     ///
-    func parse(_ html: String) -> RootNode {
+    open func parse(_ html: String) -> RootNode {
 
         // We wrap the HTML into a special root node, since it helps avoid conversion issues
         // with libxml2, where the library would add custom tags to "fix" the HTML code we

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -265,7 +265,7 @@ public class ElementNode: Node {
     ///
     /// - Returns: the first child in the children collection, that matches the specified type.
     ///
-    func firstChild(ofType type: StandardElementType) -> ElementNode? {
+    public func firstChild(ofType type: StandardElementType) -> ElementNode? {
         let elements = children.flatMap { node in
             return node as? ElementNode
         }

--- a/Aztec/Classes/Processor/HTMLAttributes.swift
+++ b/Aztec/Classes/Processor/HTMLAttributes.swift
@@ -5,14 +5,33 @@ import Foundation
 public struct HTMLAttributes {
 
     /// Attributes that have a form key=value or key="value" or key='value'
+    ///
     public let named: [String: String]
 
     /// Attributes that have a form value "value"
+    ///
     public let unamed: [String]
 
     public init(named: [String: String], unamed: [String]) {
         self.named = named
         self.unamed = unamed
+    }
+
+    /// Serializes the current HTMLAttribute Collection into a plain string
+    ///
+    public func toString() -> String {
+        var html = String()
+        for (key, value) in named {
+            html += html.isEmpty ? String() : String(.space)
+            html += "\(key)=\"\(value)\""
+        }
+
+        for value in unamed {
+            html += html.isEmpty ? String() : String(.space)
+            html += "\(value)"
+        }
+
+        return html
     }
 }
 

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -190,7 +190,7 @@ open class ImageAttachment: MediaAttachment {
         let captionX = captionPositionX(for: captionSize.width, within: containerBounds.width)
         let captionY = mediaBounds.maxY + appearance.imageInsets.bottom + appearance.captionInsets.top
 
-        return CGRect(x: captionX, y: captionY, width: captionSize.width, height: captionSize.height)
+        return CGRect(x: captionX, y: captionY, width: captionSize.width, height: captionSize.height).integral
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -660,8 +660,10 @@ open class TextView: UITextView {
         //          https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/58
         //
         font = defaultFont
-
-        storage.setHTML(processedHTML, defaultAttributes: defaultAttributes, postProcessingHTMLWith: inputTreeProcessor)
+        
+        storage.setHTML(processedHTML,
+                        defaultAttributes: defaultAttributes,
+                        postProcessingHTMLWith: inputTreeProcessor)
 
         if storage.length > 0 && selectedRange.location < storage.length {
             typingAttributesSwifted = storage.attributes(at: selectedRange.location, effectiveRange: nil)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -660,10 +660,8 @@ open class TextView: UITextView {
         //          https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/58
         //
         font = defaultFont
-        
-        storage.setHTML(processedHTML,
-                        defaultAttributes: defaultAttributes,
-                        postProcessingHTMLWith: inputTreeProcessor)
+
+        storage.setHTML(processedHTML, defaultAttributes: defaultAttributes, postProcessingHTMLWith: inputTreeProcessor)
 
         if storage.length > 0 && selectedRange.location < storage.length {
             typingAttributesSwifted = storage.attributes(at: selectedRange.location, effectiveRange: nil)

--- a/AztecTests/Processor/HTMLAttributesTests.swift
+++ b/AztecTests/Processor/HTMLAttributesTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import Aztec
+
+
+// MARK: - HTMLAttributesTests
+//
+class HTMLAttributesTests: XCTestCase {
+
+    /// Verifies that HTMLAttributes's toString method properly serializes all of the named and unnamed attributes.
+    ///
+    func testToStringProperlySerializesHTMLAttributes() {
+        let named = ["yo": "semite", "mav": "ericks"]
+        let unamed = ["moo"]
+
+        let sample = HTMLAttributes(named: named, unamed: unamed)
+
+        let expected = "yo=\"semite\" mav=\"ericks\" moo"
+        XCTAssertEqual(expected, sample.toString())
+    }
+}

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		B570B1C91E82D332008CF41E /* SpecialTagAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B570B1C81E82D332008CF41E /* SpecialTagAttachmentRenderer.swift */; };
 		B570B1CC1E82D343008CF41E /* CommentAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B570B1CB1E82D343008CF41E /* CommentAttachmentRenderer.swift */; };
 		B5AF89341E93ECE60051EFDB /* HTMLAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF89331E93ECE60051EFDB /* HTMLAttachmentRenderer.swift */; };
+		B5B988DD1FF53E0C00C0280D /* CaptionShortcodePreProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B988DC1FF53E0C00C0280D /* CaptionShortcodePreProcessorTests.swift */; };
 		B5DB1C371EC630E10005E623 /* UnknownEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */; };
 		B5FB212A1FEC38470067D597 /* captions.html in Resources */ = {isa = PBXBuildFile; fileRef = B5FB21271FEC37DB0067D597 /* captions.html */; };
 		BE2672F31FC6E5A80026107E /* EditorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2672F21FC6E5A80026107E /* EditorPage.swift */; };
@@ -126,6 +127,7 @@
 		B570B1C81E82D332008CF41E /* SpecialTagAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpecialTagAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B570B1CB1E82D343008CF41E /* CommentAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B5AF89331E93ECE60051EFDB /* HTMLAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachmentRenderer.swift; sourceTree = "<group>"; };
+		B5B988DC1FF53E0C00C0280D /* CaptionShortcodePreProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionShortcodePreProcessorTests.swift; sourceTree = "<group>"; };
 		B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnknownEditorViewController.swift; sourceTree = "<group>"; };
 		B5FB21271FEC37DB0067D597 /* captions.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = captions.html; sourceTree = "<group>"; };
 		BE2672F21FC6E5A80026107E /* EditorPage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorPage.swift; sourceTree = "<group>"; };
@@ -270,6 +272,7 @@
 			isa = PBXGroup;
 			children = (
 				607FACE91AFB9204008FA782 /* Supporting Files */,
+				B5B988DC1FF53E0C00C0280D /* CaptionShortcodePreProcessorTests.swift */,
 				FFD06EA61EC474500072AD85 /* ShortcodeProcessorTests.swift */,
 			);
 			path = Tests;
@@ -523,6 +526,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FFD06EA71EC474500072AD85 /* ShortcodeProcessorTests.swift in Sources */,
+				B5B988DD1FF53E0C00C0280D /* CaptionShortcodePreProcessorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		B570B1CC1E82D343008CF41E /* CommentAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B570B1CB1E82D343008CF41E /* CommentAttachmentRenderer.swift */; };
 		B5AF89341E93ECE60051EFDB /* HTMLAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF89331E93ECE60051EFDB /* HTMLAttachmentRenderer.swift */; };
 		B5B988DD1FF53E0C00C0280D /* CaptionShortcodePreProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B988DC1FF53E0C00C0280D /* CaptionShortcodePreProcessorTests.swift */; };
+		B5B988E21FF54D2A00C0280D /* CaptionShortcodePostProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B988E11FF54D2A00C0280D /* CaptionShortcodePostProcessorTests.swift */; };
 		B5DB1C371EC630E10005E623 /* UnknownEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */; };
 		B5FB212A1FEC38470067D597 /* captions.html in Resources */ = {isa = PBXBuildFile; fileRef = B5FB21271FEC37DB0067D597 /* captions.html */; };
 		BE2672F31FC6E5A80026107E /* EditorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2672F21FC6E5A80026107E /* EditorPage.swift */; };
@@ -128,6 +129,7 @@
 		B570B1CB1E82D343008CF41E /* CommentAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B5AF89331E93ECE60051EFDB /* HTMLAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B5B988DC1FF53E0C00C0280D /* CaptionShortcodePreProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionShortcodePreProcessorTests.swift; sourceTree = "<group>"; };
+		B5B988E11FF54D2A00C0280D /* CaptionShortcodePostProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptionShortcodePostProcessorTests.swift; sourceTree = "<group>"; };
 		B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnknownEditorViewController.swift; sourceTree = "<group>"; };
 		B5FB21271FEC37DB0067D597 /* captions.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = captions.html; sourceTree = "<group>"; };
 		BE2672F21FC6E5A80026107E /* EditorPage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorPage.swift; sourceTree = "<group>"; };
@@ -272,6 +274,7 @@
 			isa = PBXGroup;
 			children = (
 				607FACE91AFB9204008FA782 /* Supporting Files */,
+				B5B988E11FF54D2A00C0280D /* CaptionShortcodePostProcessorTests.swift */,
 				B5B988DC1FF53E0C00C0280D /* CaptionShortcodePreProcessorTests.swift */,
 				FFD06EA61EC474500072AD85 /* ShortcodeProcessorTests.swift */,
 			);
@@ -527,6 +530,7 @@
 			files = (
 				FFD06EA71EC474500072AD85 /* ShortcodeProcessorTests.swift in Sources */,
 				B5B988DD1FF53E0C00C0280D /* CaptionShortcodePreProcessorTests.swift in Sources */,
+				B5B988E21FF54D2A00C0280D /* CaptionShortcodePostProcessorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Example/CaptionShortcodePostProcessor.swift
+++ b/Example/Example/CaptionShortcodePostProcessor.swift
@@ -24,7 +24,10 @@ class CaptionShortcodePostProcessor: HTMLProcessor {
             /// Serialize the Caption's Shortcode!
             ///
             let serializer = DefaultHTMLSerializer()
-            var html = "[caption" + shortcode.attributes.toString() + "]"
+            let attributes = shortcode.attributes.toString()
+            let padding = attributes.isEmpty ? "" : " "
+
+            var html = "[caption" + padding + attributes + "]"
 
             html += serializer.serialize(image)
 

--- a/Example/Example/CaptionShortcodePreProcessor.swift
+++ b/Example/Example/CaptionShortcodePreProcessor.swift
@@ -1,27 +1,44 @@
 import Aztec
 import Foundation
 
+
+// MARK: - CaptionShortcodePreProcessor: Converts [caption] shortcode into a <figure><img><figcaption> structure.
+//
 class CaptionShortcodePreProcessor: ShortcodeProcessor {
 
+    struct Constants {
+        static let captionTag = "caption"
+    }
+
     init() {
-        super.init(tag: "caption") { shortcode -> String in
-            var html = "<div data-shortcode=\"caption\" "
-
-            for (key, value) in shortcode.attributes.named {
-                html += "\(key)=\"\(value)\" "
+        super.init(tag: Constants.captionTag) { shortcode in
+            guard let payloadText = shortcode.content else {
+                return nil
             }
 
-            for value in shortcode.attributes.unamed {
-                html += "\(value) "
+            /// Parse the Shortcode's Payload: We expect an [Img, Text, ...]
+            ///
+            let payloadNode = HTMLParser().parse(payloadText)
+            guard let imageNode = payloadNode.firstChild(ofType: .img), payloadNode.children.count >= 2 else {
+                return nil
             }
 
-            if let content = shortcode.content {
-                html += ">" + content + "</div>"
-            } else {
-                html += "/>"
-            }
-            
-            return html
+            /// Figcaption: Figure Children (minus) the image
+            ///
+            var caption = Set(payloadNode.children)
+            caption.remove(imageNode)
+
+            let figcaptionNode = ElementNode(type: .figcaption, attributes: [], children: Array(caption))
+
+            /// Figure: Image + Figcaption! Woo!
+            ///
+            let figure = ElementNode(type: .figure, attributes: [], children: [imageNode, figcaptionNode])
+
+            /// Final Step: Serialize back to string.
+            /// This is expected to produce a `<figure><img<figcaption/></figure>` snippet.
+            ///
+            let serializer = DefaultHTMLSerializer()
+            return serializer.serialize(figure)
         }
     }
 }

--- a/Example/Example/CaptionShortcodePreProcessor.swift
+++ b/Example/Example/CaptionShortcodePreProcessor.swift
@@ -25,14 +25,27 @@ class CaptionShortcodePreProcessor: ShortcodeProcessor {
 
             /// Figcaption: Figure Children (minus) the image
             ///
-            var caption = Set(payloadNode.children)
-            caption.remove(imageNode)
+            let captionChildren = payloadNode.children.filter { node in
+                return node != imageNode
+            }
 
-            let figcaptionNode = ElementNode(type: .figcaption, attributes: [], children: Array(caption))
+            let figcaptionNode = ElementNode(type: .figcaption, attributes: [], children: captionChildren)
+
+            /// Map Shortcode Attributes into ElementNode Attributes
+            ///
+            let unnamed = shortcode.attributes.unamed.map { attribute in
+                return Attribute(name: attribute)
+            }
+
+            let named = shortcode.attributes.named.map { attribute in
+                return Attribute(name: attribute.key, value: .string(attribute.value))
+            }
+
+            let figureAttributes = named + unnamed
 
             /// Figure: Image + Figcaption! Woo!
             ///
-            let figure = ElementNode(type: .figure, attributes: [], children: [imageNode, figcaptionNode])
+            let figure = ElementNode(type: .figure, attributes: figureAttributes, children: [imageNode, figcaptionNode])
 
             /// Final Step: Serialize back to string.
             /// This is expected to produce a `<figure><img<figcaption/></figure>` snippet.

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -28,14 +28,12 @@ class EditorDemoController: UIViewController {
 
         textView.outputSerializer = DefaultHTMLSerializer(prettyPrint: true)
 
-        textView.inputProcessor =
-            PipelineProcessor([CaptionShortcodePreProcessor(),
-                               VideoShortcodePreProcessor(),
-                               WPVideoShortcodePreProcessor()])
+        textView.inputProcessor = PipelineProcessor([CaptionShortcodePreProcessor(),
+                                                     VideoShortcodePreProcessor(),
+                                                     WPVideoShortcodePreProcessor()])
 
-        textView.outputProcessor =
-            PipelineProcessor([CaptionShortcodePostProcessor(),
-                               VideoShortcodePostProcessor()])
+        textView.outputProcessor = PipelineProcessor([CaptionShortcodePostProcessor(),
+                                                      VideoShortcodePostProcessor()])
 
         let accessibilityLabel = NSLocalizedString("Rich Content", comment: "Post Rich content")
         self.configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)

--- a/Example/Example/ShortcodeProcessor.swift
+++ b/Example/Example/ShortcodeProcessor.swift
@@ -20,7 +20,7 @@ public struct Shortcode {
 ///
 open class ShortcodeProcessor: RegexProcessor {
 
-    public typealias ShortcodeReplacer = (Shortcode) -> String
+    public typealias ShortcodeReplacer = (Shortcode) -> String?
 
     let tag: String
 

--- a/Example/Tests/CaptionShortcodePostProcessorTests.swift
+++ b/Example/Tests/CaptionShortcodePostProcessorTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import AztecExample
+
+
+// MARK: - CaptionShortcodePreProcessorTests
+//
+class CaptionShortcodePostProcessorTests: XCTestCase {
+
+    let processor = CaptionShortcodePostProcessor()
+
+
+    /// Verifies that a [Figure + Image + Figcaption] structure is properly mapped into a Caption Shortcode.
+    ///
+    func testFigureAndFigcaptionAreProperlyConvertedIntoCaptionShortcode() {
+        let input = "<figure><img src=\".\"><figcaption>Text</figcaption></figure>"
+        let expected = "[caption]<img src=\".\">Text[/caption]"
+
+        XCTAssertEqual(processor.process(input), expected)
+    }
+
+
+    /// Verifies that a [Figure + Image + Figcaption (with nested tags)] structure is properly mapped into a Caption Shortcode.
+    ///
+    func testFigureTagWithNestedFigcaptionEntitiesIsProperlyConvertedBackIntoCaptionShortcode() {
+        let input = "<figure><img src=\".\"><figcaption><b>Text</b><br><br><br></figcaption></figure>"
+        let expected = "[caption]<img src=\".\"><b>Text</b><br><br><br>[/caption]"
+
+        XCTAssertEqual(processor.process(input), expected)
+    }
+
+
+    /// Verifies that a Figure Tag (with parameters) gets properly converted into a Caption Shortcode.
+    ///
+    func testCaptionShortcodeAttributesAreProperlyPassedOntoTheFigureTag() {
+        let input = "<figure align=\"alignleft\" class=\"span data-mce-type=\" id=\"attachment_6\" width=\"300\">" +
+                        "<img src=\".\"><figcaption>Text</figcaption>" +
+                    "</figure>"
+
+        let expected = "[caption align=\"alignleft\" class=\"span data-mce-type=\" id=\"attachment_6\" width=\"300\"]" +
+                            "<img src=\".\">Text" +
+                        "[/caption]"
+
+        XCTAssertEqual(processor.process(input), expected)
+    }
+
+
+    /// Verifies that a figure with no figcaption tag does not get converted into a Caption Shortcode.
+    ///
+    func testFigureTagIsNotConvertedIntoCaptionShortcodeWheneverThereIsNoTextContent() {
+        let input = "<figure><img src=\".\"></figure>"
+
+        XCTAssertEqual(processor.process(input), input)
+    }
+
+
+    /// Verifies that a Figure Tag is not converted into a Caption Shortcode, whenever there is no image associated to it.
+    ///
+    func testFigureTagIsNotConvertedIntoCaptionShortcodeWheneverThereIsNoImage() {
+        let input = "<figure><figcaption>Text</figcaption></figure>"
+
+        XCTAssertEqual(processor.process(input), input)
+    }
+}

--- a/Example/Tests/CaptionShortcodePreProcessorTests.swift
+++ b/Example/Tests/CaptionShortcodePreProcessorTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import AztecExample
+
+
+// MARK: - CaptionShortcodePreProcessorTests
+//
+class CaptionShortcodePreProcessorTests: XCTestCase {
+
+    let processor = CaptionShortcodePreProcessor()
+
+
+    /// Verifies that a Caption Shortcode wrapping an Image + Text is properly processed.
+    ///
+    func testCaptionShortcodeIsProperlyConvertedIntoFigureTag() {
+        let input = "[caption]<img src=\".\">Text[/caption]"
+        let expected = "<figure><img src=\".\"><figcaption>Text</figcaption></figure>"
+
+        XCTAssertEqual(processor.process(input), expected)
+    }
+
+
+    /// Verifies that a caption shortcode wrapping [Image + Text + Multiple Line Breaks] is properly processed.
+    ///
+    func testCaptionShortcodeIsProperlyConvertedIntoFigureTagPreservingNestedTags() {
+        let input = "[caption]<img src=\".\"><b>Text</b><br><br><br>[/caption]"
+        let expected = "<figure><img src=\".\"><figcaption><b>Text</b><br><br><br></figcaption></figure>"
+
+        XCTAssertEqual(processor.process(input), expected)
+    }
+
+
+    /// Verifies that the caption shortcode's attributes are transferred over the Figure Tag.
+    ///
+    func testCaptionShortcodeAttributesAreProperlyPassedOntoTheFigureTag() {
+        let input = "[caption id=\"attachment_6\" align=\"alignleft\" width=\"300\" class=\"span data-mce-type=\"]" +
+                        "<img src=\".\">Text" +
+                    "[/caption]"
+
+        let expected = "<figure align=\"alignleft\" class=\"span data-mce-type=\" id=\"attachment_6\" width=\"300\">" +
+                            "<img src=\".\"><figcaption>Text</figcaption>" +
+                        "</figure>"
+
+        XCTAssertEqual(processor.process(input), expected)
+    }
+
+
+    /// Verifies that a caption shortcode with no text doesn't get processed.
+    ///
+    func testCaptionShortcodeDoesNotGetProcessedIfThereIsNoTextContent() {
+        let input = "[caption]<img src=\".\">[/caption]"
+
+        XCTAssertEqual(processor.process(input), input)
+    }
+
+
+    /// Verifies that a caption shortcode with no image doesn't get processed.
+    ///
+    func testCaptionShortcodeDoesNotGetProcessedIfThereIsNoImage() {
+        let input = "[caption]Text[/caption]"
+
+        XCTAssertEqual(processor.process(input), input)
+    }
+}

--- a/Example/Tests/ShortcodeProcessorTests.swift
+++ b/Example/Tests/ShortcodeProcessorTests.swift
@@ -1,16 +1,11 @@
 import XCTest
 @testable import AztecExample
 
+
+// MARK: - ShortcodeProcessorTests
+//
 class ShortcodeProcessorTests: XCTestCase {
-    
-    override func setUp() {
-        super.setUp()
-    }
-    
-    override func tearDown() {
-        super.tearDown()
-    }
-    
+
     func testParserOfVideoPressCode() {
         let shortCodeParser = ShortcodeProcessor(tag:"wpvideo", replacer:{ (shortcode) in
             var html = "<video "
@@ -45,5 +40,4 @@ class ShortcodeProcessorTests: XCTestCase {
         let parsedText = shortCodeParser.process(sampleText)
         XCTAssertEqual(parsedText, "<video src=\"video-source.mp4\" />")
     }
-    
 }


### PR DESCRIPTION
### Details:
In this PR we're adding support for **caption** shortcode processing:

- **CaptionShortcodePreProcessor:** Converts `[caption]` shortcode into `<figure><img><figcaption>` structures
- **CaptionShortcodePostProcessor:** Converts `<figure><img><figcaption>` back into `[caption]` shortcodes.

Closes #879 

Needs Review: @diegoreymendez 

### Scenario: Tests
Run `CaptionShortcodePreProcessorTests` and `CaptionShortcodePostProcessorTests` and verify all of the tests are green (**AztecExample.app**).

### Scenario: Shortcodes
Verify that the **caption** shortcode works as expected:

1. Input:
```
<figure><img src="."><figcaption><b>Test</b></figcaption></figure>
```


2. Output:
```
[caption]<img src=\".\"><b>Test</b>[/caption]
```

