### PR TITLE
Align center not being saved

### DIFF
--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -1030,9 +1030,7 @@ private extension AttributedStringParser {
     ///
     private func imageClassAttribute(from attachment: ImageAttachment) -> Attribute? {
         var style = String()
-        if attachment.alignment != .center {
-            style += attachment.alignment.htmlString()
-        }
+        style += attachment.alignment.htmlString()        
         
         if attachment.size != .none {
             style += style.isEmpty ? String() : String(.space)

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -16,7 +16,7 @@ open class ImageAttachment: MediaAttachment {
 
     /// Attachment Alignment
     ///
-    open var alignment: Alignment = .center {
+    open var alignment: Alignment = .none {
         willSet {
             if newValue != alignment {
                 glyphImage = nil

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringSerializerTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringSerializerTests.swift
@@ -154,7 +154,7 @@ class AttributedStringSerializerTests: XCTestCase {
     /// Verifies that a linked image is properly converted from HTML to attributed string and back to HTML.
     ///
     func testLinkedImageGetsProperlyEncodedAndDecoded() {
-        let inHtml = "<p><a href=\"https://wordpress.com\"><img src=\"https://s.w.org/about/images/wordpress-logo-notext-bg.png\"></a></p>"
+        let inHtml = "<p><a href=\"https://wordpress.com\" class=\"alignnone\"><img src=\"https://s.w.org/about/images/wordpress-logo-notext-bg.png\" class=\"alignnone\"></a></p>"
         
         let inNode = HTMLParser().parse(inHtml)
         let attrString = attributedString(from: inNode)

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -134,7 +134,7 @@ class TextStorageTests: XCTestCase {
         let html = storage.getHTML(serializer: serializer)
 
         XCTAssertEqual(attachment.url, URL(string: "https://wordpress.com"))
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"></p>")
     }
 
     /// Verifies that any edition performed on ImageAttachment attributes is properly serialized back during
@@ -321,7 +321,7 @@ class TextStorageTests: XCTestCase {
 
         XCTAssertEqual(firstAttachment.url, URL(string: "https://wordpress.com"))
         XCTAssertEqual(secondAttachment.url, URL(string: "https://wordpress.org"))
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\"><img src=\"https://wordpress.org\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"><img src=\"https://wordpress.org\" class=\"alignnone\"></p>")
     }
 
     /// This test check if the insertion of two images one after the other works correctly and to img tag are inserted
@@ -336,7 +336,7 @@ class TextStorageTests: XCTestCase {
 
         XCTAssertEqual(firstAttachment.url, URL(string: "https://wordpress.com"))
         XCTAssertEqual(secondAttachment.url, URL(string: "https://wordpress.com"))
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\"><img src=\"https://wordpress.com\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"><img src=\"https://wordpress.com\" class=\"alignnone\"></p>")
     }
 
     /// This test verifies if the `removeTextAttachements` call effectively nukes all of the TextAttachments present

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1523,7 +1523,7 @@ class TextViewTests: XCTestCase {
 
         let html = textView.getHTML()
 
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"></p>")
 
         textView.selectedRange = NSRange(location: NSAttributedString.lengthOfTextAttachment, length: 1)
         guard let font = textView.typingAttributesSwifted[.font] as? UIFont else {
@@ -1550,7 +1550,7 @@ class TextViewTests: XCTestCase {
 
         var html = textView.getHTML()
 
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"></p>")
 
         textView.remove(attachmentID: attachment.identifier)
 
@@ -1608,7 +1608,7 @@ class TextViewTests: XCTestCase {
     /// This test verifies that img class attributes are not duplicated
     ///
     func testParseImageDoesntDuplicateExtraAttributes() {
-        let html = "<img src=\"image.jpg\" class=\"wp-image-test\" title=\"Title\" alt=\"Alt\">"
+        let html = "<img src=\"image.jpg\" class=\"alignnone wp-image-test\" title=\"Title\" alt=\"Alt\">"
         let textView = createTextView(withHTML: html)
         let generatedHTML = textView.getHTML()
 
@@ -1798,7 +1798,7 @@ class TextViewTests: XCTestCase {
 
         let html = textView.getHTML()
 
-        XCTAssertEqual(html, "<p><img src=\"http://placeholder\"></p>" )
+        XCTAssertEqual(html, "<p><img src=\"http://placeholder\" class=\"alignnone\"></p>" )
     }
 
     /// This test makes sure that if an `<hr>` was in the original HTML, it will still get output after our processing.

--- a/Example/AztecUITests/ImagesTests.swift
+++ b/Example/AztecUITests/ImagesTests.swift
@@ -66,7 +66,7 @@ class ImagesTests: XCTestCase {
     // Tests the issue described in
     // https://github.com/wordpress-mobile/AztecEditor-Android/issues/196
     func testParsingOfImagesWithLink() {
-        let imageHtml = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\"><img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\"></a>"
+        let imageHtml = "<a href=\"https://github.com/wordpress-mobile/WordPress-Aztec-Android\"><img src=\"https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png\" class=\"alignnone\"></a>"
         let expectedHTML = "<p>" + imageHtml + "</p>"
         
         let html = richEditorPage

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1204,6 +1204,7 @@ private extension EditorDemoController
         
         let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange, sourceURL: fileURL, placeHolderImage: image)
         attachment.size = .full
+        attachment.alignment = .none
         if let attachmentRange = richTextView.textStorage.ranges(forAttachment: attachment).first {
             richTextView.setLink(fileURL, inRange: attachmentRange)
         }


### PR DESCRIPTION
Fixes #890

This PR changes the alignment setting on images to be by default `none` it also make sure that all alignments are written in the serialiser.

One thing that come up to my mind is: should we have a value for the alignment enum called "not defined" for cases where no alignment is set on HTML? it will be visually equivalent to none but it will tell us if no value was available  the original HTML and that we don't need to write anything.

To test:
 - Open the editor app on empty demo mode
 - Insert an image
 - Switch to HTML and see if alignm class setting is `alignnone`
 - Switch to visual tap on the image and change alignment to center
 - Switch to HTML mode and see if align class setting is `aligncenter`
 - Do the same for right and left alignments. 
