### PR TITLE
FormatBar: Fix vertical position after updating for safe area insets

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -443,7 +443,10 @@ open class FormatBar: UIView {
             heightConstraint?.constant = newHeight
             updateDividerInsets()
             invalidateIntrinsicContentSize()
-            layoutIfNeeded()
+
+            DispatchQueue.main.async {
+                self.layoutIfNeeded()
+            }
         }
     }
 

--- a/Aztec/Classes/GUI/FormatBar/FormatBar.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBar.swift
@@ -444,6 +444,10 @@ open class FormatBar: UIView {
             updateDividerInsets()
             invalidateIntrinsicContentSize()
 
+            // Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/8413.
+            // Despite this method always being called on the main thread, without
+            // this dispatch the toolbar's vertical position sometimes doesn't get
+            // to be adjusted by the system to account for its height change.
             DispatchQueue.main.async {
                 self.layoutIfNeeded()
             }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/8413.

I apologise that the fix is a `dispatch async`, but I tried a number of things and couldn't come up with another way to fix this. Essentially, we resize the toolbar as necessary when the safe area insets change, but for some reason in the situation described in the original ticket the system doesn't adjust the position of the bar to match its new height unless we dispatch it.

**To test:**

* Follow the steps in the original issue, and check that the format bar appears in the correct vertical position.