### PR TITLE
NSParagraphStyle's isEqual now compares correctly against ParagraphStyle.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -141,6 +141,8 @@
 		F1C05B9D1E37FA77007510EA /* String+CharacterName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B9C1E37FA77007510EA /* String+CharacterName.swift */; };
 		F1C05B9F1E37FD2F007510EA /* NSAttributedString+CharacterName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B9E1E37FD2F007510EA /* NSAttributedString+CharacterName.swift */; };
 		F1DE83D51EF20493009269E6 /* UIColor+Parsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DE83D41EF20493009269E6 /* UIColor+Parsers.swift */; };
+		F1E1B7762062BD47004642BB /* NSMutableAttributedStringParagraphProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E1B7752062BD47004642BB /* NSMutableAttributedStringParagraphProperty.swift */; };
+		F1E1B7782062BE6B004642BB /* ParagraphStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E1B7772062BE6B004642BB /* ParagraphStyleTests.swift */; };
 		F1E1D5801FEC44B30086B339 /* AttachmentElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E1D57F1FEC44B30086B339 /* AttachmentElementConverter.swift */; };
 		F1E1D5881FEC52EE0086B339 /* GenericElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E1D5871FEC52EE0086B339 /* GenericElementConverter.swift */; };
 		F1FA0E811E6EF514009D98EE /* Attribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FA0E791E6EF514009D98EE /* Attribute.swift */; };
@@ -340,6 +342,8 @@
 		F1C05B9C1E37FA77007510EA /* String+CharacterName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+CharacterName.swift"; sourceTree = "<group>"; };
 		F1C05B9E1E37FD2F007510EA /* NSAttributedString+CharacterName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+CharacterName.swift"; sourceTree = "<group>"; };
 		F1DE83D41EF20493009269E6 /* UIColor+Parsers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Parsers.swift"; sourceTree = "<group>"; };
+		F1E1B7752062BD47004642BB /* NSMutableAttributedStringParagraphProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringParagraphProperty.swift; sourceTree = "<group>"; };
+		F1E1B7772062BE6B004642BB /* ParagraphStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParagraphStyleTests.swift; sourceTree = "<group>"; };
 		F1E1D57F1FEC44B30086B339 /* AttachmentElementConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentElementConverter.swift; sourceTree = "<group>"; };
 		F1E1D5871FEC52EE0086B339 /* GenericElementConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericElementConverter.swift; sourceTree = "<group>"; };
 		F1FA0E791E6EF514009D98EE /* Attribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Attribute.swift; sourceTree = "<group>"; };
@@ -718,6 +722,7 @@
 				B5D575851F2288E2003A62F6 /* TextViewStubAttachmentDelegate.swift */,
 				B52220D21F86A05400D7E092 /* TextViewStubDelegate.swift */,
 				B5D575861F2288E2003A62F6 /* TextViewTests.swift */,
+				F1E1B7772062BE6B004642BB /* ParagraphStyleTests.swift */,
 				B5D575801F226FF4003A62F6 /* UnsupportedHTMLTests.swift */,
 				B5D575821F22820A003A62F6 /* HTMLRepresentationTests.swift */,
 			);
@@ -863,6 +868,7 @@
 				F10BE61B1EA7B1DB002E4625 /* NSAttributedStringReplaceOcurrencesTests.swift */,
 				F17BC8741F4E48FF00398E2B /* NSAttributedStringHTMLInitializerTests.swift */,
 				B574F4AE1FB110850048F355 /* NSAttributedStringKeyHelperTests.swift */,
+				F1E1B7752062BD47004642BB /* NSMutableAttributedStringParagraphProperty.swift */,
 				F14665441EA7C230008DE2B8 /* NSMutableAttributedStringReplaceOcurrencesTests.swift */,
 				F18733C71DA09737005AEB80 /* NSRangeComparisonTests.swift */,
 				F1000CE81EAA5C720000B15B /* StringEndOfLineTests.swift */,
@@ -1206,8 +1212,10 @@
 				B5D575831F22820A003A62F6 /* HTMLRepresentationTests.swift in Sources */,
 				B5D575871F2288E2003A62F6 /* TextStorageTests.swift in Sources */,
 				F17BC8B61F4E517100398E2B /* AttributedStringSerializerTests.swift in Sources */,
+				F1E1B7762062BD47004642BB /* NSMutableAttributedStringParagraphProperty.swift in Sources */,
 				FF152D8E1E68552A00FF596C /* StringRangeConversionTests.swift in Sources */,
 				F17BC8A41F4E4F5A00398E2B /* NodeTests.swift in Sources */,
+				F1E1B7782062BE6B004642BB /* ParagraphStyleTests.swift in Sources */,
 				E11B77601DBA14B40024E455 /* BlockquoteFormatterTests.swift in Sources */,
 				F17BC8A21F4E4F5A00398E2B /* DefaultHTMLSerializerTests.swift in Sources */,
 				F1953E251F4E544A00C717C9 /* HTMLParserTests.swift in Sources */,

--- a/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
@@ -30,8 +30,11 @@ extension NSAttributedString
         let finalString = NSMutableAttributedString(attachment: attachment, attributes: figureAttributes)
         
         let mutableCaption = NSMutableAttributedString(attributedString: caption)
-        mutableCaption.append(figure)
-        mutableCaption.append(figcaption)
+        print("Self: \(ObjectIdentifier(mutableCaption))")
+        mutableCaption.append(paragraphProperty: figure)
+        print("Self: \(ObjectIdentifier(mutableCaption))")
+        mutableCaption.append(paragraphProperty: figcaption)
+        print("Self: \(ObjectIdentifier(mutableCaption))")
         
         let paragraphSeparator = NSAttributedString(.paragraphSeparator, attributes: [:])
         

--- a/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Attachments.swift
@@ -30,11 +30,8 @@ extension NSAttributedString
         let finalString = NSMutableAttributedString(attachment: attachment, attributes: figureAttributes)
         
         let mutableCaption = NSMutableAttributedString(attributedString: caption)
-        print("Self: \(ObjectIdentifier(mutableCaption))")
         mutableCaption.append(paragraphProperty: figure)
-        print("Self: \(ObjectIdentifier(mutableCaption))")
         mutableCaption.append(paragraphProperty: figcaption)
-        print("Self: \(ObjectIdentifier(mutableCaption))")
         
         let paragraphSeparator = NSAttributedString(.paragraphSeparator, attributes: [:])
         

--- a/Aztec/Classes/Extensions/NSMutableAttributedString+ParagraphProperty.swift
+++ b/Aztec/Classes/Extensions/NSMutableAttributedString+ParagraphProperty.swift
@@ -10,12 +10,19 @@ extension NSMutableAttributedString {
     ///
     /// - Returns: the final string attributes.
     ///
-    func append(_ property: ParagraphProperty) {
-        self.enumerateParagraphRanges(spanning: self.rangeOfEntireString) { (_, range) in
+    func append(paragraphProperty property: ParagraphProperty) {
+        enumerateParagraphRanges(spanning: self.rangeOfEntireString) { (_, range) in
             let attributes = self.attributes(at: range.lowerBound, effectiveRange: nil)
-            let newAttributes = attributes.appending(property)
+            let paragraphStyle = attributes.paragraphStyle()
             
-            self.setAttributes(newAttributes, range: range)
+            paragraphStyle.appendProperty(property)
+            
+            // IMPORTANT: since we are using a custom subclass of NSParagraphStyle for our convenience, it's important
+            // to remove `.paragraphStyle` before trying to add it back, as it seems `addAttribute` compares the attribute
+            // and fails to notice a difference otherwise.
+            //
+            //self.removeAttribute(.paragraphStyle, range: range)
+            self.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
         }
     }
 }

--- a/Aztec/Classes/Extensions/NSMutableAttributedString+ParagraphProperty.swift
+++ b/Aztec/Classes/Extensions/NSMutableAttributedString+ParagraphProperty.swift
@@ -16,12 +16,7 @@ extension NSMutableAttributedString {
             let paragraphStyle = attributes.paragraphStyle()
             
             paragraphStyle.appendProperty(property)
-            
-            // IMPORTANT: since we are using a custom subclass of NSParagraphStyle for our convenience, it's important
-            // to remove `.paragraphStyle` before trying to add it back, as it seems `addAttribute` compares the attribute
-            // and fails to notice a difference otherwise.
-            //
-            //self.removeAttribute(.paragraphStyle, range: range)
+
             self.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
         }
     }

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -9,7 +9,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     
     /// This is sort of a nasty hack to be able to initialize the class at runtime
     ///
-    private static let initializeClass: () = {
+    static let initializeClass: () = {
         swizzleSuperclass()
     }()
     
@@ -448,8 +448,9 @@ extension ParagraphStyle {
 
 extension NSParagraphStyle {
     @objc func swizzledIsEqual(_ object: Any?) -> Bool {
-        guard object_getClass(self) == object_getClass(object) else {
-            return false
+        guard object_getClass(object) == NSParagraphStyle.self
+            || object_getClass(object) == NSMutableParagraphStyle.self else {
+                return false
         }
         
         return swizzledIsEqual(object)

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -452,6 +452,6 @@ extension NSParagraphStyle {
             return false
         }
         
-        return self.swizzledIsEqual(object)
+        return swizzledIsEqual(object)
     }
 }

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -13,6 +13,10 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         setParagraphStyle(paragraphStyle)
     }
     
+    deinit {
+        print("gone")
+    }
+    
     // MARK: - CustomReflectable
     
     public var customMirror: Mirror {
@@ -292,7 +296,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
     // MARK: - Equatable
     
-    open override func isEqual(_ object: Any?) -> Bool {
+    @objc open override func isEqual(_ object: Any?) -> Bool {
         guard let otherParagraph = object as? ParagraphStyle else {
             return false
         }

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -15,10 +15,14 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     
     // MARK: - Initializers
     
-    init(with paragraphStyle: NSParagraphStyle) {
+    override init() {
         ParagraphStyle.initializeClass
         
         super.init()
+    }
+    
+    convenience init(with paragraphStyle: NSParagraphStyle) {
+        self.init()
         
         setParagraphStyle(paragraphStyle)
     }
@@ -81,10 +85,6 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
             return property as? HTMLPre
         }
         return htmlPres.first
-    }
-
-    override init() {
-        super.init()
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -213,7 +213,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
     open var baseFirstLineHeadIndent: CGFloat = 0
     open var baseTailIndent: CGFloat = 0
     
-    open var regularLineSpacing = CGFloat(8)
+    open var regularLineSpacing = CGFloat(0)
     open var regularParagraphSpacing = CGFloat(0)
     open var regularParagraphSpacingBefore = CGFloat(0)
     

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
@@ -1013,12 +1013,9 @@ class AttributedStringParserTests: XCTestCase {
             return
         }
         
-        print("Is equal \(paragraphStyle.isEqual(NSParagraphStyle()))")
-        
         XCTAssert(paragraphStyle.hasProperty(where: { $0 is Figure }))
     }
 }
-
 
 // MARK: - Helpers
 //

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
@@ -967,18 +967,55 @@ class AttributedStringParserTests: XCTestCase {
         let string = NSAttributedString(attachment: attachment, caption: caption, attributes: [:])
 
         let node = AttributedStringParser().parse(string)
-        let figcaptionNode = node.firstChild(ofType: .figure)?.firstChild(ofType: .figcaption)
-        XCTAssertNotNil(figcaptionNode)
+        print(node)
+        
+        guard let figureNode = node.firstChild(ofType: .figure) else {
+            XCTFail()
+            return
+        }
+        
+        guard let figcaptionNode = figureNode.firstChild(ofType: .figcaption) else {
+            XCTFail()
+            return
+        }
 
-        let strongNode = figcaptionNode?.firstChild(ofType: .strong)
-        XCTAssertNotNil(strongNode)
+        guard let strongNode = figcaptionNode.firstChild(ofType: .strong) else {
+            XCTFail()
+            return
+        }
 
-        let italicsNode = strongNode?.firstChild(ofType: .em)
-        XCTAssertNotNil(italicsNode)
+        guard let italicsNode = strongNode.firstChild(ofType: .em) else {
+            XCTFail()
+            return
+        }
 
-        let textNode = italicsNode?.children.first as? TextNode
-        XCTAssertNotNil(textNode)
-        XCTAssert(textNode?.text() == captionText)
+        guard let textNode = italicsNode.children.first as? TextNode else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(textNode.text(), captionText)
+    }
+    
+    /// Verifies that Images with *Styled* caption fields get properly converted into their corresponding HTML
+    ///
+    /// - Input: Image Attachment, with a caption in Bold + Italics.
+    ///
+    /// - Output: <figure><img src="."><figcaption><strong><em>Bold and Italics</em></strong></figcaption></figure>
+    ///
+    func testAppendProperty() {
+        let string = NSMutableAttributedString(string: "Hello world!", attributes: Constants.sampleAttributes)
+        
+        string.append(paragraphProperty: Figure())
+        
+        guard let paragraphStyle = string.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? ParagraphStyle else {
+            XCTFail() // Expected a ParagraphStyle object.
+            return
+        }
+        
+        print("Is equal \(paragraphStyle.isEqual(NSParagraphStyle()))")
+        
+        XCTAssert(paragraphStyle.hasProperty(where: { $0 is Figure }))
     }
 }
 

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
@@ -996,25 +996,6 @@ class AttributedStringParserTests: XCTestCase {
         
         XCTAssertEqual(textNode.text(), captionText)
     }
-    
-    /// Verifies that Images with *Styled* caption fields get properly converted into their corresponding HTML
-    ///
-    /// - Input: Image Attachment, with a caption in Bold + Italics.
-    ///
-    /// - Output: <figure><img src="."><figcaption><strong><em>Bold and Italics</em></strong></figcaption></figure>
-    ///
-    func testAppendProperty() {
-        let string = NSMutableAttributedString(string: "Hello world!", attributes: Constants.sampleAttributes)
-        
-        string.append(paragraphProperty: Figure())
-        
-        guard let paragraphStyle = string.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? ParagraphStyle else {
-            XCTFail() // Expected a ParagraphStyle object.
-            return
-        }
-        
-        XCTAssert(paragraphStyle.hasProperty(where: { $0 is Figure }))
-    }
 }
 
 // MARK: - Helpers

--- a/AztecTests/NSMutableAttributedStringParagraphProperty.swift
+++ b/AztecTests/NSMutableAttributedStringParagraphProperty.swift
@@ -1,0 +1,29 @@
+import Foundation
+import XCTest
+@testable import Aztec
+
+class NSMutableAttributedStringParagraphPropertyTests: XCTestCase {
+    
+    let sampleAttributes: [NSAttributedStringKey : Any] = [
+        .font: UIFont.systemFont(ofSize: UIFont.systemFontSize),
+        .paragraphStyle: NSParagraphStyle()
+    ]
+    /// Verifies that Images with *Styled* caption fields get properly converted into their corresponding HTML
+    ///
+    /// - Input: Image Attachment, with a caption in Bold + Italics.
+    ///
+    /// - Output: <figure><img src="."><figcaption><strong><em>Bold and Italics</em></strong></figcaption></figure>
+    ///
+    func testAppendProperty() {
+        let string = NSMutableAttributedString(string: "Hello world!", attributes: sampleAttributes)
+        
+        string.append(paragraphProperty: Figure())
+        
+        guard let paragraphStyle = string.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? ParagraphStyle else {
+            XCTFail() // Expected a ParagraphStyle object.
+            return
+        }
+        
+        XCTAssert(paragraphStyle.hasProperty(where: { $0 is Figure }))
+    }
+}

--- a/AztecTests/ParagraphStyleTests.swift
+++ b/AztecTests/ParagraphStyleTests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import XCTest
+@testable import Aztec
+
+class ParagraphStyleTests: XCTestCase {
+    
+    func testThatIsEqualSwizzlingWorked() {
+        let nsParagraphStyle = NSParagraphStyle()
+        let ourParagraphStyle = ParagraphStyle()
+        
+        // First we make sure we haven't affected the base implementation
+        XCTAssert(nsParagraphStyle.swizzledIsEqual(ourParagraphStyle))
+        
+        XCTAssertEqual(nsParagraphStyle.isEqual(ourParagraphStyle), false)
+        XCTAssertEqual(ourParagraphStyle.isEqual(nsParagraphStyle), false)
+    }
+}

--- a/AztecTests/ParagraphStyleTests.swift
+++ b/AztecTests/ParagraphStyleTests.swift
@@ -4,7 +4,16 @@ import XCTest
 
 class ParagraphStyleTests: XCTestCase {
     
-    func testThatIsEqualSwizzlingWorked() {
+    override func setUp() {
+        super.setUp()
+        
+        // Unfortunately, the swizzling can only be activated by initializing ParagraphStyle.
+        // In normal usage circumstances of Aztec this should not be a problem because Aztec would take care,
+        // but in these tests we want to make sure the swizzling is activated.
+        ParagraphStyle.initializeClass
+    }
+    
+    func testThatIsEqualSwizzlingWorks() {
         let nsParagraphStyle = NSParagraphStyle()
         let ourParagraphStyle = ParagraphStyle()
         
@@ -13,5 +22,16 @@ class ParagraphStyleTests: XCTestCase {
         
         XCTAssertEqual(nsParagraphStyle.isEqual(ourParagraphStyle), false)
         XCTAssertEqual(ourParagraphStyle.isEqual(nsParagraphStyle), false)
+    }
+    
+    func testThatIsEqualSwizzlingWithNSMutableParagraphStyleAndNSParagraphStyleWorks() {
+        let nsParagraphStyle = NSParagraphStyle()
+        let mutableNSParagraphStyle = NSMutableParagraphStyle()
+        
+        // First we make sure we haven't affected the base implementation
+        XCTAssert(nsParagraphStyle.swizzledIsEqual(mutableNSParagraphStyle))
+        
+        XCTAssertEqual(nsParagraphStyle.isEqual(mutableNSParagraphStyle), true)
+        XCTAssertEqual(mutableNSParagraphStyle.isEqual(nsParagraphStyle), true)
     }
 }

--- a/AztecTests/ParagraphStyleTests.swift
+++ b/AztecTests/ParagraphStyleTests.swift
@@ -17,7 +17,7 @@ class ParagraphStyleTests: XCTestCase {
         let nsParagraphStyle = NSParagraphStyle()
         let ourParagraphStyle = ParagraphStyle()
         
-        // First we make sure we haven't affected the base implementation
+        // First we make sure the swizzling is loaded.
         XCTAssert(nsParagraphStyle.swizzledIsEqual(ourParagraphStyle))
         
         XCTAssertEqual(nsParagraphStyle.isEqual(ourParagraphStyle), false)
@@ -28,7 +28,7 @@ class ParagraphStyleTests: XCTestCase {
         let nsParagraphStyle = NSParagraphStyle()
         let mutableNSParagraphStyle = NSMutableParagraphStyle()
         
-        // First we make sure we haven't affected the base implementation
+        // First we make sure the swizzling is loaded.
         XCTAssert(nsParagraphStyle.swizzledIsEqual(mutableNSParagraphStyle))
         
         XCTAssertEqual(nsParagraphStyle.isEqual(mutableNSParagraphStyle), true)


### PR DESCRIPTION
### Description

Fixes #917 through method swizzling.

`NSParagraphStyle.isEqual()` now properly compares using `isEqual()` against `ParagraphStyle` objects.

Added two unit tests that trigger the problem.

### Testing

 Run the unit tests multiple times and make sure they never fail.