### PR TITLE
Fix VideoPress processors

### DIFF
--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/VideoShortcode/VideoShortcodeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/VideoShortcode/VideoShortcodeProcessor.swift
@@ -32,8 +32,7 @@ public class VideoShortcodeProcessor {
             }
             
             html += "src=\"\(videoPressScheme)://\(src)\" "
-            html += "data-wpvideopress=\"\(src)\" "
-            html += "poster=\"\(videoPressScheme)://\(src)\" "
+            html += "data-wpvideopress=\"\(src)\" "            
 
             if let width = shortcode.attributes["w"] {
                 html += shortcodeAttributeSerializer.serialize(key: "width", value: width.value) + " "
@@ -62,7 +61,8 @@ public class VideoShortcodeProcessor {
         
         let postWordPressVideoProcessor = HTMLProcessor(for: "video", replacer: { (element) in
             
-            guard let videoPressID = element.attributes[videoPressHTMLAttribute] else {
+            guard let videoPressValue = element.attributes[videoPressHTMLAttribute]?.value,
+                case let .string(videoPressID) = videoPressValue else {
                 return nil
             }
             

--- a/WordPressEditor/WordPressEditorTests/Processors/ShortcodeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Processors/ShortcodeProcessorTests.swift
@@ -6,29 +6,9 @@ import XCTest
 //
 class ShortcodeProcessorTests: XCTestCase {
 
-    func testParserOfVideoPressCode() {
-        let shortcodeAttributeSerializer = ShortcodeAttributeSerializer()
+    func testParserOfVideoPressCode() {        
         
-        let shortCodeParser = ShortcodeProcessor(tag:"wpvideo", replacer:{ (shortcode) in
-            var html = "<video "
-
-            if let src = shortcode.attributes.first(where: { $0.value == .nil }) {
-                html += shortcodeAttributeSerializer.serialize(key: "src", value: "videopress://\(src.key)") + " "
-                html += shortcodeAttributeSerializer.serialize(key: "data-wpvideopress", value: src.key) + " "
-            }
-            
-            if let width = shortcode.attributes["w"] {
-                html += shortcodeAttributeSerializer.serialize(key: "width", value: width.value) + " "
-            }
-            
-            if let height = shortcode.attributes["h"] {
-                html += shortcodeAttributeSerializer.serialize(key: "height", value: height.value) + " "
-            }
-            
-            html += "/>"
-            
-            return html
-        })
+        let shortCodeParser = VideoShortcodeProcessor.videoPressPreProcessor
         
         let sampleText = "[wpvideo OcobLTqC w=640 h=400 autoplay=true html5only=true] Some Text"
         let parsedText = shortCodeParser.process(sampleText)
@@ -38,23 +18,33 @@ class ShortcodeProcessorTests: XCTestCase {
     }
 
     func testParserOfWordPressVideoCode() {
-        let shortcodeAttributeSerializer = ShortcodeAttributeSerializer()
         
-        let shortCodeParser = ShortcodeProcessor(tag:"video", replacer: { (shortcode) in
-            var html = "<video "
-            
-            if let src = shortcode.attributes["src"] {
-                html += shortcodeAttributeSerializer.serialize(src) + " "
-            }
-            
-            html += "/>"
-            
-            return html
-        })
+        let shortCodeParser = VideoShortcodeProcessor.wordPressVideoPreProcessor
         
         let sampleText = "[video src=\"video-source.mp4\"]"
         let parsedText = shortCodeParser.process(sampleText)
         
         XCTAssertEqual(parsedText, "<video src=\"video-source.mp4\" />")
+    }
+
+    func testOutputParserOfVideoPressCode() {
+
+        let shortCodeParser = VideoShortcodeProcessor.videoPressPostProcessor
+
+        let sampleText = "<video src=\"videopress://OcobLTqC\" data-wpvideopress=\"OcobLTqC\" width=\"640\" height=\"400\" /> Some Text"
+        let parsedText = shortCodeParser.process(sampleText)
+        let expected = "[wpvideo OcobLTqC w=\"640\" h=\"400\" ] Some Text"
+
+        XCTAssertEqual(parsedText, expected)
+    }
+
+    func testOutputParserOfWordPressVideoCode() {
+
+        let shortCodeParser = VideoShortcodeProcessor.wordPressVideoPostProcessor
+
+        let sampleText = "<video src=\"video-source.mp4\" />"
+        let parsedText = shortCodeParser.process(sampleText)
+        let expected = "[video src=\"video-source.mp4\" ]"
+        XCTAssertEqual(parsedText, expected)
     }
 }


### PR DESCRIPTION
This PR updates the code of the video processor in order to serialize the output the correct way.

It also updates the unit test to use the actual processor classes that are being used on the main app.

To test:
 - Just make sure that the unit tests are green!

