### PR TITLE
Integrates renderers into Aztec libraries.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -136,6 +136,8 @@
 		F1953E251F4E544A00C717C9 /* HTMLParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1953E241F4E544A00C717C9 /* HTMLParserTests.swift */; };
 		F19544051F588F1A00671B73 /* CSSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19544041F588F1A00671B73 /* CSSParser.swift */; };
 		F197340E1FA14B85007018A8 /* HTMLTreeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F197340D1FA14B85007018A8 /* HTMLTreeProcessor.swift */; };
+		F1AFD65820B45E5700CB0279 /* CommentAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AFD65620B45E5700CB0279 /* CommentAttachmentRenderer.swift */; };
+		F1AFD65920B45E5700CB0279 /* HTMLAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AFD65720B45E5700CB0279 /* HTMLAttachmentRenderer.swift */; };
 		F1BDDDE520603C18000714E1 /* FigcaptionFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BDDDE420603C18000714E1 /* FigcaptionFormatter.swift */; };
 		F1BDDDE72060403B000714E1 /* FigureFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BDDDE62060403B000714E1 /* FigureFormatter.swift */; };
 		F1C05B991E37F99D007510EA /* Character+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B981E37F99D007510EA /* Character+Name.swift */; };
@@ -338,6 +340,8 @@
 		F1953E241F4E544A00C717C9 /* HTMLParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLParserTests.swift; sourceTree = "<group>"; };
 		F19544041F588F1A00671B73 /* CSSParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CSSParser.swift; sourceTree = "<group>"; };
 		F197340D1FA14B85007018A8 /* HTMLTreeProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLTreeProcessor.swift; sourceTree = "<group>"; };
+		F1AFD65620B45E5700CB0279 /* CommentAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentAttachmentRenderer.swift; sourceTree = "<group>"; };
+		F1AFD65720B45E5700CB0279 /* HTMLAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachmentRenderer.swift; sourceTree = "<group>"; };
 		F1BDDDE420603C18000714E1 /* FigcaptionFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FigcaptionFormatter.swift; sourceTree = "<group>"; };
 		F1BDDDE62060403B000714E1 /* FigureFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FigureFormatter.swift; sourceTree = "<group>"; };
 		F1C05B981E37F99D007510EA /* Character+Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Character+Name.swift"; sourceTree = "<group>"; };
@@ -500,6 +504,7 @@
 				F16DD2C51EE998280083A098 /* NSAttributedString */,
 				F1065DB420ADD91C008C72CC /* Plugin */,
 				FF20D63C1EDC389A00294B78 /* Processor */,
+				F1AFD65520B45E5700CB0279 /* Renderers */,
 				599F252E1D8BC9A1002871D6 /* TextKit */,
 			);
 			name = Classes;
@@ -884,6 +889,15 @@
 			name = Extensions;
 			sourceTree = "<group>";
 		};
+		F1AFD65520B45E5700CB0279 /* Renderers */ = {
+			isa = PBXGroup;
+			children = (
+				F1AFD65620B45E5700CB0279 /* CommentAttachmentRenderer.swift */,
+				F1AFD65720B45E5700CB0279 /* HTMLAttachmentRenderer.swift */,
+			);
+			path = Renderers;
+			sourceTree = "<group>";
+		};
 		F1FA0E781E6EF514009D98EE /* Data */ = {
 			isa = PBXGroup;
 			children = (
@@ -1097,6 +1111,7 @@
 				F11326B01EF1AA91007FEE9A /* Header.swift in Sources */,
 				F1C05B9F1E37FD2F007510EA /* NSAttributedString+CharacterName.swift in Sources */,
 				F17BC8921F4E4BA500398E2B /* CSSPropertyRepresentation.swift in Sources */,
+				F1AFD65920B45E5700CB0279 /* HTMLAttachmentRenderer.swift in Sources */,
 				FF20D6411EDC389A00294B78 /* HTMLProcessor.swift in Sources */,
 				B5C99D3F1E72E2E700335355 /* UIStackView+Helpers.swift in Sources */,
 				F1C05B991E37F99D007510EA /* Character+Name.swift in Sources */,
@@ -1173,6 +1188,7 @@
 				F12F586E1EF20394008AE298 /* LinkFormatter.swift in Sources */,
 				F1584796203C9B4C00EE05A1 /* NSMutableAttributedString+ParagraphProperty.swift in Sources */,
 				F1065DD520AEFBD2008C72CC /* PluginsManager.swift in Sources */,
+				F1AFD65820B45E5700CB0279 /* CommentAttachmentRenderer.swift in Sources */,
 				F12F586A1EF20394008AE298 /* HeaderFormatter.swift in Sources */,
 				F13CE5401F4DD08E0043368D /* RegexProcessor.swift in Sources */,
 				40A298731FD61E1900AEDF3B /* VideoElementConverter.swift in Sources */,

--- a/Aztec/Classes/Renderers/CommentAttachmentRenderer.swift
+++ b/Aztec/Classes/Renderers/CommentAttachmentRenderer.swift
@@ -1,15 +1,14 @@
 import Foundation
 import UIKit
-import Aztec
 
 
-// MARK: - HTMLAttachmentRenderer: Renders Unknown HTML
+// MARK: - CommentAttachmentRenderer: Renders HTML Comments!
 //
-final class HTMLAttachmentRenderer {
+final public class CommentAttachmentRenderer {
 
     /// Comment Attachment Text
     ///
-    let defaultText = NSLocalizedString("HTML", comment: "HTML Attachment Label")
+    let defaultText = NSLocalizedString("[COMMENT]", comment: "Comment Attachment Label")
 
     /// Text Color
     ///
@@ -22,7 +21,7 @@ final class HTMLAttachmentRenderer {
 
     /// Default Initializer
     ///
-    init(font: UIFont) {
+    public init(font: UIFont) {
         self.textFont = font
     }
 }
@@ -30,16 +29,16 @@ final class HTMLAttachmentRenderer {
 
 // MARK: - TextViewCommentsDelegate Methods
 //
-extension HTMLAttachmentRenderer: TextViewAttachmentImageProvider {
+extension CommentAttachmentRenderer: TextViewAttachmentImageProvider {
 
-    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
-        return attachment is HTMLAttachment
+    public func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
+        return attachment is CommentAttachment
     }
 
-    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
+    public func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
 
-        let message = messageAttributedString(with: attachment)
+        let message = messageAttributedString()
         let targetRect = boundingRect(for: message, size: size)
 
         message.draw(in: targetRect)
@@ -50,8 +49,8 @@ extension HTMLAttachmentRenderer: TextViewAttachmentImageProvider {
         return result
     }
 
-    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
-        let message = messageAttributedString(with: attachment)
+    public func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
+        let message = messageAttributedString()
 
         let size = CGSize(width: lineFragment.size.width, height: lineFragment.size.height)
         var rect = boundingRect(for: message, size: size)
@@ -64,7 +63,7 @@ extension HTMLAttachmentRenderer: TextViewAttachmentImageProvider {
 
 // MARK: - Private Methods
 //
-private extension HTMLAttachmentRenderer {
+private extension CommentAttachmentRenderer {
 
     func boundingRect(for message: NSAttributedString, size: CGSize) -> CGRect {
         let targetBounds = message.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
@@ -73,15 +72,12 @@ private extension HTMLAttachmentRenderer {
         return CGRect(origin: targetPosition, size: targetBounds.size)
     }
 
-    func messageAttributedString(with attachment: NSTextAttachment) -> NSAttributedString {
+    func messageAttributedString() -> NSAttributedString {
         let attributes: [NSAttributedStringKey: Any] = [
             .foregroundColor: textColor,
             .font: textFont
         ]
 
-        let htmlAttachment = attachment as? HTMLAttachment
-        let displayText = htmlAttachment?.rootTagName.uppercased() ?? defaultText
-
-        return NSAttributedString(string: "[\(displayText)]", attributes: attributes)
+        return NSAttributedString(string: defaultText, attributes: attributes)
     }
 }

--- a/Aztec/Classes/Renderers/CommentAttachmentRenderer.swift
+++ b/Aztec/Classes/Renderers/CommentAttachmentRenderer.swift
@@ -1,11 +1,10 @@
 import Foundation
 import UIKit
-import Aztec
 
 
 // MARK: - CommentAttachmentRenderer: Renders HTML Comments!
 //
-final class CommentAttachmentRenderer {
+final public class CommentAttachmentRenderer {
 
     /// Comment Attachment Text
     ///
@@ -22,7 +21,7 @@ final class CommentAttachmentRenderer {
 
     /// Default Initializer
     ///
-    init(font: UIFont) {
+    public init(font: UIFont) {
         self.textFont = font
     }
 }
@@ -32,11 +31,11 @@ final class CommentAttachmentRenderer {
 //
 extension CommentAttachmentRenderer: TextViewAttachmentImageProvider {
 
-    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
+    public func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
         return attachment is CommentAttachment
     }
 
-    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
+    public func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
 
         // Either this is a comment attachment, or the logic is broken.
@@ -57,7 +56,7 @@ extension CommentAttachmentRenderer: TextViewAttachmentImageProvider {
         return result
     }
 
-    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
+    public func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
         let message = messageAttributedString()
 
         // Either this is a comment attachment, or the logic is broken.

--- a/Aztec/Classes/Renderers/HTMLAttachmentRenderer.swift
+++ b/Aztec/Classes/Renderers/HTMLAttachmentRenderer.swift
@@ -1,15 +1,14 @@
 import Foundation
 import UIKit
-import Aztec
 
 
-// MARK: - CommentAttachmentRenderer: Renders HTML Comments!
+// MARK: - HTMLAttachmentRenderer: Renders Unknown HTML
 //
-final class CommentAttachmentRenderer {
+final public class HTMLAttachmentRenderer {
 
     /// Comment Attachment Text
     ///
-    let defaultText = NSLocalizedString("[COMMENT]", comment: "Comment Attachment Label")
+    let defaultText = NSLocalizedString("HTML", comment: "HTML Attachment Label")
 
     /// Text Color
     ///
@@ -22,7 +21,7 @@ final class CommentAttachmentRenderer {
 
     /// Default Initializer
     ///
-    init(font: UIFont) {
+    public init(font: UIFont) {
         self.textFont = font
     }
 }
@@ -30,16 +29,16 @@ final class CommentAttachmentRenderer {
 
 // MARK: - TextViewCommentsDelegate Methods
 //
-extension CommentAttachmentRenderer: TextViewAttachmentImageProvider {
+extension HTMLAttachmentRenderer: TextViewAttachmentImageProvider {
 
-    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
-        return attachment is CommentAttachment
+    public func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
+        return attachment is HTMLAttachment
     }
 
-    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
+    public func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
 
-        let message = messageAttributedString()
+        let message = messageAttributedString(with: attachment)
         let targetRect = boundingRect(for: message, size: size)
 
         message.draw(in: targetRect)
@@ -50,8 +49,8 @@ extension CommentAttachmentRenderer: TextViewAttachmentImageProvider {
         return result
     }
 
-    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
-        let message = messageAttributedString()
+    public func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
+        let message = messageAttributedString(with: attachment)
 
         let size = CGSize(width: lineFragment.size.width, height: lineFragment.size.height)
         var rect = boundingRect(for: message, size: size)
@@ -64,7 +63,7 @@ extension CommentAttachmentRenderer: TextViewAttachmentImageProvider {
 
 // MARK: - Private Methods
 //
-private extension CommentAttachmentRenderer {
+private extension HTMLAttachmentRenderer {
 
     func boundingRect(for message: NSAttributedString, size: CGSize) -> CGRect {
         let targetBounds = message.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
@@ -73,12 +72,15 @@ private extension CommentAttachmentRenderer {
         return CGRect(origin: targetPosition, size: targetBounds.size)
     }
 
-    func messageAttributedString() -> NSAttributedString {
+    func messageAttributedString(with attachment: NSTextAttachment) -> NSAttributedString {
         let attributes: [NSAttributedStringKey: Any] = [
             .foregroundColor: textColor,
             .font: textFont
         ]
 
-        return NSAttributedString(string: defaultText, attributes: attributes)
+        let htmlAttachment = attachment as? HTMLAttachment
+        let displayText = htmlAttachment?.rootTagName.uppercased() ?? defaultText
+
+        return NSAttributedString(string: "[\(displayText)]", attributes: attributes)
     }
 }

--- a/Aztec/Classes/Renderers/HTMLAttachmentRenderer.swift
+++ b/Aztec/Classes/Renderers/HTMLAttachmentRenderer.swift
@@ -1,10 +1,11 @@
 import Foundation
 import UIKit
+import Aztec
 
 
 // MARK: - HTMLAttachmentRenderer: Renders Unknown HTML
 //
-final public class HTMLAttachmentRenderer {
+final class HTMLAttachmentRenderer {
 
     /// Comment Attachment Text
     ///
@@ -21,7 +22,7 @@ final public class HTMLAttachmentRenderer {
 
     /// Default Initializer
     ///
-    public init(font: UIFont) {
+    init(font: UIFont) {
         self.textFont = font
     }
 }
@@ -31,11 +32,11 @@ final public class HTMLAttachmentRenderer {
 //
 extension HTMLAttachmentRenderer: TextViewAttachmentImageProvider {
 
-    public func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
+    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
         return attachment is HTMLAttachment
     }
 
-    public func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
+    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
 
         let message = messageAttributedString(with: attachment)
@@ -49,7 +50,7 @@ extension HTMLAttachmentRenderer: TextViewAttachmentImageProvider {
         return result
     }
 
-    public func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
+    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
         let message = messageAttributedString(with: attachment)
 
         let size = CGSize(width: lineFragment.size.width, height: lineFragment.size.height)

--- a/Aztec/Classes/Renderers/HTMLAttachmentRenderer.swift
+++ b/Aztec/Classes/Renderers/HTMLAttachmentRenderer.swift
@@ -1,11 +1,10 @@
 import Foundation
 import UIKit
-import Aztec
 
 
 // MARK: - HTMLAttachmentRenderer: Renders Unknown HTML
 //
-final class HTMLAttachmentRenderer {
+final public class HTMLAttachmentRenderer {
 
     /// Comment Attachment Text
     ///
@@ -22,7 +21,7 @@ final class HTMLAttachmentRenderer {
 
     /// Default Initializer
     ///
-    init(font: UIFont) {
+    public init(font: UIFont) {
         self.textFont = font
     }
 }
@@ -32,11 +31,11 @@ final class HTMLAttachmentRenderer {
 //
 extension HTMLAttachmentRenderer: TextViewAttachmentImageProvider {
 
-    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
+    public func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
         return attachment is HTMLAttachment
     }
 
-    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
+    public func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
 
         let message = messageAttributedString(with: attachment)
@@ -50,7 +49,7 @@ extension HTMLAttachmentRenderer: TextViewAttachmentImageProvider {
         return result
     }
 
-    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
+    public func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
         let message = messageAttributedString(with: attachment)
 
         let size = CGSize(width: lineFragment.size.width, height: lineFragment.size.height)

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -18,9 +18,6 @@
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
-		B570B1C91E82D332008CF41E /* SpecialTagAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B570B1C81E82D332008CF41E /* SpecialTagAttachmentRenderer.swift */; };
-		B570B1CC1E82D343008CF41E /* CommentAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B570B1CB1E82D343008CF41E /* CommentAttachmentRenderer.swift */; };
-		B5AF89341E93ECE60051EFDB /* HTMLAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AF89331E93ECE60051EFDB /* HTMLAttachmentRenderer.swift */; };
 		B5DB1C371EC630E10005E623 /* UnknownEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */; };
 		B5FB212A1FEC38470067D597 /* captions.html in Resources */ = {isa = PBXBuildFile; fileRef = B5FB21271FEC37DB0067D597 /* captions.html */; };
 		BE2672F31FC6E5A80026107E /* EditorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2672F21FC6E5A80026107E /* EditorPage.swift */; };
@@ -134,9 +131,6 @@
 		607FACDA1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		607FACDC1AFB9204008FA782 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
-		B570B1C81E82D332008CF41E /* SpecialTagAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpecialTagAttachmentRenderer.swift; sourceTree = "<group>"; };
-		B570B1CB1E82D343008CF41E /* CommentAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentAttachmentRenderer.swift; sourceTree = "<group>"; };
-		B5AF89331E93ECE60051EFDB /* HTMLAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnknownEditorViewController.swift; sourceTree = "<group>"; };
 		B5FB21271FEC37DB0067D597 /* captions.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = captions.html; sourceTree = "<group>"; };
 		BE2672F21FC6E5A80026107E /* EditorPage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorPage.swift; sourceTree = "<group>"; };
@@ -243,7 +237,6 @@
 		607FACD21AFB9204008FA782 /* Example for WordPress-Aztec-iOS */ = {
 			isa = PBXGroup;
 			children = (
-				B570B1CD1E82D349008CF41E /* Renders */,
 				599F256F1D8BCF57002871D6 /* AppDelegate.swift */,
 				59D287391D8C599B00B99C80 /* AttachmentDetailsViewController.swift */,
 				FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */,
@@ -267,16 +260,6 @@
 				607FACD41AFB9204008FA782 /* Info.plist */,
 			);
 			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		B570B1CD1E82D349008CF41E /* Renders */ = {
-			isa = PBXGroup;
-			children = (
-				B570B1CB1E82D343008CF41E /* CommentAttachmentRenderer.swift */,
-				B570B1C81E82D332008CF41E /* SpecialTagAttachmentRenderer.swift */,
-				B5AF89331E93ECE60051EFDB /* HTMLAttachmentRenderer.swift */,
-			);
-			name = Renders;
 			sourceTree = "<group>";
 		};
 		BE8EAC6A1FC1DCF3005CD7D0 /* Pages */ = {
@@ -475,11 +458,8 @@
 				599F25701D8BCF57002871D6 /* AppDelegate.swift in Sources */,
 				59D2873B1D8C599B00B99C80 /* AttachmentDetailsViewController.swift in Sources */,
 				FF6691C21E76CF9200C6A703 /* OptionsTableView.swift in Sources */,
-				B570B1CC1E82D343008CF41E /* CommentAttachmentRenderer.swift in Sources */,
-				B5AF89341E93ECE60051EFDB /* HTMLAttachmentRenderer.swift in Sources */,
 				E63EF92B1D36A60B00B5BA4B /* EditorDemoController.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
-				B570B1C91E82D332008CF41E /* SpecialTagAttachmentRenderer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
+++ b/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		F1065DCD20ADF5CB008C72CC /* AutoPProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1065DCC20ADF5CA008C72CC /* AutoPProcessor.swift */; };
 		F1065DCF20ADF5D3008C72CC /* RemovePProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1065DCE20ADF5D2008C72CC /* RemovePProcessor.swift */; };
 		F1065DD220AE3D98008C72CC /* VideoShortcodeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1065DD120AE3D98008C72CC /* VideoShortcodeProcessor.swift */; };
+		F1AFD65420B45DBB00CB0279 /* SpecialTagAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AFD65120B45DBB00CB0279 /* SpecialTagAttachmentRenderer.swift */; };
 		F1D360B72092947500B4E7A5 /* WordPressEditor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1D360AD2092947500B4E7A5 /* WordPressEditor.framework */; };
 		F1D360F7209297C300B4E7A5 /* Aztec.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1D360F2209297B400B4E7A5 /* Aztec.framework */; };
 		F1D360FB20929E0700B4E7A5 /* String+RegEx.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D360FA20929E0700B4E7A5 /* String+RegEx.swift */; };
@@ -65,6 +66,7 @@
 		F1065DCC20ADF5CA008C72CC /* AutoPProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoPProcessor.swift; sourceTree = "<group>"; };
 		F1065DCE20ADF5D2008C72CC /* RemovePProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemovePProcessor.swift; sourceTree = "<group>"; };
 		F1065DD120AE3D98008C72CC /* VideoShortcodeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoShortcodeProcessor.swift; sourceTree = "<group>"; };
+		F1AFD65120B45DBB00CB0279 /* SpecialTagAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpecialTagAttachmentRenderer.swift; sourceTree = "<group>"; };
 		F1D360AD2092947500B4E7A5 /* WordPressEditor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WordPressEditor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F1D360B12092947500B4E7A5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F1D360B62092947500B4E7A5 /* WordPressEditorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WordPressEditorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -131,6 +133,14 @@
 			path = Internals;
 			sourceTree = "<group>";
 		};
+		F1AFD65020B45DBB00CB0279 /* Renderers */ = {
+			isa = PBXGroup;
+			children = (
+				F1AFD65120B45DBB00CB0279 /* SpecialTagAttachmentRenderer.swift */,
+			);
+			path = Renderers;
+			sourceTree = "<group>";
+		};
 		F1D360A32092947500B4E7A5 = {
 			isa = PBXGroup;
 			children = (
@@ -176,9 +186,10 @@
 		F1D360C72092967E00B4E7A5 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				F1D360F920929E0700B4E7A5 /* Extensions */,
 				F1065DB720ADEC1D008C72CC /* Plugins */,
 				F1D3610C20929F3A00B4E7A5 /* Processors */,
-				F1D360F920929E0700B4E7A5 /* Extensions */,
+				F1AFD65020B45DBB00CB0279 /* Renderers */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -368,6 +379,7 @@
 				F1D360FB20929E0700B4E7A5 /* String+RegEx.swift in Sources */,
 				F1065DC320ADEEF4008C72CC /* CaptionShortcodeInputProcessor.swift in Sources */,
 				F1D3611020929F7900B4E7A5 /* ShortcodeProcessor.swift in Sources */,
+				F1AFD65420B45DBB00CB0279 /* SpecialTagAttachmentRenderer.swift in Sources */,
 				F1D3612C209352F400B4E7A5 /* MediaAttachment+WordPress.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPressEditor/WordPressEditor/Classes/Renderers/SpecialTagAttachmentRenderer.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Renderers/SpecialTagAttachmentRenderer.swift
@@ -5,11 +5,13 @@ import Aztec
 
 // MARK: - SpecialTagAttachmentRenderer. This render aims rendering WordPress specific tags.
 //
-final class SpecialTagAttachmentRenderer {
+final public class SpecialTagAttachmentRenderer {
 
     /// Text Color
     ///
     var textColor = UIColor.gray
+    
+    public init() {}
 }
 
 
@@ -17,7 +19,7 @@ final class SpecialTagAttachmentRenderer {
 //
 extension SpecialTagAttachmentRenderer: TextViewAttachmentImageProvider {
 
-    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
+    public func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
         guard let commentAttachment = attachment as? CommentAttachment else {
             return false
         }
@@ -25,7 +27,7 @@ extension SpecialTagAttachmentRenderer: TextViewAttachmentImageProvider {
         return Tags.supported.contains(commentAttachment.text)
     }
 
-    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
+    public func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
         guard let attachment = attachment as? CommentAttachment else {
             return nil
         }
@@ -66,7 +68,7 @@ extension SpecialTagAttachmentRenderer: TextViewAttachmentImageProvider {
         return result
     }
 
-    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
+    public func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
         let padding = textView.textContainer.lineFragmentPadding
         let width = lineFragment.width - padding * 2
 

--- a/WordPressEditor/WordPressEditor/Classes/Renderers/SpecialTagAttachmentRenderer.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Renderers/SpecialTagAttachmentRenderer.swift
@@ -1,15 +1,17 @@
+import Aztec
 import Foundation
 import UIKit
-import Aztec
 
 
 // MARK: - SpecialTagAttachmentRenderer. This render aims rendering WordPress specific tags.
 //
-final class SpecialTagAttachmentRenderer {
+final public class SpecialTagAttachmentRenderer {
 
     /// Text Color
     ///
     var textColor = UIColor.gray
+    
+    public init() {}
 }
 
 
@@ -17,7 +19,7 @@ final class SpecialTagAttachmentRenderer {
 //
 extension SpecialTagAttachmentRenderer: TextViewAttachmentImageProvider {
 
-    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
+    public func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
         guard let commentAttachment = attachment as? CommentAttachment else {
             return false
         }
@@ -25,7 +27,7 @@ extension SpecialTagAttachmentRenderer: TextViewAttachmentImageProvider {
         return Tags.supported.contains(commentAttachment.text)
     }
 
-    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
+    public func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
         guard let attachment = attachment as? CommentAttachment else {
             return nil
         }
@@ -61,7 +63,7 @@ extension SpecialTagAttachmentRenderer: TextViewAttachmentImageProvider {
         return result
     }
 
-    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
+    public func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
         let padding = textView.textContainer.lineFragmentPadding
         let width = lineFragment.width - padding * 2
 

--- a/WordPressEditor/WordPressEditor/Classes/Renderers/SpecialTagAttachmentRenderer.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Renderers/SpecialTagAttachmentRenderer.swift
@@ -5,13 +5,11 @@ import Aztec
 
 // MARK: - SpecialTagAttachmentRenderer. This render aims rendering WordPress specific tags.
 //
-final public class SpecialTagAttachmentRenderer {
+final class SpecialTagAttachmentRenderer {
 
     /// Text Color
     ///
     var textColor = UIColor.gray
-    
-    public init() {}
 }
 
 
@@ -19,7 +17,7 @@ final public class SpecialTagAttachmentRenderer {
 //
 extension SpecialTagAttachmentRenderer: TextViewAttachmentImageProvider {
 
-    public func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
+    func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
         guard let commentAttachment = attachment as? CommentAttachment else {
             return false
         }
@@ -27,7 +25,7 @@ extension SpecialTagAttachmentRenderer: TextViewAttachmentImageProvider {
         return Tags.supported.contains(commentAttachment.text)
     }
 
-    public func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
+    func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
         guard let attachment = attachment as? CommentAttachment else {
             return nil
         }
@@ -35,16 +33,11 @@ extension SpecialTagAttachmentRenderer: TextViewAttachmentImageProvider {
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
 
         let label = attachment.text.uppercased()
-
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.baseWritingDirection = .leftToRight
-        let attributes: [NSAttributedStringKey: Any] = [.foregroundColor: textColor, .paragraphStyle: paragraphStyle]
-
-        let colorMessage = NSAttributedString(string: label, attributes: attributes)
+        let colorMessage = NSAttributedString(string: label, attributes: [.foregroundColor: textColor])
 
         let textRect = colorMessage.boundingRect(with: size, options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil)
         let textPosition = CGPoint(x: ((size.width - textRect.width) * 0.5), y: ((size.height - textRect.height) * 0.5))
-        colorMessage.draw(in: CGRect(origin: textPosition , size: CGSize(width: size.width, height: textRect.size.height)))
+        colorMessage.draw(in: CGRect(origin: textPosition, size: CGSize(width: size.width, height: textRect.size.height)))
 
         let path = UIBezierPath()
 
@@ -56,7 +49,7 @@ extension SpecialTagAttachmentRenderer: TextViewAttachmentImageProvider {
         path.move(to: CGPoint(x: 0, y: centerY))
         path.addLine(to: CGPoint(x: ((size.width - textRect.width) * 0.5) - Constants.defaultDashWidth, y: centerY))
 
-        path.move(to: CGPoint(x:((size.width + textRect.width) * 0.5) + Constants.defaultDashWidth, y: centerY))
+        path.move(to: CGPoint(x: ((size.width + textRect.width) * 0.5) + Constants.defaultDashWidth, y: centerY))
         path.addLine(to: CGPoint(x: size.width, y: centerY))
 
         textColor.setStroke()
@@ -68,7 +61,7 @@ extension SpecialTagAttachmentRenderer: TextViewAttachmentImageProvider {
         return result
     }
 
-    public func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
+    func textView(_ textView: TextView, boundsFor attachment: NSTextAttachment, with lineFragment: CGRect) -> CGRect {
         let padding = textView.textContainer.lineFragmentPadding
         let width = lineFragment.width - padding * 2
 


### PR DESCRIPTION
### Description:

In this PR:

- We're moving our standard renderers into the `Aztec` and `WordPressEditor` targets.
- We're updating the local version of those renderers, to the latest version from WPiOS.

Next steps will be to integrate this into WPiOS and remove the duplicated renderers from it.  This will also enable us to implement a custom Gutenberg renderer for self-closed blocks.

### Testing:

- Run the unit tests.
- Try the editor out and make sure comments, more-comments and unsupported HTML is rendered correctly.