### PR TITLE
Fix single spaces are being removed

### DIFF
--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -237,6 +237,10 @@ private extension AttributedStringSerializer {
     }
     
     private func sanitize(_ text: String) -> String {
+        guard text != String(.space) else {
+            return text
+        }
+
         let hasAnEndingSpace = text.hasSuffix(String(.space))
         let hasAStartingSpace = text.hasPrefix(String(.space))
         

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -442,5 +442,16 @@ class TextStorageTests: XCTestCase {
         }
     }
 
+    func testSingleSpaceBetweenElements() {
+        let html = "<p><strong>WordPress</strong> <em>App</em></p>"
+
+        let defaultAttributes: [NSAttributedStringKey: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                               .paragraphStyle: ParagraphStyle.default]
+        storage.setHTML(html, defaultAttributes: defaultAttributes)
+        let outputHTML = storage.getHTML()
+
+        XCTAssertEqual(html, outputHTML)
+    }
+
 
 }


### PR DESCRIPTION
Fixes #886 

To test:
 - Run the demo app
 - Open the editor on HTML mode and write ```<strong>WordPress<strong> <em>App</em>```
 - Switch to Visual Mode
 - Make sure the space between WordPress and App is kept.

