### PR TITLE
Fix LI attributes lost

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -179,6 +179,8 @@
 		FF20D6441EDC395E00294B78 /* NSTextingResult+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF20D6431EDC395E00294B78 /* NSTextingResult+Helpers.swift */; };
 		FF20D6471EDC3B3900294B78 /* HTMLProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF20D6461EDC3B3900294B78 /* HTMLProcessorTests.swift */; };
 		FF24AC991F0146AF003CA91D /* Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF24AC981F0146AF003CA91D /* Assets.swift */; };
+		FF437B6420D7CB2D000D9666 /* HTMLLi.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF437B6320D7CB2D000D9666 /* HTMLLi.swift */; };
+		FF437B6620D7CB83000D9666 /* LiFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF437B6520D7CB83000D9666 /* LiFormatter.swift */; };
 		FF4E26601EA8DF1E005E8E42 /* ImageAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4E265F1EA8DF1E005E8E42 /* ImageAttachment.swift */; };
 		FF61909E202481F4004BCD0A /* CodeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF61909D202481F4004BCD0A /* CodeFormatter.swift */; };
 		FF7A1C511E5651EA00C4C7C8 /* LineAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7A1C501E5651EA00C4C7C8 /* LineAttachment.swift */; };
@@ -398,6 +400,8 @@
 		FF20D6431EDC395E00294B78 /* NSTextingResult+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSTextingResult+Helpers.swift"; sourceTree = "<group>"; };
 		FF20D6461EDC3B3900294B78 /* HTMLProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLProcessorTests.swift; sourceTree = "<group>"; };
 		FF24AC981F0146AF003CA91D /* Assets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assets.swift; sourceTree = "<group>"; };
+		FF437B6320D7CB2D000D9666 /* HTMLLi.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLLi.swift; sourceTree = "<group>"; };
+		FF437B6520D7CB83000D9666 /* LiFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiFormatter.swift; sourceTree = "<group>"; };
 		FF4E265F1EA8DF1E005E8E42 /* ImageAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageAttachment.swift; sourceTree = "<group>"; };
 		FF5B98E21DC29D0C00571CA4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		FF5B98E41DC355B400571CA4 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
@@ -780,6 +784,7 @@
 				B524228C1F30C039002E7C6C /* HTMLDiv.swift */,
 				F11326AB1EF1AA91007FEE9A /* HTMLParagraph.swift */,
 				F11326AC1EF1AA91007FEE9A /* HTMLPre.swift */,
+				FF437B6320D7CB2D000D9666 /* HTMLLi.swift */,
 				F11326AD1EF1AA91007FEE9A /* ParagraphProperty.swift */,
 				F11326AE1EF1AA91007FEE9A /* TextList.swift */,
 			);
@@ -811,6 +816,7 @@
 				F18986E41EF2043E0060EDBA /* ItalicFormatter.swift */,
 				F12F585D1EF20394008AE298 /* LinkFormatter.swift */,
 				F12F585E1EF20394008AE298 /* PreFormatter.swift */,
+				FF437B6520D7CB83000D9666 /* LiFormatter.swift */,
 				F12F585F1EF20394008AE298 /* StrikethroughFormatter.swift */,
 				F12F58601EF20394008AE298 /* TextListFormatter.swift */,
 				F12F58611EF20394008AE298 /* UnderlineFormatter.swift */,
@@ -1250,6 +1256,7 @@
 				F177FF751FB6404D00CBBE35 /* UILayoutPriority+Swift4.swift in Sources */,
 				F1C05B9D1E37FA77007510EA /* String+CharacterName.swift in Sources */,
 				F1FF7D9F201A1D24007B0B32 /* Figcaption.swift in Sources */,
+				FF437B6620D7CB83000D9666 /* LiFormatter.swift in Sources */,
 				FFFEC7DB1EA7698900F4210F /* VideoAttachment.swift in Sources */,
 				F12F58671EF20394008AE298 /* BlockquoteFormatter.swift in Sources */,
 				B5DA1C1D1EBD1CCE000AAB45 /* HTMLSerializer.swift in Sources */,
@@ -1257,6 +1264,7 @@
 				599F25351D8BC9A1002871D6 /* CLinkedListToArrayConverter.swift in Sources */,
 				F16A2B0020CDB62B00BF3A0A /* GenericElementToTagConverter.swift in Sources */,
 				599F25521D8BC9A1002871D6 /* MediaAttachment.swift in Sources */,
+				FF437B6420D7CB2D000D9666 /* HTMLLi.swift in Sources */,
 				F1000CE71EAA44AA0000B15B /* String+EndOfLine.swift in Sources */,
 				F1FA0E831E6EF514009D98EE /* ElementNode.swift in Sources */,
 				FFD0FEB71DAE59A700430586 /* NSLayoutManager+Attachments.swift in Sources */,

--- a/Aztec/Classes/ElementConverters/Input/Implementations/GenericElementConverter.swift
+++ b/Aztec/Classes/ElementConverters/Input/Implementations/GenericElementConverter.swift
@@ -33,6 +33,7 @@ class GenericElementConverter: ElementConverter {
     lazy var underlineFormatter = UnderlineFormatter()
     lazy var unorderedListFormatter = TextListFormatter(style: .unordered, increaseDepth: true)
     lazy var codeFormatter = CodeFormatter()
+    lazy var liFormatter = LiFormatter()
     
     public lazy var elementFormattersMap: [Element: AttributeFormatter] = {
         return [
@@ -53,7 +54,8 @@ class GenericElementConverter: ElementConverter {
             .h6: self.h6Formatter,
             .p: self.paragraphFormatter,
             .pre: self.preFormatter,
-            .code: self.codeFormatter
+            .code: self.codeFormatter,
+            .li: self.liFormatter
         ]
     }()
     
@@ -131,8 +133,6 @@ private extension GenericElementConverter {
         
         if let elementFormatter = formatter(for: element) {
             finalAttributes = elementFormatter.apply(to: inheritedAttributes, andStore: representation)
-        } else if element.type == .li {
-            finalAttributes = inheritedAttributes
         } else {
             finalAttributes = attributes(storing: elementRepresentation, in: inheritedAttributes)
         }

--- a/Aztec/Classes/Formatters/Implementations/LiFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/LiFormatter.swift
@@ -1,0 +1,62 @@
+import Foundation
+import UIKit
+
+
+// MARK: - Pre Formatter
+//
+open class LiFormatter: ParagraphAttributeFormatter {
+
+    /// Attributes to be added by default
+    ///
+    let placeholderAttributes: [NSAttributedStringKey: Any]?
+
+
+    /// Designated Initializer
+    ///
+    init(placeholderAttributes: [NSAttributedStringKey : Any]? = nil) {
+        self.placeholderAttributes = placeholderAttributes
+    }
+
+
+    // MARK: - Overwriten Methods
+
+    func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
+        var resultingAttributes = attributes
+        let newParagraphStyle = ParagraphStyle()
+        if let paragraphStyle = attributes[.paragraphStyle] as? NSParagraphStyle {
+            newParagraphStyle.setParagraphStyle(paragraphStyle)
+        }
+        
+        newParagraphStyle.insertProperty(HTMLLi(with: representation), afterLastOfType: TextList.self)
+
+        resultingAttributes[.paragraphStyle] = newParagraphStyle        
+
+        return resultingAttributes
+    }
+
+    func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
+        guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle
+            else {
+                return attributes
+        }
+
+        let newParagraphStyle = ParagraphStyle()
+        newParagraphStyle.setParagraphStyle(paragraphStyle)
+        newParagraphStyle.removeProperty(ofType: HTMLLi.self)
+
+        var resultingAttributes = attributes
+        resultingAttributes[.paragraphStyle] = newParagraphStyle
+
+        return resultingAttributes
+    }
+
+    func present(in attributes: [NSAttributedStringKey : Any]) -> Bool {
+        guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle
+            else {
+                return false
+        }
+        return paragraphStyle.hasProperty { (property) -> Bool in
+            return property is HTMLLi
+        }
+    }
+}

--- a/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
@@ -36,7 +36,7 @@ class TextListFormatter: ParagraphAttributeFormatter {
 
         let newList = TextList(style: self.listStyle, with: representation)
         if newParagraphStyle.lists.isEmpty || increaseDepth {
-            newParagraphStyle.insertProperty(newList, afterLastOfType: TextList.self)
+            newParagraphStyle.insertProperty(newList, afterLastOfType: HTMLLi.self)
         } else {
             newParagraphStyle.replaceProperty(ofType: TextList.self, with: newList)
         }

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -556,12 +556,15 @@ private extension AttributedStringParser {
                 guard let element = processHeaderStyle(header: header) else {
                     continue
                 }
-
                 paragraphNodes.append(element)
 
             case let list as TextList:
-                let elements = processListStyle(list: list)
-                paragraphNodes += elements
+                let element = processListStyle(list: list)
+                paragraphNodes.append(element)
+
+            case let listItem as HTMLLi:
+                let element = processListItem(listItem: listItem)
+                paragraphNodes.append(element)
 
             case let div as HTMLDiv:
                 let element = processDivStyle(div: div)
@@ -687,11 +690,10 @@ private extension AttributedStringParser {
 
     /// Extracts all of the List Elements contained within a collection of Attributes.
     ///
-    private func processListStyle(list: TextList) -> [ElementNode] {
+    private func processListStyle(list: TextList) -> ElementNode {
         let listType = list.style == .ordered ? Element.ol : Element.ul
 
         let listElement: ElementNode
-        let lineElement = ElementNode(type: .li)
 
         if let representation = list.representation,
             case let .element(element) = representation.kind {
@@ -701,7 +703,22 @@ private extension AttributedStringParser {
             listElement = ElementNode(type: listType)
         }
 
-        return [lineElement, listElement]
+        return listElement
+    }
+
+    private func processListItem(listItem: HTMLLi) -> ElementNode {
+
+        let lineElement: ElementNode
+
+        if let representation = listItem.representation,
+            case let .element(element) = representation.kind {
+
+            lineElement = element.toElementNode()
+        } else {
+            lineElement = ElementNode(type: .li)
+        }
+
+        return lineElement
     }
 
 

--- a/Aztec/Classes/TextKit/ParagraphProperty/HTMLLi.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/HTMLLi.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+class HTMLLi: ParagraphProperty {
+
+    override public func encode(with aCoder: NSCoder) {
+        super.encode(with: aCoder)
+    }
+
+    override public init(with representation: HTMLRepresentation? = nil) {
+        super.init(with: representation)
+    }
+
+    required public init?(coder aDecoder: NSCoder){
+        super.init(coder: aDecoder)
+    }
+
+    static func ==(lhs: HTMLLi, rhs: HTMLLi) -> Bool {
+        return lhs === rhs
+    }
+}

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -513,10 +513,12 @@ open class TextView: UITextView {
         }
 
         let formatter = TextListFormatter(style: list.style, placeholderAttributes: nil, increaseDepth: true)
+        let liFormatter = LiFormatter(placeholderAttributes: nil)
         let targetRange = formatter.applicationRange(for: selectedRange, in: storage)
 
         performUndoable(at: targetRange) {
             let finalRange = formatter.removeAttributes(from: storage, at: targetRange)
+            liFormatter.removeAttributes(from: storage, at: targetRange)
             typingAttributesSwifted = textStorage.attributes(at: targetRange.location, effectiveRange: nil)
             return finalRange
         }
@@ -530,10 +532,12 @@ open class TextView: UITextView {
         }
 
         let formatter = TextListFormatter(style: list.style, placeholderAttributes: nil, increaseDepth: true)
+        let liFormatter = LiFormatter(placeholderAttributes: nil)
         let targetRange = formatter.applicationRange(for: selectedRange, in: storage)
 
         performUndoable(at: targetRange) { 
             let finalRange = formatter.applyAttributes(to: storage, at: targetRange)
+            liFormatter.applyAttributes(to: storage, at: targetRange)
             typingAttributesSwifted = textStorage.attributes(at: targetRange.location, effectiveRange: nil)
             return finalRange
         }
@@ -980,6 +984,9 @@ open class TextView: UITextView {
         let formatter = TextListFormatter(style: .ordered, placeholderAttributes: typingAttributesSwifted)
         toggle(formatter: formatter, atRange: range)
 
+        let liFormatter = LiFormatter(placeholderAttributes: typingAttributesSwifted)
+        toggle(formatter: liFormatter, atRange: range)
+
         forceRedrawCursorAfterDelay()
     }
 
@@ -994,6 +1001,9 @@ open class TextView: UITextView {
         let formatter = TextListFormatter(style: .unordered, placeholderAttributes: typingAttributesSwifted)
         toggle(formatter: formatter, atRange: range)
 
+        let liFormatter = LiFormatter(placeholderAttributes: typingAttributesSwifted)
+        toggle(formatter: liFormatter, atRange: range)
+        
         forceRedrawCursorAfterDelay()
     }
 

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
@@ -194,8 +194,8 @@ class AttributedStringParserTests: XCTestCase {
         let firstText = "First Line"
         let secondText = "Second Line"
 
-        let attributes = TextListFormatter(style: .unordered).apply(to: Constants.sampleAttributes)
-
+        var attributes = TextListFormatter(style: .unordered).apply(to: Constants.sampleAttributes)
+        attributes = LiFormatter().apply(to: attributes)
         let text = firstText + String(.lineFeed) + secondText
         let testingString = NSMutableAttributedString(string: text, attributes: attributes)
 
@@ -248,8 +248,8 @@ class AttributedStringParserTests: XCTestCase {
         let firstText = "First Line"
         let secondText = "Second Line"
 
-        let attributes = TextListFormatter(style: .ordered).apply(to: Constants.sampleAttributes)
-
+        var attributes = TextListFormatter(style: .ordered).apply(to: Constants.sampleAttributes)
+        attributes = LiFormatter().apply(to: attributes)
         let text = firstText + String(.lineFeed) + secondText
         let testingString = NSMutableAttributedString(string: text, attributes: attributes)
 
@@ -560,6 +560,7 @@ class AttributedStringParserTests: XCTestCase {
 
         BlockquoteFormatter().applyAttributes(to: testingString, at: testingRange)
         TextListFormatter(style: .ordered).applyAttributes(to: testingString, at: testingRange)
+        LiFormatter().applyAttributes(to: testingString, at: testingRange)
 
         // Convert + Verify
         let node = AttributedStringParser().parse(testingString)
@@ -616,8 +617,8 @@ class AttributedStringParserTests: XCTestCase {
         let testingRange = testingString.rangeOfEntireString
 
         TextListFormatter(style: .unordered).applyAttributes(to: testingString, at: testingRange)
+        LiFormatter().applyAttributes(to: testingString, at: testingRange)
         BlockquoteFormatter().applyAttributes(to: testingString, at: testingRange)
-
         // Convert + Verify
         let node = AttributedStringParser().parse(testingString)
         XCTAssertEqual(node.children.count, 1)
@@ -676,6 +677,7 @@ class AttributedStringParserTests: XCTestCase {
         let testingRange = testingString.rangeOfEntireString
 
         TextListFormatter(style: .unordered).applyAttributes(to: testingString, at: testingRange)
+        LiFormatter().applyAttributes(to: testingString, at: testingRange)
         HeaderFormatter().applyAttributes(to: testingString, at: testingRange)
 
         // Convert + Verify

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -442,5 +442,19 @@ class TextStorageTests: XCTestCase {
         }
     }
 
+    func testListElemeAttributes() {
+        let html = """
+<ul class="wp-block-gallery alignnone columns-1 is-cropped">
+  <li class="blocks-gallery-item">
+    <figure><img src="https://sandbox.koke.me/wp-content/uploads/2018/05/fullsizeoutput_52f7.jpeg" class="alignnone" data-id="96" alt=""></figure>
+  </li>
+</ul>
+"""
+        let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                               .paragraphStyle: ParagraphStyle.default]
+        storage.setHTML(html, defaultAttributes: defaultAttributes)
+        let outputHTML = storage.getHTML(prettify: true)
 
+        XCTAssertEqual(html, outputHTML)
+    }
 }

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1717,7 +1717,7 @@ class TextViewTests: XCTestCase {
 
         // Verify!
         let expected = "<ol><li><ol><li><ol><li><blockquote>First Item</blockquote></li></ol></li></ol></li></ol>"
-        XCTAssert(textView.getHTML(prettify: false) == expected)
+        XCTAssertEqual(textView.getHTML(prettify: false), expected)
     }
 
     /// This test verifies that the `deleteBackward` call does not result in loosing the Typing Attributes.


### PR DESCRIPTION
Fixes #984 #578 

This PR makes ```<li>``` elements to be translated to proper Paragraph Property with associated HTML representation.

This on one side creates some extra complexity on handling the lists when being used on the editor by user actions, but on the other side remove "special" processing on parsing and serialising of this elements from HTML to AttributedString and back.

This PR  also saves and serializes any element attributes set on the ```<li>``` elements.

To test:
 - Make sure unit test are passing
 - On both Gutenberg and regular HTML sample test around lists to see if all works ok.

