### PR TITLE
Make Gutenberg blocks mergeable

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -23,7 +23,7 @@ public struct Element: RawRepresentable, Hashable {
 
     /// List of block HTML elements that can be merged together when they are sibling to each other
     ///
-    public static var mergeableBlocklevelElements: Set<Element> = Set([.blockquote, .div, .figure, .figcaption, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .ol, .ul, .p])
+    public static var mergeableBlockLevelElements: Set<Element> = Set([.blockquote, .div, .figure, .figcaption, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .ol, .ul, .p])
 
     /// List of style HTML elements that can be merged together when they are sibling to each other
     public static var mergeableStyleElements: Set<Element> = Set([.i, .em, .b, .strong, .strike, .u, .code, .cite])

--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -21,10 +21,15 @@ public struct Element: RawRepresentable, Hashable {
     ///
     public static var voidElements: [Element] = [.area, .base, .br, .col, .embed, .hr, .img, .input, .link, .meta, .param, .source, .track, .wbr]
 
+    /// List of block HTML elements that can be merged together when they are sibling to each other
+    ///
     public static var mergeableBlocklevelElements: [Element] = [.blockquote, .div, .figure, .figcaption, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .ol, .ul]
 
+    /// List of style HTML elements that can be merged together when they are sibling to each other
     public static var mergeableStyleElements: [Element] = [.i, .em, .b, .strong, .strike, .u, .code, .cite]
 
+    /// List of block level elements that can be merged but only when they have a single children that is also mergeable
+    ///
     public static var mergeableBlocklevelElementsSingleChildren: [Element] = []
 
     // MARK: - Initializers

--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -20,7 +20,13 @@ public struct Element: RawRepresentable, Hashable {
     /// Ref. http://w3c.github.io/html/syntax.html#void-elements
     ///
     public static var voidElements: [Element] = [.area, .base, .br, .col, .embed, .hr, .img, .input, .link, .meta, .param, .source, .track, .wbr]
-    
+
+    public static var mergeableBlocklevelElements: [Element] = [.blockquote, .div, .figure, .figcaption, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .ol, .ul]
+
+    public static var mergeableStyleElements: [Element] = [.i, .em, .b, .strong, .strike, .u, .code, .cite]
+
+    public static var mergeableBlocklevelElementsSingleChildren: [Element] = []
+
     // MARK: - Initializers
     
     public init?(rawValue: RawValue) {

--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -23,7 +23,7 @@ public struct Element: RawRepresentable, Hashable {
 
     /// List of block HTML elements that can be merged together when they are sibling to each other
     ///
-    public static var mergeableBlocklevelElements: Set<Element> = Set([.blockquote, .div, .figure, .figcaption, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .ol, .ul])
+    public static var mergeableBlocklevelElements: Set<Element> = Set([.blockquote, .div, .figure, .figcaption, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .ol, .ul, .p])
 
     /// List of style HTML elements that can be merged together when they are sibling to each other
     public static var mergeableStyleElements: Set<Element> = Set([.i, .em, .b, .strong, .strike, .u, .code, .cite])

--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -13,7 +13,7 @@ public struct Element: RawRepresentable, Hashable {
     
     /// This can be extended in case new elements need to be defined.
     ///
-    public static var blockLevelElements: [Element] = [.address, .aztecRootNode, .blockquote, .div, .dl, .dd, .dt, .fieldset, .figure, .figcaption, .form, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .noscript, .ol, .p, .pre, .table, .td, .tr, .ul]
+    public static var blockLevelElements: Set<Element> = Set([.address, .aztecRootNode, .blockquote, .div, .dl, .dd, .dt, .fieldset, .figure, .figcaption, .form, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .noscript, .ol, .p, .pre, .table, .td, .tr, .ul])
     
     /// List of void elements.  These will *not* to have a closing tag and cannot have children.
     ///
@@ -23,14 +23,14 @@ public struct Element: RawRepresentable, Hashable {
 
     /// List of block HTML elements that can be merged together when they are sibling to each other
     ///
-    public static var mergeableBlocklevelElements: [Element] = [.blockquote, .div, .figure, .figcaption, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .ol, .ul]
+    public static var mergeableBlocklevelElements: Set<Element> = Set([.blockquote, .div, .figure, .figcaption, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .ol, .ul])
 
     /// List of style HTML elements that can be merged together when they are sibling to each other
-    public static var mergeableStyleElements: [Element] = [.i, .em, .b, .strong, .strike, .u, .code, .cite]
+    public static var mergeableStyleElements: Set<Element> = Set([.i, .em, .b, .strong, .strike, .u, .code, .cite])
 
     /// List of block level elements that can be merged but only when they have a single children that is also mergeable
     ///
-    public static var mergeableBlocklevelElementsSingleChildren: [Element] = []
+    public static var mergeableBlocklevelElementsSingleChildren =  Set<Element>()
 
     // MARK: - Initializers
     

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -294,8 +294,7 @@ public class ElementNode: Node {
         }
 
         guard children.count == 1,
-            let singleChildren = children.first as? ElementNode,
-            Element.mergeableBlocklevelElements.contains(singleChildren.type) else {
+            let singleChildren = children.first as? ElementNode, singleChildren.isBlockLevel() else {
             return false
         }
 

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -263,43 +263,7 @@ public class ElementNode: Node {
         return elements.first { element in
             return element.isNodeType(type)
         }
-    }
-
-
-    /// Indicates whether the children of the specified node can be merged in, or not.
-    ///
-    /// - Parameters:
-    ///     - node: Target node for which we'll determine Merge-ability status.
-    ///
-    /// - Returns: true if both nodes can be merged, or not.
-    ///
-    func canMergeChildren(of node: ElementNode, blocklevelEnforced: Bool) -> Bool {
-        guard name == node.name && Set(attributes) == Set(node.attributes) else {
-            return false
-        }
-
-        guard blocklevelEnforced else {
-            return Element.mergeableStyleElements.contains(type)
-        }
-
-        return isBlockLevelMergeable()
-    }
-
-    public func isBlockLevelMergeable() -> Bool {
-        guard Element.mergeableBlockLevelElements.contains(type) else {
-            return false
-        }
-        guard Element.mergeableBlocklevelElementsSingleChildren.contains(type) else {
-            return Element.mergeableBlockLevelElements.contains(type)
-        }
-
-        guard children.count == 1,
-            let singleChildren = children.first as? ElementNode, singleChildren.isBlockLevel() else {
-            return false
-        }
-
-        return true
-    }
+    }    
 
     // MARK: - DOM Queries
     

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -20,10 +20,7 @@ public class ElementNode: Node {
             return nil
         }
         return headerLevels[headerLevel - 1]
-    }
-
-    private static let mergeableBlocklevelElements: [Element] = [.blockquote, .div, .figure, .figcaption, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .ol, .p, .ul]
-    private static let mergeableStyleElements: [Element] = [.i, .em, .b, .strong, .strike, .u, .code, .cite]
+    }    
     
     public var type: Element {
         get {
@@ -282,12 +279,28 @@ public class ElementNode: Node {
         }
 
         guard blocklevelEnforced else {
-            return ElementNode.mergeableStyleElements.contains(type)
+            return Element.mergeableStyleElements.contains(type)
         }
 
-        return ElementNode.mergeableBlocklevelElements.contains(type)
+        return isBlockLevelMergeable()
     }
 
+    public func isBlockLevelMergeable() -> Bool {
+        guard Element.mergeableBlocklevelElements.contains(type) else {
+            return false
+        }
+        guard Element.mergeableBlocklevelElementsSingleChildren.contains(type) else {
+            return Element.mergeableBlocklevelElements.contains(type)
+        }
+
+        guard children.count == 1,
+            let singleChildren = children.first as? ElementNode,
+            Element.mergeableBlocklevelElements.contains(singleChildren.type) else {
+            return false
+        }
+
+        return true
+    }
 
     // MARK: - DOM Queries
     

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -286,11 +286,11 @@ public class ElementNode: Node {
     }
 
     public func isBlockLevelMergeable() -> Bool {
-        guard Element.mergeableBlocklevelElements.contains(type) else {
+        guard Element.mergeableBlockLevelElements.contains(type) else {
             return false
         }
         guard Element.mergeableBlocklevelElementsSingleChildren.contains(type) else {
-            return Element.mergeableBlocklevelElements.contains(type)
+            return Element.mergeableBlockLevelElements.contains(type)
         }
 
         guard children.count == 1,

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -199,24 +199,7 @@ private extension AttributedStringParser {
             return Element.mergeableStyleElements.contains(left.type)
         }
 
-        return isBlockLevelMergeable(node: left)
-    }
-
-    func isBlockLevelMergeable(node: ElementNode) -> Bool {
-        guard Element.mergeableBlockLevelElements.contains(node.type) else {
-            return false
-        }
-        guard Element.mergeableBlocklevelElementsSingleChildren.contains(node.type) else {
-            return Element.mergeableBlockLevelElements.contains(node.type)
-        }
-
-        guard node.children.count == 1,
-            let singleChildren = node.children.first as? ElementNode,
-            singleChildren.isBlockLevel() else {
-                return false
-        }
-
-        return true
+        return Element.mergeableBlockLevelElements.contains(left.type)
     }
 }
 
@@ -412,6 +395,12 @@ private extension AttributedStringParser {
             mergeCandidates = ArraySlice<MergeablePair>(mergeableNodes)
         } else {
             mergeCandidates = mergeableNodes.dropLast()
+            
+            if let last = mergeCandidates.last,
+                Element.mergeableBlocklevelElementsSingleChildren.contains(last.left.type) {
+                
+                mergeCandidates = mergeCandidates.dropLast()
+            }
         }
 
         if lastNodeName != Element.li.rawValue {

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -171,7 +171,7 @@ private extension AttributedStringParser {
             let left = left[currentIndex]
             let right = right[currentIndex]
 
-            guard left.canMergeChildren(of: right, blocklevelEnforced: blocklevelEnforced) else {
+            guard canMergeNodes(left:left, right: right, blocklevelEnforced: blocklevelEnforced) else {
                 break
             }
 
@@ -181,6 +181,42 @@ private extension AttributedStringParser {
         }
 
         return matching.isEmpty ? nil : matching
+    }
+
+    /// Indicates whether the children of the specified node can be merged in, or not.
+    ///
+    /// - Parameters:
+    ///     - node: Target node for which we'll determine Merge-ability status.
+    ///
+    /// - Returns: true if both nodes can be merged, or not.
+    ///
+    func canMergeNodes(left: ElementNode, right: ElementNode, blocklevelEnforced: Bool) -> Bool {
+        guard left.name == right.name && Set(left.attributes) == Set(right.attributes) else {
+            return false
+        }
+
+        guard blocklevelEnforced else {
+            return Element.mergeableStyleElements.contains(left.type)
+        }
+
+        return isBlockLevelMergeable(node: left)
+    }
+
+    func isBlockLevelMergeable(node: ElementNode) -> Bool {
+        guard Element.mergeableBlockLevelElements.contains(node.type) else {
+            return false
+        }
+        guard Element.mergeableBlocklevelElementsSingleChildren.contains(node.type) else {
+            return Element.mergeableBlockLevelElements.contains(node.type)
+        }
+
+        guard node.children.count == 1,
+            let singleChildren = node.children.first as? ElementNode,
+            singleChildren.isBlockLevel() else {
+                return false
+        }
+
+        return true
     }
 }
 
@@ -348,7 +384,7 @@ private extension AttributedStringParser {
             return false
         }
 
-        leftMerger.children += rightMerger.children
+        leftMerger.children = leftMerger.children + rightMerger.children
 
         return true
     }

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergAttributeNames.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergAttributeNames.swift
@@ -8,4 +8,5 @@ struct GutenbergAttributeNames {
     public static let selfCloser = "selfCloser"
     public static let blockOpener = "opener"
     public static let blockCloser = "closer"
+    public static let blockType = "blockType"
 }

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergAttributeNames.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergAttributeNames.swift
@@ -8,5 +8,4 @@ struct GutenbergAttributeNames {
     public static let selfCloser = "selfCloser"
     public static let blockOpener = "opener"
     public static let blockCloser = "closer"
-    public static let blockType = "blockType"
 }

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
@@ -8,14 +8,14 @@ public class GutenbergInputHTMLTreeProcessor: HTMLTreeProcessor {
     // MARK: - Initializers
     
     private static let classInitializer: () = {
-        Element.blockLevelElements.append(.gutenblock)
+        Element.blockLevelElements.insert(.gutenblock)
 
-        Element.mergeableBlocklevelElements.append(.gutenblock)
+        Element.mergeableBlocklevelElements.insert(.gutenblock)
 
-        Element.mergeableBlocklevelElementsSingleChildren.append(.gutenblock)
+        Element.mergeableBlocklevelElementsSingleChildren.insert(.gutenblock)
         
         // Self-closing blocks are packed into attachments.
-        Element.blockLevelElements.append(.gutenpack)
+        Element.blockLevelElements.insert(.gutenpack)
     }()
     
     public init() {

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
@@ -10,7 +10,7 @@ public class GutenbergInputHTMLTreeProcessor: HTMLTreeProcessor {
     private static let classInitializer: () = {
         Element.blockLevelElements.insert(.gutenblock)
 
-        Element.mergeableBlocklevelElements.insert(.gutenblock)
+        Element.mergeableBlockLevelElements.insert(.gutenblock)
 
         Element.mergeableBlocklevelElementsSingleChildren.insert(.gutenblock)
         

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
@@ -9,6 +9,10 @@ public class GutenbergInputHTMLTreeProcessor: HTMLTreeProcessor {
     
     private static let classInitializer: () = {
         Element.blockLevelElements.append(.gutenblock)
+
+        Element.mergeableBlocklevelElements.append(.gutenblock)
+
+        Element.mergeableBlocklevelElementsSingleChildren.append(.gutenblock)
         
         // Self-closing blocks are packed into attachments.
         Element.blockLevelElements.append(.gutenpack)

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
@@ -107,8 +107,12 @@ private extension GutenbergInputHTMLTreeProcessor {
     func openerAttributes(for commentNode: CommentNode) -> [Attribute] {
         let attributeName = GutenbergAttributeNames.blockOpener
         let openerBase64String = encode(commentNode)
-        
-        return [Attribute(name: attributeName, value: .string(openerBase64String))]
+        // TODO: Parse and create an extra attribute to get the block name.        
+        let blockName = commentNode.comment.trimmingCharacters(in: .whitespaces).prefix { (char) -> Bool in
+            return char != " "
+        }
+        let nameAttribute = Attribute(name:GutenbergAttributeNames.blockType, value: .string(String(blockName)))
+        return [Attribute(name: attributeName, value: .string(openerBase64String)), nameAttribute]
     }
     
     func selfClosingAttributes(for commentNode: CommentNode) -> [Attribute] {

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
@@ -107,12 +107,8 @@ private extension GutenbergInputHTMLTreeProcessor {
     func openerAttributes(for commentNode: CommentNode) -> [Attribute] {
         let attributeName = GutenbergAttributeNames.blockOpener
         let openerBase64String = encode(commentNode)
-        // TODO: Parse and create an extra attribute to get the block name.        
-        let blockName = commentNode.comment.trimmingCharacters(in: .whitespaces).prefix { (char) -> Bool in
-            return char != " "
-        }
-        let nameAttribute = Attribute(name:GutenbergAttributeNames.blockType, value: .string(String(blockName)))
-        return [Attribute(name: attributeName, value: .string(openerBase64String)), nameAttribute]
+        
+        return [Attribute(name: attributeName, value: .string(openerBase64String))]
     }
     
     func selfClosingAttributes(for commentNode: CommentNode) -> [Attribute] {

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
@@ -89,5 +89,41 @@ class WordpressPluginTests: XCTestCase {
         
         XCTAssertEqual(outputTextNode.text(), text)
     }
+
+    // MARK: - Test merging of gutenberg block
+
+    func testMergingOfListBlockWithMultipleListElements() {
+        let initialHTML = """
+<!-- wp:list -->
+<ul>
+    <li>Media library/HTML for images, multimedia and approved files.</li>
+    <li>Pasted links for embeds.</li>
+    <li>Shortcodes for specialized assets from plugins.</li>
+    <li>Featured images for the image at the top of a post or page.</li>
+    <li>Excerpts for subheads.</li>
+    <li>Widgets for content on the side of a page.</li>
+</ul>
+<!-- /wp:list -->
+"""
+        let attrString = htmlConverter.attributedString(from: initialHTML)
+        let finalHTML = htmlConverter.html(from: attrString)
+
+        XCTAssertEqual(finalHTML, initialHTML)
+    }
+
+    func testMerginOfBlockquoteBlockWithMultipleLinesElements() {
+        let initialHTML = """
+<!-- wp:quote -->
+<blockquote class="wp-block-quote is-large">
+    <p>Take comfort in the fact that you 'can' keep your current publishing flow... </p>
+    <p>and then take some time to explore the possibilities that Gutenberg opens up to you.</p>
+</blockquote>
+<!-- /wp:quote -->
+"""
+        let attrString = htmlConverter.attributedString(from: initialHTML)
+        let finalHTML = htmlConverter.html(from: attrString)
+
+        XCTAssertEqual(finalHTML, initialHTML)
+    }
 }
 

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
@@ -96,17 +96,17 @@ class WordpressPluginTests: XCTestCase {
         let initialHTML = """
 <!-- wp:list -->
 <ul>
-    <li>Media library/HTML for images, multimedia and approved files.</li>
-    <li>Pasted links for embeds.</li>
-    <li>Shortcodes for specialized assets from plugins.</li>
-    <li>Featured images for the image at the top of a post or page.</li>
-    <li>Excerpts for subheads.</li>
-    <li>Widgets for content on the side of a page.</li>
+  <li>Media library/HTML for images, multimedia and approved files.</li>
+  <li>Pasted links for embeds.</li>
+  <li>Shortcodes for specialized assets from plugins.</li>
+  <li>Featured images for the image at the top of a post or page.</li>
+  <li>Excerpts for subheads.</li>
+  <li>Widgets for content on the side of a page.</li>
 </ul>
 <!-- /wp:list -->
 """
         let attrString = htmlConverter.attributedString(from: initialHTML)
-        let finalHTML = htmlConverter.html(from: attrString)
+        let finalHTML = htmlConverter.html(from: attrString, prettify: true)
 
         XCTAssertEqual(finalHTML, initialHTML)
     }
@@ -115,13 +115,28 @@ class WordpressPluginTests: XCTestCase {
         let initialHTML = """
 <!-- wp:quote -->
 <blockquote class="wp-block-quote is-large">
-    <p>Take comfort in the fact that you 'can' keep your current publishing flow... </p>
-    <p>and then take some time to explore the possibilities that Gutenberg opens up to you.</p>
+  <p>Take comfort in the fact that you 'can' keep your current publishing flow... </p>
+  <p>and then take some time to explore the possibilities that Gutenberg opens up to you.</p>
 </blockquote>
 <!-- /wp:quote -->
 """
         let attrString = htmlConverter.attributedString(from: initialHTML)
-        let finalHTML = htmlConverter.html(from: attrString)
+        let finalHTML = htmlConverter.html(from: attrString, prettify: true)
+
+        XCTAssertEqual(finalHTML, initialHTML)
+    }
+
+    func testMerginOfMultipleParagraphsElements() {
+        let initialHTML = """
+<!-- wp:paragraph -->
+<p>Take comfort in the fact that you 'can' keep your current publishing flow... </p>
+<!-- /wp:paragraph -->
+<!-- wp:paragraph -->
+<p>and then take some time to explore the possibilities that Gutenberg opens up to you.</p>
+<!-- /wp:paragraph -->
+"""
+        let attrString = htmlConverter.attributedString(from: initialHTML)
+        let finalHTML = htmlConverter.html(from: attrString, prettify: true)
 
         XCTAssertEqual(finalHTML, initialHTML)
     }


### PR DESCRIPTION
Fixes #977 

This PR makes the following changes:
 - Make the definition of mergeable elements configurable from the outside of the library
 - Add Gutenblocks to the list of mergeable blocks
 - Add a special rule for Gutenblocks merge where this can only happen when they have elements that are mergeable them selfs.

To test:
 - Run unit tests to make sure all are green.

