### PR TITLE
Fix replacement range on auto replaces for different sized text.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1238,13 +1238,14 @@ open class TextView: UITextView {
             let currentAttributes = self.typingAttributesSwifted
             superMethod(self, selector, range, replacementText)
             // apply all attributes that where set before the call to the new text
-            self.textStorage.setAttributes(currentAttributes, range: rangeFrom(uiTextRange: range))
+            self.textStorage.setAttributes(currentAttributes, range: adjustedRangeFrom(uiTextRange: range, replacedBy: replacementText))
         }
     }
 
-    func rangeFrom(uiTextRange range: UITextRange) -> NSRange {
+    func adjustedRangeFrom(uiTextRange range: UITextRange, replacedBy text: String) -> NSRange {
         let location = offset(from: beginningOfDocument, to: range.start)
-        let length = offset(from: range.start, to: range.end)
+        let length = (text as NSString).length
+
         return NSRange(location: location, length: length)
     }
 

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1850,7 +1850,7 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(html, "<h1>Header</h1><p>test</p><p><hr></p>")
     }
 
-    /// This test makes sure that if an auto replacement is made with an emoji things work correctly
+    /// This test makes sure that if an auto replacement is made with smaller text, for example an emoji, things work correctly
     func testAutoCompletionReplacementHackWhenUsingEmoji() {
         let textView = createTextView(withHTML: "Love")
         let uiTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.endOfDocument)!

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1850,4 +1850,14 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(html, "<h1>Header</h1><p>test</p><p><hr></p>")
     }
 
+    /// This test makes sure that if an auto replacement is made with an emoji things work correctly
+    func testAutoCompletionReplacementHackWhenUsingEmoji() {
+        let textView = createTextView(withHTML: "Love")
+        let uiTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.endOfDocument)!
+        textView.replaceRangeWithTextWithoutClosingTyping(uiTextRange, replacementText:"😘")
+        let html = textView.getHTML()
+
+        XCTAssertEqual(html, "<p>😘</p>")
+    }
+
 }


### PR DESCRIPTION
This PR fixes an issue where an auto completion of text was being done using smaller or larger text than the original. For example replacing the word Love for the emoji ❤️ .

I added a unit test to future proof this scenario

To test:
 - Open the empty editor demo
 - Type the word Cheers
 - Select the word
 - Activate the emoji keyboard (tap on the globe symbol)
 - see if on the autocompletion shows an emoji 
 - tap on the autocompletion with the emoji
 - see if it not crashes.

