### PR TITLE
Implements EditorView.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		E11B77601DBA14B40024E455 /* BlockquoteFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11B775F1DBA14B40024E455 /* BlockquoteFormatterTests.swift */; };
 		F1000CE71EAA44AA0000B15B /* String+EndOfLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000CE61EAA44AA0000B15B /* String+EndOfLine.swift */; };
 		F1000CE91EAA5C720000B15B /* StringEndOfLineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000CE81EAA5C720000B15B /* StringEndOfLineTests.swift */; };
+		F1079D67208F80FE009717FA /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1079D66208F80FE009717FA /* EditorView.swift */; };
 		F10BE6181EA7ADA6002E4625 /* NSMutableAttributedString+ReplaceOcurrences.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10BE6171EA7ADA6002E4625 /* NSMutableAttributedString+ReplaceOcurrences.swift */; };
 		F10BE61A1EA7AE9D002E4625 /* NSAttributedString+ReplaceOcurrences.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10BE6191EA7AE9D002E4625 /* NSAttributedString+ReplaceOcurrences.swift */; };
 		F10BE61C1EA7B1DB002E4625 /* NSAttributedStringReplaceOcurrencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10BE61B1EA7B1DB002E4625 /* NSAttributedStringReplaceOcurrencesTests.swift */; };
@@ -278,6 +279,7 @@
 		E11B775F1DBA14B40024E455 /* BlockquoteFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockquoteFormatterTests.swift; sourceTree = "<group>"; };
 		F1000CE61EAA44AA0000B15B /* String+EndOfLine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+EndOfLine.swift"; sourceTree = "<group>"; };
 		F1000CE81EAA5C720000B15B /* StringEndOfLineTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringEndOfLineTests.swift; sourceTree = "<group>"; };
+		F1079D66208F80FE009717FA /* EditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorView.swift; sourceTree = "<group>"; };
 		F10BE6171EA7ADA6002E4625 /* NSMutableAttributedString+ReplaceOcurrences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+ReplaceOcurrences.swift"; sourceTree = "<group>"; };
 		F10BE6191EA7AE9D002E4625 /* NSAttributedString+ReplaceOcurrences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+ReplaceOcurrences.swift"; sourceTree = "<group>"; };
 		F10BE61B1EA7B1DB002E4625 /* NSAttributedStringReplaceOcurrencesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAttributedStringReplaceOcurrencesTests.swift; sourceTree = "<group>"; };
@@ -489,6 +491,7 @@
 			children = (
 				599F251F1D8BC9A1002871D6 /* Constants */,
 				599F25031D8BC9A1002871D6 /* Converter */,
+				F1079D65208F80AE009717FA /* EditorView */,
 				599F25241D8BC9A1002871D6 /* Extensions */,
 				40D513641FD6185A00A64501 /* ElementConverters */,
 				B5B86D3A1DA41A550083DB3F /* Formatters */,
@@ -697,6 +700,14 @@
 				B5C16A621F4DF77300B113CF /* HeaderFormatterTests.swift */,
 			);
 			path = Formatters;
+			sourceTree = "<group>";
+		};
+		F1079D65208F80AE009717FA /* EditorView */ = {
+			isa = PBXGroup;
+			children = (
+				F1079D66208F80FE009717FA /* EditorView.swift */,
+			);
+			path = EditorView;
 			sourceTree = "<group>";
 		};
 		F10DB19F1E63390700358E7E /* TextKit */ = {
@@ -1168,6 +1179,7 @@
 				F12328771FB638C6001E35EF /* NSAttributedStringKey+Aztec.swift in Sources */,
 				599F25501D8BC9A1002871D6 /* FormattingIdentifier.swift in Sources */,
 				B524228F1F30C098002E7C6C /* HTMLDivFormatter.swift in Sources */,
+				F1079D67208F80FE009717FA /* EditorView.swift in Sources */,
 				599F25341D8BC9A1002871D6 /* ArrayConverter.swift in Sources */,
 				F1FA0E811E6EF514009D98EE /* Attribute.swift in Sources */,
 			);

--- a/Aztec/Classes/EditorView/EditorView.swift
+++ b/Aztec/Classes/EditorView/EditorView.swift
@@ -1,0 +1,151 @@
+import Foundation
+import UIKit
+
+/// Composite view containing Aztec for visual editing and an HTML editor view.
+///
+public class EditorView: UIView {
+    public let htmlTextView: UITextView
+    public let richTextView: TextView
+    
+    // MARK: - Encoding / Decoding
+    static let htmlTextViewKey = "Aztec.EditorView.htmlTextView"
+    static let richTextViewKey = "Aztec.EditorView.richTextView"
+    
+    // MARK: - Editing Mode
+    
+    public enum EditMode {
+        case richText
+        case html
+        
+        mutating func toggle() {
+            switch self {
+            case .html:
+                self = .richText
+            case .richText:
+                self = .html
+            }
+        }
+    }
+    
+    fileprivate(set) public var editingMode: EditMode = .richText {
+        didSet {
+            self.endEditing(true)
+            
+            switch editingMode {
+            case .html:
+                htmlTextView.text = richTextView.getHTML()
+                htmlTextView.becomeFirstResponder()
+            case .richText:
+                richTextView.setHTML(htmlTextView.text)
+                richTextView.becomeFirstResponder()
+            }
+            
+            refreshSubviewsVisibility()
+        }
+    }
+    
+    public func toggleEditingMode() {
+        editingMode.toggle()
+    }
+    
+    // MARK: - Initializers
+    
+    public required init?(coder aDecoder: NSCoder) {
+        guard let htmlTextView = aDecoder.decodeObject(forKey: EditorView.htmlTextViewKey) as? UITextView,
+            let richTextView = aDecoder.decodeObject(forKey: EditorView.richTextViewKey) as? TextView else {
+                return nil
+        }
+        
+        self.htmlTextView = htmlTextView
+        self.richTextView = richTextView
+        
+        super.init(coder: aDecoder)
+        
+        initialSetup()
+    }
+    
+    public init(defaultFont: UIFont, defaultHTMLFont: UIFont, defaultParagraphStyle: ParagraphStyle, defaultMissingImage: UIImage) {
+        let storage = HTMLStorage(defaultFont: defaultHTMLFont)
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer()
+        
+        storage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(container)
+        
+        self.htmlTextView = UITextView(frame: .zero, textContainer: container)
+        self.richTextView = TextView(defaultFont: defaultFont, defaultParagraphStyle: defaultParagraphStyle, defaultMissingImage: defaultMissingImage)
+        
+        super.init(frame: .zero)
+        
+        initialSetup()
+    }
+    
+    // MARK: - Initial Setup
+    
+    private func initialSetup() {
+        initialSubviewsSetup()
+    }
+    
+    // MARK: - Subview Visibility
+    
+    private func refreshSubviewsVisibility() {
+        richTextView.isHidden = editingMode == .html
+        htmlTextView.isHidden = editingMode == .richText
+    }
+    
+    // MARK: - HTML
+    
+    public func getHTML() -> String {
+        return richTextView.getHTML()
+    }
+    
+    public func setHTML(_ html: String) {
+        richTextView.setHTML(html)
+    }
+}
+
+// MARK: - Initial Setup
+
+private extension EditorView {
+    
+    /// Performs the initial setup for the view.
+    ///
+    func initialSubviewsSetup() {
+        addSubviews()
+        setupConstraints()
+        refreshSubviewsVisibility()
+    }
+    
+    /// Adds the default subviews for the editor.
+    ///
+    private func addSubviews() {
+        // This method should only be run once.  Running this more than once would mean something's off.
+        assert(htmlTextView.superview == nil)
+        assert(richTextView.superview == nil)
+        
+        self.addSubview(htmlTextView)
+        self.addSubview(richTextView)
+    }
+    
+    /// Sets-up the constraints for all subviews
+    ///
+    func setupConstraints() {
+        translatesAutoresizingMaskIntoConstraints = false
+        htmlTextView.translatesAutoresizingMaskIntoConstraints = false
+        richTextView.translatesAutoresizingMaskIntoConstraints = false
+        
+        addConstraints([
+                NSLayoutConstraint(item: htmlTextView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0.0),
+                NSLayoutConstraint(item: htmlTextView, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1.0, constant: 0.0),
+                NSLayoutConstraint(item: htmlTextView, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0.0),
+                NSLayoutConstraint(item: htmlTextView, attribute: .right, relatedBy: .equal, toItem: self, attribute: .right, multiplier: 1.0, constant: 0.0)
+            ])
+        
+        addConstraints([
+            NSLayoutConstraint(item: richTextView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0.0),
+            NSLayoutConstraint(item: richTextView, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1.0, constant: 0.0),
+            NSLayoutConstraint(item: richTextView, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0.0),
+            NSLayoutConstraint(item: richTextView, attribute: .right, relatedBy: .equal, toItem: self, attribute: .right, multiplier: 1.0, constant: 0.0)
+            ])
+    }
+}


### PR DESCRIPTION
### Description

This PR implements EditorView, which is a view that combines the rich and HTML editing components into Aztec.

The idea behind this change is to move towards providing more flexible Aztec components that other Apps can reuse.

More similar changes will follow.

### Testing

Launch the different editor tests and:

- Make sure everything is fine.
- Make sure there are no constraint warnings.
- Make sure fonts and coloring are correct.
- Make sure switching between rich and html modes works in the demo app.