### PR TITLE
Fixed EditorView's HTML source layout.

### DIFF
--- a/Aztec/Classes/EditorView/EditorView.swift
+++ b/Aztec/Classes/EditorView/EditorView.swift
@@ -8,8 +8,44 @@ public class EditorView: UIView {
     public let richTextView: TextView
     
     // MARK: - Encoding / Decoding
+    
     static let htmlTextViewKey = "Aztec.EditorView.htmlTextView"
     static let richTextViewKey = "Aztec.EditorView.richTextView"
+    
+    // MARK: - Content Insets
+    
+    public var contentInset: UIEdgeInsets {
+        get {
+            return activeView.contentInset
+        }
+        
+        set {
+            htmlTextView.contentInset = newValue
+            richTextView.contentInset = newValue
+        }
+    }
+    
+    public var contentOffset: CGPoint {
+        get {
+            return activeView.contentOffset
+        }
+        
+        set {
+            htmlTextView.contentOffset = newValue
+            richTextView.contentOffset = newValue
+        }
+    }
+    
+    public var scrollIndicatorInsets: UIEdgeInsets {
+        get {
+            return activeView.scrollIndicatorInsets
+        }
+        
+        set {
+            htmlTextView.scrollIndicatorInsets = newValue
+            richTextView.scrollIndicatorInsets = newValue
+        }
+    }
     
     // MARK: - Editing Mode
     
@@ -113,6 +149,153 @@ public class EditorView: UIView {
     }
 }
 
+// MARK: - UIResponder
+
+extension EditorView {
+    @discardableResult
+    override public func becomeFirstResponder() -> Bool {
+        return activeView.becomeFirstResponder()
+    }
+}
+
+// MARK: - UITextInput
+
+extension EditorView: UITextInput {
+    public func text(in range: UITextRange) -> String? {
+        return activeView.text(in: range)
+    }
+    
+    public func replace(_ range: UITextRange, withText text: String) {
+        activeView.replace(range, withText: text)
+    }
+    
+    public var markedTextRange: UITextRange? {
+        return activeView.markedTextRange
+    }
+    
+    public var markedTextStyle: [AnyHashable : Any]? {
+        get {
+            return activeView.markedTextStyle
+        }
+        
+        set(markedTextStyle) {
+            activeView.markedTextStyle = markedTextStyle
+        }
+    }
+    
+    public func setMarkedText(_ markedText: String?, selectedRange: NSRange) {
+        activeView.setMarkedText(markedText, selectedRange: selectedRange)
+    }
+    
+    public func unmarkText() {
+        activeView.unmarkText()
+    }
+    
+    public var beginningOfDocument: UITextPosition {
+        return activeView.beginningOfDocument
+    }
+    
+    public var endOfDocument: UITextPosition {
+        return activeView.endOfDocument
+    }
+    
+    public func textRange(from fromPosition: UITextPosition, to toPosition: UITextPosition) -> UITextRange? {
+        return activeView.textRange(from: fromPosition, to: toPosition)
+    }
+    
+    public func position(from position: UITextPosition, offset: Int) -> UITextPosition? {
+        return activeView.position(from: position, offset: offset)
+    }
+    
+    public func position(from position: UITextPosition, in direction: UITextLayoutDirection, offset: Int) -> UITextPosition? {
+        return activeView.position(from: position, in: direction, offset: offset)
+    }
+    
+    public func compare(_ position: UITextPosition, to other: UITextPosition) -> ComparisonResult {
+        return activeView.compare(position, to: other)
+    }
+    
+    public func offset(from: UITextPosition, to toPosition: UITextPosition) -> Int {
+        return activeView.offset(from: from, to: toPosition)
+    }
+    
+    public var inputDelegate: UITextInputDelegate? {
+        get {
+            return activeView.inputDelegate
+        }
+        
+        set(inputDelegate) {
+            activeView.inputDelegate = inputDelegate
+        }
+    }
+    
+    public var tokenizer: UITextInputTokenizer {
+        return activeView.tokenizer
+    }
+    
+    public func position(within range: UITextRange, farthestIn direction: UITextLayoutDirection) -> UITextPosition? {
+        return activeView.position(within: range, farthestIn: direction)
+    }
+    
+    public func characterRange(byExtending position: UITextPosition, in direction: UITextLayoutDirection) -> UITextRange? {
+        return activeView.characterRange(byExtending: position, in: direction)
+    }
+    
+    public func baseWritingDirection(for position: UITextPosition, in direction: UITextStorageDirection) -> UITextWritingDirection {
+        return activeView.baseWritingDirection(for: position, in: direction)
+    }
+    
+    public func setBaseWritingDirection(_ writingDirection: UITextWritingDirection, for range: UITextRange) {
+        activeView.setBaseWritingDirection(writingDirection, for: range)
+    }
+    
+    public func firstRect(for range: UITextRange) -> CGRect {
+        return activeView.firstRect(for: range)
+    }
+    
+    public func caretRect(for position: UITextPosition) -> CGRect {
+        return activeView.caretRect(for: position)
+    }
+    
+    public func selectionRects(for range: UITextRange) -> [Any] {
+        return activeView.selectionRects(for: range)
+    }
+    
+    public func closestPosition(to point: CGPoint) -> UITextPosition? {
+        return activeView.closestPosition(to: point)
+    }
+    
+    public func closestPosition(to point: CGPoint, within range: UITextRange) -> UITextPosition? {
+        return activeView.closestPosition(to: point, within: range)
+    }
+    
+    public func characterRange(at point: CGPoint) -> UITextRange? {
+        return activeView.characterRange(at: point)
+    }
+    
+    public var hasText: Bool {
+        return activeView.hasText
+    }
+    
+    public func insertText(_ text: String) {
+        activeView.insertText(text)
+    }
+    
+    public func deleteBackward() {
+        activeView.deleteBackward()
+    }
+    
+    public var selectedTextRange: UITextRange? {
+        get {
+            return activeView.selectedTextRange
+        }
+        
+        set {
+            activeView.selectedTextRange = selectedTextRange
+        }
+    }
+}
+
 // MARK: - Initial Setup
 
 private extension EditorView {
@@ -144,10 +327,10 @@ private extension EditorView {
         richTextView.translatesAutoresizingMaskIntoConstraints = false
         
         addConstraints([
-                NSLayoutConstraint(item: htmlTextView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0.0),
-                NSLayoutConstraint(item: htmlTextView, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1.0, constant: 0.0),
-                NSLayoutConstraint(item: htmlTextView, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0.0),
-                NSLayoutConstraint(item: htmlTextView, attribute: .right, relatedBy: .equal, toItem: self, attribute: .right, multiplier: 1.0, constant: 0.0)
+            NSLayoutConstraint(item: htmlTextView, attribute: .top, relatedBy: .equal, toItem: self, attribute: .top, multiplier: 1.0, constant: 0.0),
+            NSLayoutConstraint(item: htmlTextView, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1.0, constant: 0.0),
+            NSLayoutConstraint(item: htmlTextView, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0.0),
+            NSLayoutConstraint(item: htmlTextView, attribute: .right, relatedBy: .equal, toItem: self, attribute: .right, multiplier: 1.0, constant: 0.0)
             ])
         
         addConstraints([

--- a/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
+++ b/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
@@ -43,7 +43,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CC400F161E9EC04200859AB4"

--- a/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
+++ b/Example/AztecExample.xcodeproj/xcshareddata/xcschemes/AztecExample.xcscheme
@@ -43,7 +43,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CC400F161E9EC04200859AB4"

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -192,6 +192,7 @@ class EditorDemoController: UIViewController {
         } else {
             html = ""
         }
+        
         editorView.setHTML(html)
         editorView.becomeFirstResponder()
     }
@@ -227,29 +228,28 @@ class EditorDemoController: UIViewController {
 
     // MARK: - Title and Title placeholder position methods
     func updateTitlePosition() {
-        let referenceView: UITextView = editorView.activeView
-        titleTopConstraint.constant = -(referenceView.contentOffset.y + referenceView.contentInset.top)
+        titleTopConstraint.constant = -(editorView.contentOffset.y + editorView.contentInset.top)
         titlePlaceholderTopConstraint.constant = titleTextView.textContainerInset.top + titleTextView.contentInset.top
         titlePlaceholderLeadingConstraint.constant = titleTextView.textContainerInset.left + titleTextView.contentInset.left  + titleTextView.textContainer.lineFragmentPadding
-        var contentInset = referenceView.contentInset
+        
+        var contentInset = editorView.contentInset
         contentInset.top = titleHeightConstraint.constant + separatorView.frame.height
-        referenceView.contentInset = contentInset
+        editorView.contentInset = contentInset
+        
         updateScrollInsets()
     }
 
     func updateScrollInsets() {
-        let referenceView: UITextView = editorView.activeView
-        var scrollInsets = referenceView.contentInset
+        var scrollInsets = editorView.contentInset
         var rightMargin = (view.frame.maxX - editorView.frame.maxX)
         if #available(iOS 11.0, *) {
             rightMargin -= view.safeAreaInsets.right
         }
         scrollInsets.right = -rightMargin
-        referenceView.scrollIndicatorInsets = scrollInsets
+        editorView.scrollIndicatorInsets = scrollInsets
     }
 
     func updateTitleHeight() {
-        let referenceView: UITextView = editorView.activeView
         let layoutMargins = view.layoutMargins
         let insets = titleTextView.textContainerInset
 
@@ -264,10 +264,10 @@ class EditorDemoController: UIViewController {
 
         titlePlaceholderLabel.isHidden = !titleTextView.text.isEmpty
 
-        var contentInset = referenceView.contentInset
+        var contentInset = editorView.contentInset
         contentInset.top = (titleHeightConstraint.constant + separatorView.frame.height)
-        referenceView.contentInset = contentInset
-        referenceView.setContentOffset(CGPoint(x: 0, y: -contentInset.top), animated: false)
+        editorView.contentInset = contentInset
+        editorView.contentOffset = CGPoint(x: 0, y: -contentInset.top)
     }
 
     // MARK: - Configuration Methods
@@ -378,13 +378,10 @@ class EditorDemoController: UIViewController {
     }
 
     fileprivate func refreshInsets(forKeyboardFrame keyboardFrame: CGRect) {
-        let referenceView: UIScrollView = editorView.activeView
-
         let keyboardHeight = view.frame.maxY - (keyboardFrame.minY + view.layoutMargins.bottom)
+        let contentInset = UIEdgeInsets(top: editorView.contentInset.top, left: 0, bottom: keyboardHeight, right: 0)
 
-        let contentInset = UIEdgeInsets(top: referenceView.contentInset.top, left: 0, bottom: keyboardHeight, right: 0)
-
-        editorView.activeView.contentInset = contentInset
+        editorView.contentInset = contentInset
         updateScrollInsets()
     }
 
@@ -622,6 +619,7 @@ extension EditorDemoController {
                                                   fromBarItem: item,
                                                   selectedRowIndex: selectedIndex,
                                                   onSelect: { [weak self] selected in
+                                                    
             guard let range = self?.richTextView.selectedRange else {
                 return
             }
@@ -925,10 +923,9 @@ extension EditorDemoController {
     }
     
     @objc func tabOnTitle() {
-        let activeTextView = editorView.activeView
-        
-        activeTextView.becomeFirstResponder()
-        activeTextView.selectedTextRange = activeTextView.textRange(from: activeTextView.endOfDocument, to: activeTextView.endOfDocument)
+        if editorView.becomeFirstResponder() {
+            editorView.selectedTextRange = editorView.htmlTextView.textRange(from: editorView.htmlTextView.endOfDocument, to: editorView.htmlTextView.endOfDocument)
+        }
     }
 
     @objc func showImagePicker() {


### PR DESCRIPTION
### Description:

This PR:

- [Fixes a bug](https://github.com/wordpress-mobile/AztecEditor-iOS/issues/956) that was causing HTML mode to have its layout broken as shown in the animation below.
- [Implements `UITextImput` in EditorView](https://github.com/wordpress-mobile/AztecEditor-iOS/compare/develop...try/fix-source-view?expand=1#diff-8c6bb98a814743991581ef39e0b91050R163) to avoid having to use the contained views directly.  We'll gradually move towards making the contained views private.

### Testing:

**Test 1:**
- Run the unit tests.

**Test 2:**
- Open the empty editor
- Type anything in the rich editor's body.
- Switch to HTML mode, and make sure the source view layout is fine.

**Test 3:**
- Test the editor freely, manually.  Add styles, change contents, etc.