### PR TITLE
Change attachment delete delegate interface to return the full attachment

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -47,9 +47,9 @@ protocol TextStorageAttachmentsDelegate: class {
     ///
     /// - Parameters:
     ///   - textView: The textView where the attachment was removed.
-    ///   - attachmentID: The attachment identifier of the media removed.
+    ///   - attachment: The media attachment that was removed.
     ///
-    func storage(_ storage: TextStorage, deletedAttachmentWith attachmentID: String)
+    func storage(_ storage: TextStorage, deletedAttachment: MediaAttachment)
 
     /// Provides the Bounds required to represent a given attachment, within a specified line fragment.
     ///
@@ -213,7 +213,7 @@ open class TextStorage: NSTextStorage {
         }
 
         textStore.enumerateAttachmentsOfType(MediaAttachment.self, range: range) { (attachment, range, stop) in
-            delegate.storage(self, deletedAttachmentWith: attachment.identifier)
+            delegate.storage(self, deletedAttachment: attachment)
         }
     }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -46,9 +46,9 @@ public protocol TextViewAttachmentDelegate: class {
     ///
     /// - Parameters:
     ///   - textView: The textView where the attachment was removed.
-    ///   - attachmentID: The attachment identifier of the media removed.
+    ///   - attachment: The media attachment that was removed.
     ///
-    func textView(_ textView: TextView, deletedAttachmentWith attachmentID: String)
+    func textView(_ textView: TextView, deletedAttachment attachment: MediaAttachment)
 
     /// Called after an attachment is selected with a single tap.
     ///
@@ -1792,8 +1792,8 @@ extension TextView: TextStorageAttachmentsDelegate {
         return textAttachmentDelegate.textView(self, urlFor: imageAttachment)
     }
 
-    func storage(_ storage: TextStorage, deletedAttachmentWith attachmentID: String) {
-        textAttachmentDelegate?.textView(self, deletedAttachmentWith: attachmentID)
+    func storage(_ storage: TextStorage, deletedAttachment attachment: MediaAttachment) {
+        textAttachmentDelegate?.textView(self, deletedAttachment: attachment)
     }
 
     func storage(_ storage: TextStorage, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -102,8 +102,8 @@ class TextStorageTests: XCTestCase {
 
         var deletedAttachmendIDCalledWithString: String?
 
-        func storage(_ storage: TextStorage, deletedAttachmentWith attachmentID: String) {
-            deletedAttachmendIDCalledWithString = attachmentID
+        func storage(_ storage: TextStorage, deletedAttachment attachment: MediaAttachment) {
+            deletedAttachmendIDCalledWithString = attachment.identifier
         }
 
         func storage(_ storage: TextStorage, urlFor imageAttachment: ImageAttachment) -> URL? {

--- a/AztecTests/TextKit/TextViewStubAttachmentDelegate.swift
+++ b/AztecTests/TextKit/TextViewStubAttachmentDelegate.swift
@@ -31,7 +31,7 @@ class TextViewStubAttachmentDelegate: TextViewAttachmentDelegate, TextViewAttach
         return nil
     }
 
-    func textView(_ textView: TextView, deletedAttachmentWith attachmentID: String) {
+    func textView(_ textView: TextView, deletedAttachment attachment: MediaAttachment) {
 
     }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1026,8 +1026,8 @@ extension EditorDemoController: TextViewAttachmentDelegate {
         return saveToDisk(image: image)
     }
 
-    func textView(_ textView: TextView, deletedAttachmentWith attachmentID: String) {
-        print("Attachment \(attachmentID) removed.\n")
+    func textView(_ textView: TextView, deletedAttachment attachment: MediaAttachment) {
+        print("Attachment \(attachment.identifier) removed.\n")
     }
 
     func textView(_ textView: TextView, selected attachment: NSTextAttachment, atPosition position: CGPoint) {


### PR DESCRIPTION
Fixes #891

This PR changes the interface of delegate callback when attachments are deleted, instead of only passing back the identifier the full attachment object is being sent.

To test:
 - Open the editor demo app
 - Delete media attachment and see if all works ok.
