### PR TITLE
Fixes unit tests, fixes newline inside single-line paragraph attributes.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1787,7 +1787,7 @@ private extension TextView {
         guard mustRemoveSingleLineParagraphAttributesAfterPressingEnter(input: input) else {
             return
         }
-
+        
         removeSingleLineParagraphAttributes(at: selectedRange)
     }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -283,10 +283,6 @@ open class TextView: UITextView {
             super.typingAttributes = newValue
         }
     }
-    
-    @objc func setTypingAttributes(_ attributes: [String: Any]) {
-        self.typingAttributes = attributes
-    }
 
     /// Returns the collection of Typing Attributes, with all of the available 'String' keys properly converted into
     /// NSAttributedStringKey. Also known as: what you would expect from the SDK.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -269,22 +269,6 @@ open class TextView: UITextView {
 
 
     // MARK: - Overwritten Properties
-
-    /// Overrides `selectedTextRange` since it's called whenever the user changes the text selection
-    /// through taps or keyboard arrow keys.
-    ///
-    /// - IMPORTANT: keep in mind this is not triggered the selection change is triggered through typing.
-    ///         Tested in iOS 11 on 2018-05-02.
-    ///
-    override open var selectedTextRange: UITextRange? {
-        get {
-            return super.selectedTextRange
-        }
-        
-        set {
-            super.selectedTextRange = newValue
-        }
-    }
     
     /// Overwrites Typing Attributes:
     /// This is the (only) valid hook we've found, in order to (selectively) remove the [Blockquote, List, Pre] attributes.
@@ -298,6 +282,10 @@ open class TextView: UITextView {
         set {
             super.typingAttributes = newValue
         }
+    }
+    
+    @objc func setTypingAttributes(_ attributes: [String: Any]) {
+        self.typingAttributes = attributes
     }
 
     /// Returns the collection of Typing Attributes, with all of the available 'String' keys properly converted into
@@ -627,7 +615,6 @@ open class TextView: UITextView {
             super.insertText(text)
         }
 
-        //evaluateRemovalOfSingleLineParagraphAttributes(forInput: text)
         evaluateRemovalOfSingleLineParagraphAttributesAfterSelectionChange()
 
         restoreDefaultFontIfNeeded()
@@ -1820,7 +1807,9 @@ private extension TextView {
     ///
     private func removeSingleLineParagraphAttributes() {
         for formatter in type(of: self).singleLineParagraphFormatters {
-            removeAttributes(managedBy: formatter, from: selectedRange)
+            let range = formatter.applicationRange(for: selectedRange, in: textStorage)
+            
+            removeAttributes(managedBy: formatter, from: range)
             removeTypingAttributes(managedBy: formatter)
         }
     }

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -793,7 +793,7 @@ class TextViewTests: XCTestCase {
         let identifiers = textView.formatIdentifiersAtIndex(textView.selectedRange.location)
         XCTAssert(identifiers.contains(.header1))
 
-        XCTAssertEqual(textView.getHTML(), "<h1>Header</h1><p> Header</p>")
+        XCTAssertEqual(textView.getHTML(), "<h1>Header</h1><h1> Header</h1>")
     }
 
 
@@ -996,7 +996,7 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
         textView.insertText(String(.lineFeed))
 
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.paragraphSeparator) )
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.lineFeed) )
     }
 
     /// Verifies that toggling an Ordered List, when editing an empty document, inserts a Newline.
@@ -1033,7 +1033,7 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
         textView.insertText(String(.lineFeed))
 
-        let expected = Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.paragraphSeparator)
+        let expected = Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.lineFeed)
         
         XCTAssertEqual(textView.text, expected)
     }
@@ -1261,7 +1261,7 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
         textView.insertText(String(.lineFeed))
 
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.paragraphSeparator))
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.lineFeed))
     }
 
 
@@ -1447,7 +1447,7 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
         textView.insertText(String(.lineFeed))
         
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.paragraphSeparator))
+        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.lineFeed))
     }
 
 
@@ -1791,7 +1791,7 @@ class TextViewTests: XCTestCase {
         textView.insertText("Three")
 
         let expected = "<h1>Header</h1><p>One Two</p><p>Three</p>"
-        XCTAssert(textView.getHTML() == expected)
+        XCTAssertEqual(textView.getHTML(), expected)
     }
 
     /// This test verifies that H1 Style doesn't turn rogue (Scenario #2), and come back after editing a line
@@ -1812,7 +1812,7 @@ class TextViewTests: XCTestCase {
         textView.insertText("1")
 
         let expected = "<h1>Header</h1><p>1</p>"
-        XCTAssert(textView.getHTML() == expected)
+        XCTAssertEqual(textView.getHTML(), expected)
     }
 
     /// This test verifies that attributes on media attachment are being removed properly.

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1033,7 +1033,9 @@ class TextViewTests: XCTestCase {
         textView.insertText(Constants.sampleText1)
         textView.insertText(String(.lineFeed))
 
-        XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.paragraphSeparator))
+        let expected = Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.paragraphSeparator)
+        
+        XCTAssertEqual(textView.text, expected)
     }
 
     /// When deleting the newline between lines 1 and 2 in the following example:


### PR DESCRIPTION
### Description:

Fixes #943.  A unit test was failing due to recent changes..

### Details:

In this PR we:

- [Define a list of single-line paragraph formatters](https://github.com/wordpress-mobile/AztecEditor-iOS/compare/issue/943-failing-unit-test?expand=1#diff-8d8015f3f021c0252c1569e4965dce80R144).
- [Generalize the method that removes single-line paragraph styles](https://github.com/wordpress-mobile/AztecEditor-iOS/compare/issue/943-failing-unit-test?expand=1#diff-8d8015f3f021c0252c1569e4965dce80R1811).
- [Modularize the code a bit](https://github.com/wordpress-mobile/AztecEditor-iOS/compare/issue/943-failing-unit-test?expand=1#diff-8d8015f3f021c0252c1569e4965dce80R1830).
- [Roll back a recent change that didn't make much sense](https://github.com/wordpress-mobile/AztecEditor-iOS/compare/issue/943-failing-unit-test?expand=1#diff-c443bd9f1da7e0860dca35041b25cfc3R796).

### Testing:

Run the unit tests and make sure they succeed.