### PR TITLE
Fix editor layout and scroll

### DIFF
--- a/Aztec/Classes/EditorView/EditorView.swift
+++ b/Aztec/Classes/EditorView/EditorView.swift
@@ -102,6 +102,15 @@ public class EditorView: UIView {
     public func setHTML(_ html: String) {
         richTextView.setHTML(html)
     }
+
+    public var activeView: UITextView {
+        switch editingMode {
+        case .html:
+            return htmlTextView
+        case .richText:
+            return richTextView
+        }
+    }
 }
 
 // MARK: - Initial Setup

--- a/Aztec/Classes/EditorView/EditorView.swift
+++ b/Aztec/Classes/EditorView/EditorView.swift
@@ -158,3 +158,18 @@ private extension EditorView {
             ])
     }
 }
+
+// MARK: - Helper methods to set values on both views
+
+public extension EditorView {
+
+    var isScrollEnabled: Bool {
+        set {
+            htmlTextView.isScrollEnabled = newValue
+            richTextView.isScrollEnabled = newValue
+        }
+        get {
+            return activeView.isScrollEnabled
+        }
+    }
+}

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -371,8 +371,10 @@ class EditorDemoController: UIViewController {
     fileprivate func refreshInsets(forKeyboardFrame keyboardFrame: CGRect) {
         let referenceView: UIScrollView = editorView.editingMode == .richText ? richTextView : htmlTextView
 
-        let scrollInsets = UIEdgeInsets(top: referenceView.scrollIndicatorInsets.top, left: 0, bottom: view.frame.maxY - (keyboardFrame.minY + view.layoutMargins.bottom), right: 0)
-        let contentInset = UIEdgeInsets(top: referenceView.contentInset.top, left: 0, bottom: view.frame.maxY - (keyboardFrame.minY + view.layoutMargins.bottom), right: 0)
+        let keyboardHeight = view.frame.maxY - (keyboardFrame.minY + view.layoutMargins.bottom)
+
+        let scrollInsets = UIEdgeInsets(top: referenceView.scrollIndicatorInsets.top, left: 0, bottom:keyboardHeight , right: 0)
+        let contentInset = UIEdgeInsets(top: referenceView.contentInset.top, left: 0, bottom: keyboardHeight, right: 0)
 
         htmlTextView.scrollIndicatorInsets = scrollInsets
         htmlTextView.contentInset = contentInset

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -212,7 +212,6 @@ class EditorDemoController: UIViewController {
         super.viewDidAppear(animated)
         //Reanable scroll after setup is done
         editorView.isScrollEnabled = true
-        updateTitlePosition(scrollToStart: true)
     }
 
 
@@ -231,7 +230,7 @@ class EditorDemoController: UIViewController {
     }
 
     // MARK: - Title and Title placeholder position methods
-    func updateTitlePosition(scrollToStart: Bool = false) {
+    func updateTitlePosition() {
         let referenceView: UITextView = editorView.activeView
         titleTopConstraint.constant = -(referenceView.contentOffset.y + referenceView.contentInset.top)
         titlePlaceholderTopConstraint.constant = titleTextView.textContainerInset.top + titleTextView.contentInset.top
@@ -245,10 +244,7 @@ class EditorDemoController: UIViewController {
             rightMargin -= view.safeAreaInsets.right
         }
         scrollInsets.right = -rightMargin
-        referenceView.scrollIndicatorInsets = scrollInsets
-        if (scrollToStart) {
-            referenceView.setContentOffset(CGPoint(x: 0, y: -contentInset.top), animated: true)
-        }
+        referenceView.scrollIndicatorInsets = scrollInsets        
     }
 
     func updateTitleHeight() {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -228,7 +228,7 @@ class EditorDemoController: UIViewController {
 
     // MARK: - Title and Title placeholder position methods
     func updateTitlePosition(scrollToStart: Bool = false) {
-        let referenceView: UITextView = editorView.editingMode == .richText ? richTextView : htmlTextView
+        let referenceView: UITextView = editorView.activeView
         titleTopConstraint.constant = -(referenceView.contentOffset.y + referenceView.contentInset.top)
         titlePlaceholderTopConstraint.constant = titleTextView.textContainerInset.top + titleTextView.contentInset.top
         titlePlaceholderLeadingConstraint.constant = titleTextView.textContainerInset.left + titleTextView.contentInset.left  + titleTextView.textContainer.lineFragmentPadding
@@ -248,7 +248,7 @@ class EditorDemoController: UIViewController {
     }
 
     func updateTitleHeight() {
-        let referenceView: UITextView = editorView.editingMode == .richText ? richTextView : htmlTextView
+        let referenceView: UITextView = editorView.activeView
         let layoutMargins = view.layoutMargins
         let insets = titleTextView.textContainerInset
 
@@ -377,7 +377,7 @@ class EditorDemoController: UIViewController {
     }
 
     fileprivate func refreshInsets(forKeyboardFrame keyboardFrame: CGRect) {
-        let referenceView: UIScrollView = editorView.editingMode == .richText ? richTextView : htmlTextView
+        let referenceView: UIScrollView = editorView.activeView
 
         let keyboardHeight = view.frame.maxY - (keyboardFrame.minY + view.layoutMargins.bottom)
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -238,13 +238,18 @@ class EditorDemoController: UIViewController {
         var contentInset = referenceView.contentInset
         contentInset.top = titleHeightConstraint.constant + separatorView.frame.height
         referenceView.contentInset = contentInset
-        var scrollInsets = contentInset
+        updateScrollInsets()
+    }
+
+    func updateScrollInsets() {
+        let referenceView: UITextView = editorView.activeView
+        var scrollInsets = referenceView.contentInset
         var rightMargin = (view.frame.maxX - editorView.frame.maxX)
         if #available(iOS 11.0, *) {
             rightMargin -= view.safeAreaInsets.right
         }
         scrollInsets.right = -rightMargin
-        referenceView.scrollIndicatorInsets = scrollInsets        
+        referenceView.scrollIndicatorInsets = scrollInsets
     }
 
     func updateTitleHeight() {
@@ -381,14 +386,10 @@ class EditorDemoController: UIViewController {
 
         let keyboardHeight = view.frame.maxY - (keyboardFrame.minY + view.layoutMargins.bottom)
 
-        let scrollInsets = UIEdgeInsets(top: referenceView.scrollIndicatorInsets.top, left: 0, bottom:keyboardHeight, right: 0)
         let contentInset = UIEdgeInsets(top: referenceView.contentInset.top, left: 0, bottom: keyboardHeight, right: 0)
 
-        htmlTextView.scrollIndicatorInsets = scrollInsets
-        htmlTextView.contentInset = contentInset
-
-        richTextView.scrollIndicatorInsets = scrollInsets
-        richTextView.contentInset = contentInset
+        editorView.activeView.contentInset = contentInset
+        updateScrollInsets()
     }
 
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -41,7 +41,8 @@ class EditorDemoController: UIViewController {
             defaultHTMLFont: defaultHTMLFont,
             defaultParagraphStyle: .default,
             defaultMissingImage: Constants.defaultMissingImage)
-        
+
+        editorView.clipsToBounds = false
         setupHTMLTextView(editorView.htmlTextView)
         setupRichTextView(editorView.richTextView)
         
@@ -65,7 +66,7 @@ class EditorDemoController: UIViewController {
         textView.formattingDelegate = self
         textView.textAttachmentDelegate = self
         textView.accessibilityIdentifier = "richContentView"
-        
+        textView.clipsToBounds = false
         if #available(iOS 11, *) {
             textView.smartDashesType = .no
             textView.smartQuotesType = .no
@@ -81,7 +82,7 @@ class EditorDemoController: UIViewController {
         textView.accessibilityIdentifier = "HTMLContentView"
         textView.autocorrectionType = .no
         textView.autocapitalizationType = .none
-        
+        textView.clipsToBounds = false
         if #available(iOS 10, *) {
             textView.adjustsFontForContentSizeCategory = true
         }
@@ -234,6 +235,13 @@ class EditorDemoController: UIViewController {
         var contentInset = referenceView.contentInset
         contentInset.top = titleHeightConstraint.constant + separatorView.frame.height
         referenceView.contentInset = contentInset
+        var scrollInsets = contentInset
+        var rightMargin = (view.frame.maxX - editorView.frame.maxX)
+        if #available(iOS 11.0, *) {
+            rightMargin -= view.safeAreaInsets.right
+        }
+        scrollInsets.right = -rightMargin
+        referenceView.scrollIndicatorInsets = scrollInsets
         if (scrollToStart) {
             referenceView.setContentOffset(CGPoint(x: 0, y: -contentInset.top), animated: true)
         }
@@ -373,7 +381,7 @@ class EditorDemoController: UIViewController {
 
         let keyboardHeight = view.frame.maxY - (keyboardFrame.minY + view.layoutMargins.bottom)
 
-        let scrollInsets = UIEdgeInsets(top: referenceView.scrollIndicatorInsets.top, left: 0, bottom:keyboardHeight , right: 0)
+        let scrollInsets = UIEdgeInsets(top: referenceView.scrollIndicatorInsets.top, left: 0, bottom:keyboardHeight, right: 0)
         let contentInset = UIEdgeInsets(top: referenceView.contentInset.top, left: 0, bottom: keyboardHeight, right: 0)
 
         htmlTextView.scrollIndicatorInsets = scrollInsets

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -184,6 +184,8 @@ class EditorDemoController: UIViewController {
         view.addSubview(titleTextView)
         view.addSubview(titlePlaceholderLabel)
         view.addSubview(separatorView)
+        //Don't allow scroll while the constraints are being setup and text set
+        editorView.isScrollEnabled = false
         configureConstraints()
         registerAttachmentImageProviders()
 
@@ -208,6 +210,8 @@ class EditorDemoController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        //Reanable scroll after setup is done
+        editorView.isScrollEnabled = true
         updateTitlePosition(scrollToStart: true)
     }
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -94,7 +94,6 @@ class EditorDemoController: UIViewController {
 
     fileprivate(set) lazy var titleTextView: UITextView = {
         let textView = UITextView()
-        //textField.placeholder = NSLocalizedString("Enter title here", comment: "Label for the title of the post field. Should be the same as WP core.")
         
         textView.accessibilityLabel = NSLocalizedString("Title", comment: "Post title")
         textView.delegate = self
@@ -109,8 +108,26 @@ class EditorDemoController: UIViewController {
         return textView
     }()
 
+    /// Placeholder Label
+    ///
+    fileprivate(set) lazy var titlePlaceholderLabel: UILabel = {
+        let placeholderText = NSLocalizedString("Enter title here", comment: "Post title placeholder")
+        let titlePlaceholderLabel = UILabel()
+
+        let attributes: [NSAttributedStringKey: Any] = [.foregroundColor: UIColor.lightGray, .font: UIFont.preferredFont(forTextStyle: UIFontTextStyle.headline)]
+
+        titlePlaceholderLabel.attributedText = NSAttributedString(string: placeholderText, attributes: attributes)
+        titlePlaceholderLabel.sizeToFit()
+        titlePlaceholderLabel.translatesAutoresizingMaskIntoConstraints = false
+        titlePlaceholderLabel.textAlignment = .natural
+
+        return titlePlaceholderLabel
+    }()
+
     fileprivate var titleHeightConstraint: NSLayoutConstraint!
     fileprivate var titleTopConstraint: NSLayoutConstraint!
+    fileprivate var titlePlaceholderTopConstraint: NSLayoutConstraint!
+    fileprivate var titlePlaceholderLeadingConstraint: NSLayoutConstraint!
 
     fileprivate(set) lazy var separatorView: UIView = {
         let separatorView = UIView(frame: CGRect(x: 0, y: 0, width: 44, height: 1))
@@ -164,6 +181,7 @@ class EditorDemoController: UIViewController {
         view.backgroundColor = .white
         view.addSubview(editorView)
         view.addSubview(titleTextView)
+        view.addSubview(titlePlaceholderLabel)
         view.addSubview(separatorView)
         configureConstraints()
         registerAttachmentImageProviders()
@@ -209,8 +227,10 @@ class EditorDemoController: UIViewController {
 
     // MARK: - Title and Title placeholder position methods
     func updateTitlePosition(scrollToStart: Bool = false) {
-        let referenceView: UIScrollView = editorView.editingMode == .richText ? richTextView : htmlTextView
+        let referenceView: UITextView = editorView.editingMode == .richText ? richTextView : htmlTextView
         titleTopConstraint.constant = -(referenceView.contentOffset.y + referenceView.contentInset.top)
+        titlePlaceholderTopConstraint.constant = titleTextView.textContainerInset.top + titleTextView.contentInset.top
+        titlePlaceholderLeadingConstraint.constant = titleTextView.textContainerInset.left + titleTextView.contentInset.left  + titleTextView.textContainer.lineFragmentPadding
         var contentInset = referenceView.contentInset
         contentInset.top = titleHeightConstraint.constant + separatorView.frame.height
         referenceView.contentInset = contentInset
@@ -233,7 +253,7 @@ class EditorDemoController: UIViewController {
         let sizeThatShouldFitTheContent = titleTextView.sizeThatFits(CGSize(width: titleWidth, height: CGFloat.greatestFiniteMagnitude))
         titleHeightConstraint.constant = max(sizeThatShouldFitTheContent.height, titleTextView.font!.lineHeight + insets.top + insets.bottom)
 
-        //textPlaceholderTopConstraint.constant = referenceView.textContainerInset.top + referenceView.contentInset.top
+        titlePlaceholderLabel.isHidden = !titleTextView.text.isEmpty
 
         var contentInset = referenceView.contentInset
         contentInset.top = (titleHeightConstraint.constant + separatorView.frame.height)
@@ -252,6 +272,8 @@ class EditorDemoController: UIViewController {
 
         titleHeightConstraint = titleTextView.heightAnchor.constraint(equalToConstant: ceil(titleTextView.font!.lineHeight))
         titleTopConstraint = titleTextView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0)
+        titlePlaceholderTopConstraint = titlePlaceholderLabel.topAnchor.constraint(equalTo: titleTextView.topAnchor, constant:0)
+        titlePlaceholderLeadingConstraint = titlePlaceholderLabel.leadingAnchor.constraint(equalTo: titleTextView.leadingAnchor, constant: 0)
         updateTitlePosition()
         updateTitleHeight()
 
@@ -262,6 +284,12 @@ class EditorDemoController: UIViewController {
             titleTextView.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: 0),
             titleHeightConstraint,
             titleTopConstraint
+            ])
+
+        NSLayoutConstraint.activate([
+            titlePlaceholderLeadingConstraint,
+            titlePlaceholderLabel.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: 0),
+            titlePlaceholderTopConstraint
             ])
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
This PR fixes the following issues on the editor view controller demo:
- Bounce scroll on the end of the post was breaking up
- Scroll Indicator positions when going up and down and switching between keyboard mode and several layout modes (landscape, portrait, multitask ipad modes)
- Add placeholder for title label
- Allow title view to grow to accommodate longer titles

To test:
 - Start the demo app
 - Open the post with content and test the following works ok
 - Scroll to start and end of content causing bounce
 - Write on title to make it grow or shrink and see if interface works
 - Rotate the device and test on all orientations (check scroll position and if able to scroll to the top and bottom of content)
 - Test on multitask modes of iPad

