### PR TITLE
Issue/915 set and remove link

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -837,6 +837,33 @@ open class TextView: UITextView {
         notifyTextViewDidChange()
     }
 
+    func apply(formatter: AttributeFormatter, atRange range: NSRange, remove: Bool) {
+
+        let applicationRange = formatter.applicationRange(for: range, in: textStorage)
+        let originalString = storage.attributedSubstring(from: applicationRange)
+
+        undoManager?.registerUndo(withTarget: self, handler: { [weak self] target in
+            self?.undoTextReplacement(of: originalString, finalRange: applicationRange)
+        })
+
+        if remove {
+            formatter.removeAttributes(from: storage, at: applicationRange)
+        } else {
+            formatter.applyAttributes(to: storage, at: applicationRange)
+        }        
+
+        if applicationRange.length == 0 {
+            typingAttributesSwifted = formatter.toggle(in: typingAttributesSwifted)
+        } else {
+            // NOTE: We are making sure that the selectedRange location is inside the string
+            // The selected range can be out of the string when you are adding content to the end of the string.
+            // In those cases we check the atributes of the previous caracter
+            let location = max(0,min(selectedRange.location, textStorage.length-1))
+            typingAttributesSwifted = textStorage.attributes(at: location, effectiveRange: nil)
+        }
+        notifyTextViewDidChange()
+    }
+
     /// Adds or removes a bold style from the specified range.
     ///
     /// - Parameter range: The NSRange to edit.
@@ -1258,7 +1285,7 @@ open class TextView: UITextView {
     open func setLink(_ url: URL, inRange range: NSRange) {
         let formatter = LinkFormatter()
         formatter.attributeValue = url
-        toggle(formatter: formatter, atRange: range)
+        apply(formatter: formatter, atRange: range, remove: false)
     }
 
     /// Removes the link, if any, at the specified range
@@ -1267,8 +1294,7 @@ open class TextView: UITextView {
     ///
     open func removeLink(inRange range: NSRange) {
         let formatter = LinkFormatter()
-        formatter.toggle(in: storage, at: range)
-        notifyTextViewDidChange()
+        apply(formatter: formatter, atRange: range, remove: true)
     }
 
 

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -673,6 +673,44 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(textView.getHTML(), "<p><a href=\"\(linkUrl)\">\(linkTitle)</a></p>")
     }
 
+    /// Tests that inserting a link on the same place twice works properly
+    ///
+    func testSetLinkTwiceInSameRangeWorks() {
+
+        let linkUrl = "www.wordpress.com"
+        let linkTitle = "WordPress.com"
+        let insertionRange = NSRange(location: 0, length: linkTitle.utf8.count)
+
+        let textView = createTextView(withHTML: linkTitle)
+        let url = URL(string: linkUrl)!
+
+        textView.setLink(url, inRange: insertionRange)
+        XCTAssertEqual(textView.getHTML(), "<p><a href=\"\(linkUrl)\">\(linkTitle)</a></p>")
+        textView.setLink(url, inRange: insertionRange)
+
+        XCTAssertEqual(textView.getHTML(), "<p><a href=\"\(linkUrl)\">\(linkTitle)</a></p>")
+    }
+
+    /// Tests that removing a link on the same place twice works properly
+    ///
+    func testRemoveLinkTwiceInSameRangeWorks() {
+
+        let linkUrl = "www.wordpress.com"
+        let linkTitle = "WordPress.com"
+        let insertionRange = NSRange(location: 0, length: linkTitle.utf8.count)
+
+        let textView = createTextView(withHTML: linkTitle)
+        let url = URL(string: linkUrl)!
+
+        textView.setLink(url, inRange: insertionRange)
+        XCTAssertEqual(textView.getHTML(), "<p><a href=\"\(linkUrl)\">\(linkTitle)</a></p>")
+        textView.removeLink(inRange: insertionRange)
+        XCTAssertEqual(textView.getHTML(), "<p>\(linkTitle)</p>")
+        textView.removeLink(inRange: insertionRange)
+
+        XCTAssertEqual(textView.getHTML(), "<p>\(linkTitle)</p>")
+    }
+
     func testParsingOfInvalidLink() {
         let html = "<p><a href=\"\\http:\\badlink&?\">link</a></p>"
         let textView = createTextView(withHTML: html)

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1321,14 +1321,13 @@ private extension EditorDemoController
         
         let linkInfo = richTextView.linkInfo(for: attachment)
         let linkRange = linkInfo?.range
-        let linkURL = linkInfo?.url
         let linkUpdateRange = linkRange ?? richTextView.textStorage.ranges(forAttachment: attachment).first!
         
         if let linkURL = linkInfo?.url {
             detailsViewController.linkURL = linkURL
         }
 
-        detailsViewController.onUpdate = { [weak self] (alignment, size, url, updatedURL, alt, caption) in
+        detailsViewController.onUpdate = { [weak self] (alignment, size, srcURL, linkURL, alt, caption) in
             guard let `self` = self else {
                 return
             }
@@ -1340,7 +1339,7 @@ private extension EditorDemoController
 
                 updated.alignment = alignment
                 updated.size = size
-                updated.updateURL(url)
+                updated.updateURL(srcURL)
 
                 if let caption = caption, caption.length > 0 {
                     self.richTextView.replaceCaption(for: attachment, with: caption)
@@ -1349,8 +1348,8 @@ private extension EditorDemoController
                 }
             }
             
-            if let updatedURL = updatedURL {
-                self.richTextView.setLink(updatedURL, inRange: linkUpdateRange)
+            if let newLinkURL = linkURL {
+                self.richTextView.setLink(newLinkURL, inRange: linkUpdateRange)
             } else if linkURL != nil {
                 self.richTextView.removeLink(inRange: linkUpdateRange)
             }


### PR DESCRIPTION
Fixes #915 

This PR fixes the `setLink` and `removeLink` methods to proper set and remove links instead of doing a toggle.

To test:

 - Open the demo app.
- Select an image
- Edit the options
- Write something for the link of the image
- Press Done
- Tap to edit again
- Tap done again
- Switch to HTML
- Notice that the link is still there
- Also after adding a link to a section of text, tap on the link option in the toolbar and select remove and see if it works properly
