### PR TITLE
Fixes gutenberg self-closing blocks.

### DIFF
--- a/Example/Example/SampleContent/gutenberg.html
+++ b/Example/Example/SampleContent/gutenberg.html
@@ -138,3 +138,5 @@
 <!-- wp:separator -->
 <hr class="wp-block-separator" />
 <!-- /wp:separator -->
+
+<!-- wp:latest-posts /-->

--- a/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
+++ b/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
@@ -26,10 +26,10 @@
 		F16A2ADF20CD9F1300BF3A0A /* GalleryAttachmentToElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16A2ADE20CD9F1300BF3A0A /* GalleryAttachmentToElementConverter.swift */; };
 		F16A2AEC20CDA20300BF3A0A /* GallerySupportedAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16A2AEB20CDA20300BF3A0A /* GallerySupportedAttribute.swift */; };
 		F1AFD65420B45DBB00CB0279 /* SpecialTagAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AFD65120B45DBB00CB0279 /* SpecialTagAttachmentRenderer.swift */; };
-		F1B1FDCE20D14ACB0090A0A5 /* WordPressInputCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B1FDCD20D14ACB0090A0A5 /* WordPressInputCustomizer.swift */; };
-		F1B1FDD220D14B6D0090A0A5 /* WordPressOutputCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B1FDD120D14B6D0090A0A5 /* WordPressOutputCustomizer.swift */; };
 		F1B0012920C5895800612EE9 /* GalleryShortcodeInputProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B0012820C5895800612EE9 /* GalleryShortcodeInputProcessor.swift */; };
 		F1B0012D20C5948000612EE9 /* GalleryShortcodeInputProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B0012C20C5948000612EE9 /* GalleryShortcodeInputProcessorTests.swift */; };
+		F1B1FDCE20D14ACB0090A0A5 /* WordPressInputCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B1FDCD20D14ACB0090A0A5 /* WordPressInputCustomizer.swift */; };
+		F1B1FDD220D14B6D0090A0A5 /* WordPressOutputCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B1FDD120D14B6D0090A0A5 /* WordPressOutputCustomizer.swift */; };
 		F1C14C4B20CDE653002A4083 /* GalleryElementToTagConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C14C4A20CDE653002A4083 /* GalleryElementToTagConverter.swift */; };
 		F1C9F40920AF62E900205227 /* GutenbergOutputHTMLTreeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C9F40420AF62E800205227 /* GutenbergOutputHTMLTreeProcessor.swift */; };
 		F1C9F40A20AF62E900205227 /* GutenblockConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C9F40520AF62E800205227 /* GutenblockConverter.swift */; };
@@ -99,10 +99,10 @@
 		F16A2ADE20CD9F1300BF3A0A /* GalleryAttachmentToElementConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryAttachmentToElementConverter.swift; sourceTree = "<group>"; };
 		F16A2AEB20CDA20300BF3A0A /* GallerySupportedAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GallerySupportedAttribute.swift; sourceTree = "<group>"; };
 		F1AFD65120B45DBB00CB0279 /* SpecialTagAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpecialTagAttachmentRenderer.swift; sourceTree = "<group>"; };
-		F1B1FDCD20D14ACB0090A0A5 /* WordPressInputCustomizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressInputCustomizer.swift; sourceTree = "<group>"; };
-		F1B1FDD120D14B6D0090A0A5 /* WordPressOutputCustomizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOutputCustomizer.swift; sourceTree = "<group>"; };
 		F1B0012820C5895800612EE9 /* GalleryShortcodeInputProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryShortcodeInputProcessor.swift; sourceTree = "<group>"; };
 		F1B0012C20C5948000612EE9 /* GalleryShortcodeInputProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryShortcodeInputProcessorTests.swift; sourceTree = "<group>"; };
+		F1B1FDCD20D14ACB0090A0A5 /* WordPressInputCustomizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressInputCustomizer.swift; sourceTree = "<group>"; };
+		F1B1FDD120D14B6D0090A0A5 /* WordPressOutputCustomizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOutputCustomizer.swift; sourceTree = "<group>"; };
 		F1C14C4A20CDE653002A4083 /* GalleryElementToTagConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryElementToTagConverter.swift; sourceTree = "<group>"; };
 		F1C9F40420AF62E800205227 /* GutenbergOutputHTMLTreeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenbergOutputHTMLTreeProcessor.swift; sourceTree = "<group>"; };
 		F1C9F40520AF62E800205227 /* GutenblockConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenblockConverter.swift; sourceTree = "<group>"; };

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/CommentNode+Gutenberg.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/CommentNode+Gutenberg.swift
@@ -27,14 +27,11 @@ public extension CommentNode {
     }
     
     func isGutenbergSelfClosingBlock() -> Bool {
-        return false
-        
-        // Temporarily disabled this code until we can get self-closing blocks working correctly.
-//        let prefix = CommentNode.openerPrefix
-//        let selfClosingBlockSuffix = CommentNode.selfClosingBlockSuffix
-//
-//        return comment.trimmingCharacters(in: .whitespaces).prefix(prefix.count) == prefix
-//            && comment.trimmingCharacters(in: .whitespaces).suffix(selfClosingBlockSuffix.count) == selfClosingBlockSuffix
+        let prefix = CommentNode.openerPrefix
+        let selfClosingBlockSuffix = CommentNode.selfClosingBlockSuffix
+
+        return comment.trimmingCharacters(in: .whitespaces).prefix(prefix.count) == prefix
+            && comment.trimmingCharacters(in: .whitespaces).suffix(selfClosingBlockSuffix.count) == selfClosingBlockSuffix
     }
     
     // MARK: - Internal Logic

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergAttributeNames.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergAttributeNames.swift
@@ -5,7 +5,7 @@ struct GutenbergAttributeNames {
     
     // MARK: - HTML Attribute Names
     
-    public static let selfCloser = "selfCloser"
+    public static let selfCloser = "selfcloser"
     public static let blockOpener = "opener"
     public static let blockCloser = "closer"
 }

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
@@ -186,6 +186,8 @@ class GutenbergInputHTMLTreeProcessorTests: XCTestCase {
         let expected = "<gutenblock data=\"\(encodedGutentag)\">"
         
         let output = processor.process(input)
+        let rootNode = parser.parse(input)
+        processor.process(rootNode)
         
         XCTAssertEqual(output, expected)
     }

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
@@ -140,5 +140,13 @@ class WordpressPluginTests: XCTestCase {
 
         XCTAssertEqual(finalHTML, initialHTML)
     }
+
+    func testSelfClosingGutenbergBlock() {
+        let initialHTML = "<!-- wp:latest-posts /-->"
+        let attrString = htmlConverter.attributedString(from: initialHTML)
+        let finalHTML = htmlConverter.html(from: attrString, prettify: true)
+
+        XCTAssertEqual(finalHTML, initialHTML)
+    }
 }
 


### PR DESCRIPTION
### Description:

WordPressEditor now supports Gutenberg self-closing blocks.

Fixes #959 
Fixes #968

### Details:

The problem we had is that Aztec doesn't recognize attachments as block-level style representations.  So it wraps Gutenberg blocks inside `<p>` tags.

The ideal solution would be to rewrite the logic for the output HTML serialization from scratch.

The proposed solution in this PR is to post-process the HTML to remove the self-closing Gutenberg blocks from the wrapping `<p>` tags.  It's ugly and hacky, but it's the only easy way I found to get this working in a reasonable amount of time.

### Testing:

Manual testing for now.  I'll be adding automated testing for all of our Gutenberg compatibility code soon.


