### PR TITLE
TextView: Allow linking text with a pasted URL

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -409,13 +409,7 @@ open class TextView: UITextView {
     }
 
     open override func paste(_ sender: Any?) {
-        if let urlTypes = UIPasteboardTypeListURL as? [String],
-            UIPasteboard.general.contains(pasteboardTypes: urlTypes),
-            let pastedURL = UIPasteboard.general.url,
-            selectedRange.length > 0 {
-            // If we have some selected text, and a URL is pasted,
-            // create a link with the selected text.
-            setLink(pastedURL, inRange: selectedRange)
+        if tryPastingURL() {
             return
         }
 
@@ -451,6 +445,24 @@ open class TextView: UITextView {
         storage.replaceCharacters(in: selectedRange, with: string)
         notifyTextViewDidChange()
         selectedRange = NSRange(location: selectedRange.location + string.length, length: 0)
+    }
+
+    /// If there is selected text and a URL is available on the pasteboard,
+    /// this method creates a link to the URL using the selected text.
+    /// - returns: True if a link was successfully created
+    ///
+    private func tryPastingURL() -> Bool {
+        guard let urlTypes = UIPasteboardTypeListURL as? [String],
+            UIPasteboard.general.contains(pasteboardTypes: urlTypes),
+            let pastedURL = UIPasteboard.general.url,
+            selectedRange.length > 0 else {
+                return false
+        }
+
+        // If we have some selected text, and a URL is pasted,
+        // create a link with the selected text.
+        setLink(pastedURL, inRange: selectedRange)
+        return true
     }
 
     // MARK: - Intercept Keystrokes

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -409,6 +409,16 @@ open class TextView: UITextView {
     }
 
     open override func paste(_ sender: Any?) {
+        if let urlTypes = UIPasteboardTypeListURL as? [String],
+            UIPasteboard.general.contains(pasteboardTypes: urlTypes),
+            let pastedURL = UIPasteboard.general.url,
+            selectedRange.length > 0 {
+            // If we have some selected text, and a URL is pasted,
+            // create a link with the selected text.
+            setLink(pastedURL, inRange: selectedRange)
+            return
+        }
+
         guard let string = UIPasteboard.general.loadAttributedString() else {
             super.paste(sender)
             return


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/6904

This PR detects URLs on the pasteboard during a paste operation, and creates a link with the currently selected text if there is any. This should match the way Calypso works.

![aztec-paste](https://user-images.githubusercontent.com/4780/36985426-267a2c3a-208f-11e8-82ed-6c568150ef66.gif)

**To test:**

* Copy a URL to the pasteboard – for example, hit the Share button in Safari and copy the link
* Select some text in Aztec and hit paste in the popup menu
* The selected text should become a link
* If you try pasting onto an empty line (no text selected), the existing paste handling code should just insert the URL.
* Ensure pasting other items still works as expected. I found if I tried to copy an image directly out of Safari I couldn't always paste it as I might expect to, but that seems to be a pre-existing issue. Sometimes the URL just inserts instead – I think this is due to `loadAttributedString()` not returning anything.
