### PR TITLE
Data lost near comments.

### DIFF
--- a/Aztec/Classes/ElementConverters/Implementations/FigureElementConverter.swift
+++ b/Aztec/Classes/ElementConverters/Implementations/FigureElementConverter.swift
@@ -26,8 +26,11 @@ class FigureElementConverter: ElementConverter {
     }
     
     private func attributes(for element: ElementNode, inheriting attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
+        let elementRepresentation = HTMLElementRepresentation(element)
+        let representation = HTMLRepresentation(for: .element(elementRepresentation))
+        
         let paragraphStyle = attributes.paragraphStyle()
-        paragraphStyle.appendProperty(Figure())
+        paragraphStyle.appendProperty(Figure(with: representation))
         
         var finalAttributes = attributes
         finalAttributes[.paragraphStyle] = paragraphStyle

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -100,17 +100,12 @@ public class ElementNode: Node {
 
     /// Checks if the specified node requires a closing paragraph separator.
     ///
-    func needsClosingParagraphSeparator() -> Bool {
-
+    override func needsClosingParagraphSeparator() -> Bool {
         guard children.count == 0 else {
             return false
         }
 
-        guard !hasRightBlockLevelSibling() else {
-            return true
-        }
-
-        return !isLastInTree() && isLastInAncestorEndingInBlockLevelSeparation()
+        return super.needsClosingParagraphSeparator()
     }
 
     // MARK: - Node Queries

--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -53,6 +53,16 @@ public class Node: Equatable, CustomReflectable, Hashable {
         
         return false
     }
+    
+    /// Checks if the specified node requires a closing paragraph separator.
+    ///
+    func needsClosingParagraphSeparator() -> Bool {
+        guard !hasRightBlockLevelSibling() else {
+            return true
+        }
+        
+        return !isLastInTree() && isLastInAncestorEndingInBlockLevelSeparation()
+    }
 
     func isLastIn(blockLevelElement element: ElementNode) -> Bool {
         return element.isBlockLevelElement() && element.children.last === self

--- a/Aztec/Classes/Libxml2/DOM/Data/StandardElementType.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/StandardElementType.swift
@@ -51,12 +51,10 @@ public enum StandardElementType: String {
     case ul = "ul"
     case video = "video"
     case code = "code"
-
+    
     /// Returns an array with all block-level elements.
     ///
-    static var blockLevelNodeNames: [StandardElementType] {
-        return [.address, .blockquote, .div, .dl, .fieldset, .figure, .figcaption, .form, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .noscript, .ol, .p, .pre, .table, .tr, .td, .ul]
-    }
+    static let blockLevelNodeNames: [StandardElementType] = [.address, .blockquote, .div, .dl, .fieldset, .figure, .figcaption, .form, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .noscript, .ol, .p, .pre, .table, .tr, .td, .ul]
 
     static func isBlockLevelNodeName(_ name: String) -> Bool {
         return StandardElementType(rawValue: name)?.isBlockLevelNodeName() ?? false

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -33,16 +33,12 @@ public class TextNode: Node {
 
     /// Checks if the specified node requires a closing paragraph separator.
     ///
-    func needsClosingParagraphSeparator() -> Bool {
+    override func needsClosingParagraphSeparator() -> Bool {
         guard length() > 0 else {
             return false
         }
 
-        guard !hasRightBlockLevelSibling() else {
-            return true
-        }
-
-        return !isLastInTree() && isLastInAncestorEndingInBlockLevelSeparation()
+        return super.needsClosingParagraphSeparator()
     }
 
     // MARK: - LeafNode

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -83,7 +83,13 @@ class AttributedStringSerializer {
         let attachment = CommentAttachment()
         attachment.text = node.comment
 
-        return NSAttributedString(attachment: attachment, attributes: attributes)
+        let content = NSMutableAttributedString(attachment: attachment, attributes: attributes)
+        
+        guard !node.needsClosingParagraphSeparator() else {
+            return appendParagraphSeparator(to: content, inheriting: attributes)
+        }
+        
+        return content
     }
 
     /// Serializes an `ElementNode`.

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -391,9 +391,11 @@ class TextStorageTests: XCTestCase {
     }
 
     func testCommentFollowedByBlockLevelElements() {
-        for blockLevelNodeName in StandardElementType.blockLevelNodeNames {
-            let html = "<!-- comment --><\(blockLevelNodeName) class=\"custom_hr\">Some content</\(blockLevelNodeName)>"
-            let expectedHTML = "<p><!-- comment --></p><\(blockLevelNodeName) class=\"custom_hr\">Some content</\(blockLevelNodeName)>"
+        let elementsToTest: [StandardElementType] = [.p, .pre, .div, .h2, .h3, .h4, .h5, .h6]
+        
+        for element in elementsToTest {
+            let html = "<!-- comment --><\(element) class=\"custom_hr\">Some content</\(element)>"
+            let expectedHTML = "<p><!-- comment --></p><\(element) class=\"custom_hr\">Some content</\(element)>"
             let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
                                                                    .paragraphStyle: ParagraphStyle.default]
             storage.setHTML(html, defaultAttributes: defaultAttributes)

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -431,5 +431,20 @@ class TextStorageTests: XCTestCase {
         XCTAssertEqual(expectedHTML, outputHTML)
     }
 
+    func testCommentSurroundingBlockLevelElements() {
+        let elementsToTest: [StandardElementType] = [.p, .pre, .div, .h2, .h3, .h4, .h5, .h6]
+
+        for element in elementsToTest {
+            let html = "<!-- comment --><\(element) class=\"custom_hr\">Some content</\(element)><!-- comment -->"
+            let expectedHTML = "<p><!-- comment --></p><\(element) class=\"custom_hr\">Some content</\(element)><p><!-- comment --></p>"
+            let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                                   .paragraphStyle: ParagraphStyle.default]
+            storage.setHTML(html, defaultAttributes: defaultAttributes)
+            let outputHTML = storage.getHTML(serializer: serializer)
+
+            XCTAssertEqual(expectedHTML, outputHTML)
+        }
+    }
+
 
 }

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -389,4 +389,37 @@ class TextStorageTests: XCTestCase {
 
         XCTAssertEqual(String(), resultHTML)
     }
+
+    func testHRAttributesArePreserved() {
+        let html = "<!-- wp:separator --><hr class=\"custom_hr\"><!-- /wp:separator -->"
+        let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                               .paragraphStyle: ParagraphStyle.default]
+        storage.setHTML(html, defaultAttributes: defaultAttributes)
+
+        let resultHTML = storage.getHTML(serializer: serializer)
+
+        XCTAssertEqual(html, resultHTML)
+    }
+
+    func testBlockquoteAttributesArePreserved() {
+        let html = "<blockquote class=\"wp-block-quote\">This is an amazing editor</blockquote>"
+        let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                               .paragraphStyle: ParagraphStyle.default]
+        storage.setHTML(html, defaultAttributes: defaultAttributes)
+
+        let resultHTML = storage.getHTML(serializer: serializer)
+
+        XCTAssertEqual(html, resultHTML)
+    }
+
+    func testH2AttributesArePreserved() {
+        let html = "<!-- wp:quote --><h2>This is an amazing editor</h2><!-- /wp:quote -->"
+        let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                               .paragraphStyle: ParagraphStyle.default]
+        storage.setHTML(html, defaultAttributes: defaultAttributes)
+
+        let resultHTML = storage.getHTML(serializer: serializer)
+
+        XCTAssertEqual(html, resultHTML)
+    }
 }

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -404,4 +404,32 @@ class TextStorageTests: XCTestCase {
             XCTAssertEqual(expectedHTML, outputHTML)
         }
     }
+
+    func testElementFollowedByComment() {
+        let elementsToTest: [StandardElementType] = [.p, .pre, .div, .h2, .h3, .h4, .h5, .h6]
+
+        for element in elementsToTest {
+            let html = "<\(element) class=\"custom_hr\"><!-- comment -->Some content</\(element)>"
+            let expectedHTML = "<\(element) class=\"custom_hr\"><!-- comment -->Some content</\(element)>"
+            let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                                   .paragraphStyle: ParagraphStyle.default]
+            storage.setHTML(html, defaultAttributes: defaultAttributes)
+            let outputHTML = storage.getHTML(serializer: serializer)
+
+            XCTAssertEqual(expectedHTML, outputHTML)
+        }
+    }
+
+    func testMultipleComments() {
+        let html = "<!-- comment 1 --><!-- comment 2 -->Some content<!-- comment 3-->"
+        let expectedHTML = "<p><!-- comment 1 --><!-- comment 2 -->Some content<!-- comment 3--></p>"
+        let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                                   .paragraphStyle: ParagraphStyle.default]
+        storage.setHTML(html, defaultAttributes: defaultAttributes)
+        let outputHTML = storage.getHTML(serializer: serializer)
+
+        XCTAssertEqual(expectedHTML, outputHTML)
+    }
+
+
 }

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -390,36 +390,16 @@ class TextStorageTests: XCTestCase {
         XCTAssertEqual(String(), resultHTML)
     }
 
-    func testHRAttributesArePreserved() {
-        let html = "<!-- wp:separator --><hr class=\"custom_hr\"><!-- /wp:separator -->"
-        let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
-                                                               .paragraphStyle: ParagraphStyle.default]
-        storage.setHTML(html, defaultAttributes: defaultAttributes)
-
-        let resultHTML = storage.getHTML(serializer: serializer)
-
-        XCTAssertEqual(html, resultHTML)
-    }
-
-    func testBlockquoteAttributesArePreserved() {
-        let html = "<blockquote class=\"wp-block-quote\">This is an amazing editor</blockquote>"
-        let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
-                                                               .paragraphStyle: ParagraphStyle.default]
-        storage.setHTML(html, defaultAttributes: defaultAttributes)
-
-        let resultHTML = storage.getHTML(serializer: serializer)
-
-        XCTAssertEqual(html, resultHTML)
-    }
-
-    func testH2AttributesArePreserved() {
-        let html = "<!-- wp:quote --><h2>This is an amazing editor</h2><!-- /wp:quote -->"
-        let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
-                                                               .paragraphStyle: ParagraphStyle.default]
-        storage.setHTML(html, defaultAttributes: defaultAttributes)
-
-        let resultHTML = storage.getHTML(serializer: serializer)
-
-        XCTAssertEqual(html, resultHTML)
+    func testCommentFollowedByBlockLevelElements() {
+        for blockLevelNodeName in StandardElementType.blockLevelNodeNames {
+            let html = "<!-- comment --><\(blockLevelNodeName) class=\"custom_hr\">Some content</\(blockLevelNodeName)>"
+            let expectedHTML = "<p><!-- comment --></p><\(blockLevelNodeName) class=\"custom_hr\">Some content</\(blockLevelNodeName)>"
+            let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                                   .paragraphStyle: ParagraphStyle.default]
+            storage.setHTML(html, defaultAttributes: defaultAttributes)
+            let outputHTML = storage.getHTML(serializer: serializer)
+            
+            XCTAssertEqual(expectedHTML, outputHTML)
+        }
     }
 }

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1810,7 +1810,7 @@ class TextViewTests: XCTestCase {
         textView.insertText("1")
 
         let expected = "<h1>Header</h1><p>1</p>"
-        XCTAssert(textView.getHTML() == expected)
+        XCTAssertEqual(expected, textView.getHTML())
     }
 
     /// This test verifies that attributes on media attachment are being removed properly.

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		F13CE5481F4DD99D0043368D /* WPVideoShortcodePreProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE5471F4DD99D0043368D /* WPVideoShortcodePreProcessor.swift */; };
 		F13CE54A1F4DDA8B0043368D /* VideoShortcodePreProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE5491F4DDA8B0043368D /* VideoShortcodePreProcessor.swift */; };
 		F13CE54C1F4DDB3A0043368D /* VideoShortcodePostProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F13CE54B1F4DDB3A0043368D /* VideoShortcodePostProcessor.swift */; };
+		FF1FD05C20932EDE00186384 /* gutenberg.html in Resources */ = {isa = PBXBuildFile; fileRef = FF1FD05B20932EDE00186384 /* gutenberg.html */; };
 		FF6691C21E76CF9200C6A703 /* OptionsTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */; };
 		FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */; };
 		FFD06EA41EC3C5350072AD85 /* ShortcodeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD06EA31EC3C5350072AD85 /* ShortcodeProcessor.swift */; };
@@ -154,6 +155,7 @@
 		F13CE5471F4DD99D0043368D /* WPVideoShortcodePreProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPVideoShortcodePreProcessor.swift; sourceTree = "<group>"; };
 		F13CE5491F4DDA8B0043368D /* VideoShortcodePreProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoShortcodePreProcessor.swift; sourceTree = "<group>"; };
 		F13CE54B1F4DDB3A0043368D /* VideoShortcodePostProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoShortcodePostProcessor.swift; sourceTree = "<group>"; };
+		FF1FD05B20932EDE00186384 /* gutenberg.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = gutenberg.html; sourceTree = "<group>"; };
 		FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionsTableView.swift; sourceTree = "<group>"; };
 		FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AttachmentDetailsViewController.storyboard; sourceTree = "<group>"; };
 		FFD06EA31EC3C5350072AD85 /* ShortcodeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcodeProcessor.swift; sourceTree = "<group>"; };
@@ -203,6 +205,7 @@
 				59280F281D47CAF40083FB59 /* content.html */,
 				B5FB21271FEC37DB0067D597 /* captions.html */,
 				59280F291D47CAF40083FB59 /* SampleText.rtf */,
+				FF1FD05B20932EDE00186384 /* gutenberg.html */,
 			);
 			path = SampleContent;
 			sourceTree = "<group>";
@@ -486,6 +489,7 @@
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
 				59280F2A1D47CAF40083FB59 /* content.html in Resources */,
 				B5FB212A1FEC38470067D597 /* captions.html in Resources */,
+				FF1FD05C20932EDE00186384 /* gutenberg.html in Resources */,
 				59280F2B1D47CAF40083FB59 /* SampleText.rtf in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
 				FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */,

--- a/Example/Example/SampleContent/gutenberg.html
+++ b/Example/Example/SampleContent/gutenberg.html
@@ -1,0 +1,226 @@
+<!-- wp:paragraph -->
+<h2>In 2017 I set out to read at least one book each month, and I'm happy to say that I met that goal. I also read longer books than last year.</h2>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":1987} -->
+<figure class="wp-block-image"><img src="https://koke.me/wp-content/uploads/2017/12/Screen-Shot-2017-12-19-at-17.45.50.png" alt="" class="wp-image-1987" />
+    <figcaption>Number of pages read</figcaption>
+</figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>These aren't all the books I read, but those I found most inspiring. Every book on this list is a book I would definitely recommend reading.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:more -->
+<!--more-->
+<!-- /wp:more -->
+
+<!-- wp:paragraph -->
+<p>I started 2017 reading <a href="https://www.goodreads.com/book/show/4069.Man_s_Search_for_Meaning">Man's Search for Meaning</a>. I think bought the paperback over a decade ago but never actually read it before. It is both terrifying and inspiring.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>The pessimist resembles a man who observes with fear and sadness that his wall calendar, from which he daily tears a sheet, grows thinner with each passing day. On the other hand, the person who attacks the problems of life actively is like a man who removes each successive leaf from his calendar and files it neatly and carefully away with its predecessors, after first having jotted down a few diary notes on the back. He can reflect with pride and joy on all the richness set down in these notes, on all the life he has already lived to the fullest. What will it matter to him if he notices that he is growing old? Has he any reason to envy the young people whom he sees, or wax nostalgic over his own lost youth? What reasons has he to envy a young person? For the possibilities that a young person has, the future which is in store for him? “No, thank you,” he will think. “Instead of possibilities, I have realities in my past, not only the reality of work done and of love loved, but of sufferings bravely suffered. These sufferings are even the things of which I am most proud, though these are things which cannot inspire envy.</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>To be sure, a human being is a finite thing, and his freedom is restricted. It is not freedom from conditions, but it is freedom to take a stand toward the conditions</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>For the world is in a bad state, but everything will become still worse unless each of us does his best.</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator" />
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p>This one was important to me: <a href="https://www.goodreads.com/book/show/34042436-nobody-told-me">Nobody Told Me: Poetry and Parenthood</a>. I came across Hollie McNish and this book when my son had just turned two, and it was <a href="https://koke.me/2017/05/07/terrible-twos-hollie-mcnish/">just what I needed to read</a>. It definitely changed how I approached being a parent (at least in theory).</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image -->
+<figure class="wp-block-image"><img src="https://koke.me/wp-content/uploads/2017/05/terribletwos.jpeg" alt="" /></figure>
+<!-- /wp:image -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator" />
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p>I really loved <a href="https://www.goodreads.com/book/show/29507568-the-hidden-life-of-trees">The Hidden Life of Trees</a>. Yes, it is about trees and forests, and mostly a collection of mind blowing facts about them. But it’s also in a way inspiring and adds some perspective to life:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>One reason that many of us fail to understand trees is that they live on a different time scale than us. One of the oldest trees on Earth, a spruce in Sweden, is more than 9,500 years old. That’s 115 times longer than the average human lifetime. Creatures with such a luxury of time on their hands can afford to take things at a leisurely pace.</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:paragraph -->
+<p>And how important diversity and cooperation can be:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>A tree is not a forest. On its own, a tree cannot establish a consistent local climate. It is at the mercy of wind and weather. But together, many trees create an ecosystem that moderates extremes of heat and cold, stores a great deal of water, and generates a great deal of humidity. And in this protected environment, trees can live to be very old.</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>If you “help” individual trees by getting rid of their supposed competition, the remaining trees are bereft. They send messages out to their neighbors in vain, because nothing remains but stumps. Every tree now muddles along on its own, giving rise to great differences in productivity. Some individuals photosynthesize like mad until sugar positively bubbles along their trunk. As a result, they are fit and grow better, but they aren’t particularly long-lived. This is because a tree can be only as strong as the forest that surrounds it. </p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>Diversity provides security for ancient forests. Because fungi are also very dependent on stable conditions, they support other species underground and protect them from complete collapse to ensure that one species of tree doesn’t manage to dominate.</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator" />
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p>Then I read <a href="https://www.goodreads.com/book/show/6514.The_Bell_Jar">The Bell Jar</a> followed by <a href="https://www.goodreads.com/book/show/20199491-the-sane-society">The Sane Society</a>, which was an interesting combination of someone struggling with not fitting society’s expectations to the point of suicide, with someone arguing that it is in fact our society which is insane.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>This is a book written in 1955, so it’s at time funny to observe his predictions for the future. But other than that, the analysis and critique was still scarily accurate.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>We have reduced the average working hours to about half what they were one hundred years ago. We today have more free time available than our forefathers dared to dream of. But what has happened? We do not know how to use the newly gained free time; we try to kill the time we have saved, and are glad when another day is over</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>Could it be that the middle-class life of prosperity, while satisfying our material needs leaves us with a feeling of intense boredom, and that suicide and alcoholism are pathological ways of escape from this boredom? Could it be that these figures are a drastic illustration for the truth of the statement that “man lives not by bread alone,” and that they show that modern civilization fails to satisfy profound needs in man? If so, what are these needs?</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>The danger of the past was that men became slaves. The danger of the future is that men may become robots. True enough, robots do not rebel. But given man’s nature, robots cannot live and remain sane, they become “Golems,” they will destroy their world and themselves because they cannot stand any longer the boredom of a meaningless life</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator" />
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p>This was a tough read so I followed with a children’s book: <a href="https://www.goodreads.com/book/show/27718.Momo">Momo</a> ?</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>It was an easy read but had a deep message warning us about the obsession with time and productivity.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>Beppo was widely believed to be not quite right in the head. This was because, when asked a question, he would give an amiable smile and say nothing. If, after pondering the question, he felt it needed no answer, he still said nothing. If it did, he would ponder what answer to give. He could take as long as a couple of hours to reply, or even a whole day. By this time the person who had asked the question would have forgotten what it was, so Beppo’s answer seemed peculiar in the extreme.</p>
+    <p>Only Momo was capable of waiting patiently enough to grasp his meaning. She knew that Beppo took as long as he did because he was determined never to say anything untrue. In his opinion, all the world’s misfortunes stemmed from the countless untruths, both deliberate and unintentional, which people told because of haste or carelessness.</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator" />
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p>Then there’s <a href="https://www.goodreads.com/book/show/36125684-technically-wrong">Technically Wrong</a>, which is an amazing book about all the ways tech has gone wrong.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>One reason data collection has become so commonplace, and so intense, is that too many of us have spent the past two decades enamored of the brilliance of technology, and blind to how that technology comes to be. Meanwhile, back at the companies behind those technologies, a world of mostly white men has wholeheartedly embraced the idea that they’re truly smarter than the rest of us. That they do know best. That they deserve to make choices on our behalf. That there’s nothing wrong with watching us in “god view,” because they are, in fact, gods. And there’s no one around to tell them otherwise, because anyone who’s different either shuts up or gets pushed out.</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator" />
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p>The next one is a very interesting one: <a href="https://www.goodreads.com/book/show/26203640-nonviolent-communication">Nonviolent Communication: A Language of Life</a>. I looked into this one from the perspective of a parent, but it has invaluable lessons to deal with conflict in any scenario.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>All violence is the result of people tricking themselves (…) into believing that their pain derives from other people and that consequently those people deserve to be punished</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>Our attention is focused on classifying, analyzing, and determining levels of wrongness rather than on what we and others need and are not getting. Thus if my partner wants more affection than I’m giving her, she is “needy and dependent.” But if I want more affection than she is giving me, then she is “aloof and insensitive.” If my colleague is more concerned about details than I am, he is “picky and compulsive.” On the other hand, if I am more concerned about details than he is, he is “sloppy and disorganized.”</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>In 75 percent of the television programs shown during hours when American children are most likely to be watching, the hero either kills people or beats them up. This violence typically constitutes the “climax” of the show. Viewers, having been taught that bad guys deserve to be punished, take pleasure in watching this violence.</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator" />
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p>The last one I finished is <a href="https://www.goodreads.com/book/show/33775950-the-mother-of-all-questions">The Mother of All Questions</a>, the latest of my favorite author Rebecca Solnit, and a sort of continuation of <a href="https://www.goodreads.com/book/show/18528190-men-explain-things-to-me">Men Explain Things to Me</a> and <a href="https://www.goodreads.com/book/show/28048.Hope_in_the_Dark">Hope in the Dark</a>. I struggled getting trough the first third of the book as it was mostly about rape and got quite depressing and frustrating. But being Solnit, there’s always room for hope:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>This has not been a harmonious year 2014, and male rage is definitely part of the landscape—the trolls, men’s rights movement misogynists, Gamergate ranters, and the perpetrators of the actual violence, which has not stopped. The histrionic response to California’s “Yes Means Yes” campus consent law shows that some heterosexual men are alarmed that they will now have to negotiate their erotic and social interactions with human beings who have voices and rights backed up by law. In other words, they are unhappy that the world has changed—but the most important thing is that it has. Women are coming out of a silence that lasted so long no one can name a beginning for it. This noisy year is not the end—but perhaps it is the beginning of the end.</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>For a century, the human response to stress and danger has been defined as “fight or flight.” A 2000 UCLA study by several psychologists noted that this research was based largely on studies of male rats and male human beings. But studying women led them to a third, often deployed option: gather for solidarity, support, advice</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:paragraph -->
+<p>Interestingly enough, days after reading and sharing the quote above I came across <a href="https://www.nature.com/news/male-researchers-stress-out-rodents-1.15106">a study</a> revealing that "Rats and mice show increased stress levels when handled by men rather than women, potentially skewing study results."</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator" />
+<!-- /wp:separator -->
+
+<!-- wp:paragraph -->
+<p>And now, I’ve recently started reading <a href="https://www.goodreads.com/book/show/31124533-the-gardener-and-the-carpenter">The Gardener and the Carpenter</a>:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>“’Parent’ is not actually a verb, not a form of work, and it isn’t and shouldn’t be directed toward the goal of sculpting a child into a particular kind of adult …. We recognize the difference between work and other relationships, other kinds of love. To be a wife is not to engage in ‘wifing,’ to be a friend is not to ‘friend,’ even on Facebook, and we don’t ‘child’ our mothers and fathers".</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>I would not evaluate the success of my marriage by measuring whether my husband’s character had improved in the years since we wed. I would not evaluate the quality of an old friendship by whether my friend was happier or more successful than when we first met—indeed, we all know that friendships show their quality most in the darkest days. Nevertheless, this is the implicit picture of parenting—that your qualities as a parent can be, and even should be, judged by the child you create.</p>
+</blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+    <p>The rise of parenting is a lot like what happened to food in America at about the same time, what Michael Pollan has called “the omnivore’s dilemma.” In the past we learned how to eat by participating in cooking traditions. We ate pie, pasta, or pot stickers because our mothers cooked them, and they cooked that way because their mothers did before them. Those many and varied traditions all led to reasonably healthy outcomes. In the twentieth century, especially the American middle-class twentieth century, the erosion of those traditions led to a culture of “nutrition” and “dieting” that has a lot in common with the culture of parenting. In both cases traditions have been replaced by prescriptions. What was once a matter of experience has become a matter of expertise. What was once simply a way of being, what the philosopher Ludwig Wittgenstein called a form of life, became a form of work. An act of spontaneous and loving care became, instead, a management plan.</p>
+</blockquote>
+<!-- /wp:quote -->

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -16,6 +16,7 @@ class ViewController: UITableViewController
         rows = [
             DemoRow(title: "Editor Demo", action: { self.showEditorDemo(filename: "content") }),
             DemoRow(title: "Captions Demo", action: { self.showEditorDemo(filename: "captions") }),
+            DemoRow(title: "Gutenberg Sample", action: { self.showEditorDemo(filename: "gutenberg") }),
             DemoRow(title: "Empty Editor Demo", action: { self.showEditorDemo() }),
         ]
     }


### PR DESCRIPTION
### Description:

Fixes #939.  Comments before block-level elements no longer cause data loss issues.

### Credits:

The initial PR and unit tests were provided by @SergioEstevao.  I reopened the PR here to make sure the review history looks clean.  I also modified the unit tests to only affect what's fixed in this PR.

### Important:

There's a failing unit test that's coming from develop and outside the scope of this PR.  The test is:

`testHeaderStyleDoesNotComeBackFromNonExistanceWheneverDeleteBackwardResultsInEmptyParagraphBeforeHeaderStyle`

### Testing:

Just run the unit tests, and make sure all (except the failing test mentioned above) succeed.
