### PR TITLE
Refresh layout display only when progress is changed.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1511,12 +1511,15 @@ open class TextView: UITextView {
     /// - Parameters:
     ///   - attachment: the attachment to update
     ///
-    open func refresh(_ attachment: NSTextAttachment) {
+    open func refresh(_ attachment: NSTextAttachment, overlayUpdateOnly: Bool = false) {
         guard let range = storage.range(for: attachment) else {
             return
         }
-
-        storage.edited(.editedAttributes, range: range, changeInLength: 0)
+        if overlayUpdateOnly {
+            layoutManager.invalidateDisplay(forCharacterRange: range)
+        } else {
+            storage.edited(.editedAttributes, range: range, changeInLength: 0)
+        }
     }
 
     /// Helper that allows us to Edit a NSTextAttachment instance, with two extras:

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1510,6 +1510,7 @@ open class TextView: UITextView {
     ///
     /// - Parameters:
     ///   - attachment: the attachment to update
+    ///   - overlayUpdateOnly: when this arguments is true, the attachment is only marked to refresh it's display, witthout the need to relayout. This should only be used when changes done to the attachment don't affect it's previous dimensions.
     ///
     open func refresh(_ attachment: NSTextAttachment, overlayUpdateOnly: Bool = false) {
         guard let range = storage.range(for: attachment) else {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1255,7 +1255,7 @@ private extension EditorDemoController
                 videoAttachment.srcURL = videoURL
             }
         }
-        richTextView.refresh(attachment)
+        richTextView.refresh(attachment, overlayUpdateOnly: true)
     }
 
     var mediaMessageAttributes: [NSAttributedStringKey: Any] {


### PR DESCRIPTION
Fixes #899 

This PR adds a new parameter to the refresh attachment method to allow only mark the attachment for redisplay instead of a full layout step that makes the textview scroll up and down.

To test:
 - Start with the empty editor
 - Write a paragraph with text
 - Add three images after the paragraph.
 - After those are "uploaded", and a fourth one.
 - While the "upload/progress" is going on scroll to the top and edit the first paragraph
 - Check that the doesn't scroll up and down while uploaded is going on.
