### PR TITLE
Fix Travis: Xcode 9.3 support and more.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode9.2
+osx_image: xcode9.3
 language: objective-c
 xcode_workspace: Aztec.xcworkspace
 xcode_scheme: AztecExample

--- a/Aztec.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Aztec.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Updates Travis to use Xcode 9.3.

**To verify:**

Simply check that this PR has been verified correctly by Travis.