### PR TITLE
Pressing tab in the title changes the focus.

### DIFF
--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -409,6 +409,12 @@ class EditorDemoController: UIViewController {
     }
 
     override var keyCommands: [UIKeyCommand] {
+        if titleTextView.isFirstResponder {
+            return [
+                UIKeyCommand(input: "\t", modifierFlags: [], action: #selector(tabOnTitle))
+            ]
+        }
+        
         if richTextView.isFirstResponder {
             return [ UIKeyCommand(input:"B", modifierFlags: .command, action:#selector(toggleBold), discoverabilityTitle:NSLocalizedString("Bold", comment: "Discoverability title for bold formatting keyboard shortcut.")),
                      UIKeyCommand(input:"I", modifierFlags: .command, action:#selector(toggleItalic), discoverabilityTitle:NSLocalizedString("Italic", comment: "Discoverability title for italic formatting keyboard shortcut.")),
@@ -921,7 +927,13 @@ extension EditorDemoController {
 
         insertAction.isEnabled = !urlFieldText.isEmpty
     }
-
+    
+    @objc func tabOnTitle() {
+        let activeTextView = editorView.activeView
+        
+        activeTextView.becomeFirstResponder()
+        activeTextView.selectedTextRange = activeTextView.textRange(from: activeTextView.endOfDocument, to: activeTextView.endOfDocument)
+    }
 
     @objc func showImagePicker() {
         let picker = UIImagePickerController()


### PR DESCRIPTION
Fixes #947 

Pressing tab while the focus is on the title, should move the focus to the content.

### IMPORTANT:

While testing this feature I found an issue that's causing the HTML view to not be laid out properly.  The issue was recorded [here](https://github.com/wordpress-mobile/AztecEditor-iOS/issues/948), since it's unrelated to this PR.
