### PR TITLE
ImageAttachment: Explicit Width and Height

### DIFF
--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -910,6 +910,10 @@ private extension AttributedStringParser {
             imageElement.updateAttribute(named: attribute.name, value: attribute.value)
         }
 
+        for attribute in imageSizeAttributes(from: attachment) {
+            imageElement.updateAttribute(named: attribute.name, value: attribute.value)
+        }
+
         for (key,value) in attachment.extraAttributes {
             var finalValue = value
             if key == "class", let baseValue = imageElement.stringValueForAttribute(named: "class"){
@@ -1039,6 +1043,24 @@ private extension AttributedStringParser {
         }
 
         return Attribute(name: "class", value: .string(style))
+    }
+
+
+    /// Extracts the Image's Width and Height attributes, whenever the Attachment's Size is set to (anything) but .none.
+    ///
+    private func imageSizeAttributes(from attachment: ImageAttachment) -> [Attribute] {
+        guard let imageSize = attachment.image?.size, attachment.size.shouldResizeAsset else {
+            return []
+        }
+
+        let calculatedHeight = floor(attachment.size.width * imageSize.height / imageSize.width)
+        let heightValue = String(describing: Int(calculatedHeight))
+        let widthValue = String(describing: Int(attachment.size.width))
+
+        return [
+            Attribute(name: "width", value: .string(widthValue)),
+            Attribute(name: "height", value: .string(heightValue))
+        ]
     }
 
 

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -310,6 +310,10 @@ extension ImageAttachment {
         case full
         case none
 
+        var shouldResizeAsset: Bool {
+            return width != Settings.maximum
+        }
+
         func htmlString() -> String {
             switch self {
             case .thumbnail:

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
@@ -860,6 +860,71 @@ class AttributedStringParserTests: XCTestCase {
     }
 
 
+    /// Verifies that Images with their .size property set to [.thumbnail, .medium, .large] do get explicit `width` and `height` attributes.
+    ///
+    /// - Input: Image Attachment, with it's size set to [.thumbnail, .medium, .large].
+    ///
+    /// - Output: <img width=".." height=".">, matching the tested size
+    ///
+    func testImagesWithNonDefaultSizeGetsExplicitWidthAndHeightAttributes() {
+        let attachment = ImageAttachment(identifier: UUID().uuidString)
+        attachment.image = Assets.imageIcon
+
+        let string = NSAttributedString(attachment: attachment)
+        let parser = AttributedStringParser()
+
+        for targetSize in [ImageAttachment.Size.thumbnail, .medium, .large] {
+
+            attachment.size = targetSize
+
+            let node = parser.parse(string)
+            XCTAssert(node.children.count == 1)
+
+            let imageNode = node.firstChild(ofType: .p)?.firstChild(ofType: .img)
+            XCTAssertNotNil(imageNode)
+
+            let widthAttribute = imageNode?.attributes.first { $0.name == "width" }
+            XCTAssertNotNil(widthAttribute)
+            XCTAssertEqual(widthAttribute?.value.toString(), String(describing: Int(targetSize.width)))
+
+            let heightAttribute = imageNode?.attributes.first { $0.name == "height" }
+            XCTAssertNotNil(heightAttribute)
+        }
+    }
+
+
+    /// Verifies that Images with their .size property set to [.full, .none] do NOT get explicit `width` and `height` attributes.
+    ///
+    /// - Input: Image Attachment, with it's size set to [.full, .none].
+    ///
+    /// - Output: <img />, with no "height=" nor "width=" attributes.
+    ///
+    func testImagesWithDefaultSizesDoNotGetExplicitDimensionAttributes() {
+        let attachment = ImageAttachment(identifier: UUID().uuidString)
+        attachment.image = Assets.imageIcon
+
+        let string = NSAttributedString(attachment: attachment)
+        let parser = AttributedStringParser()
+
+        for targetSize in [ImageAttachment.Size.full, .none] {
+
+            attachment.size = targetSize
+
+            let node = parser.parse(string)
+            XCTAssert(node.children.count == 1)
+
+            let imageNode = node.firstChild(ofType: .p)?.firstChild(ofType: .img)
+            XCTAssertNotNil(imageNode)
+
+            let widthAttribute = imageNode?.attributes.first { $0.name == "width" }
+            XCTAssertNil(widthAttribute)
+
+            let heightAttribute = imageNode?.attributes.first { $0.name == "height" }
+            XCTAssertNil(heightAttribute)
+        }
+    }
+
+
     /// Verifies that Images with it's caption field get properly wrapped within a figure element.
     ///
     /// - Input: Image Attachment, with it's caption set.


### PR DESCRIPTION
### Description:
In this PR we're enhancing the AttributedStringParser, so that ImageAttachments get their **width** and **height** properly serialized, whenever the size is set to (anything) but `.none / .full`.

Needs Review: @diegoreymendez / @SergioEstevao 
Closes #883

### Details:
Motivation for this PR is [this WPiOS issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/8384#issuecomment-354154635).

**TL;DR version:** `WordPress.com/wp-admin`'s post editor doesn't pick up the size's CSS classes. Instead, it relies on explicit width / height fields, in order to render images in their 'actual final size'.

In this PR we're explicitly setting the image's size, so that wp-admin behaves in a WYSIWYG fashion.

### To test:
1. Run the unit tests. Verify they're green!
2. Add an attachment. Change it's size to `None / Full`, switch to HTML, and verify no width or height attribute shows up.
3. Change the attachment's size to `Thumbnail / Medium / Large`. Verify that the HTML produced, for each image size, contains explicit `width` and `height` fields.
