### PR TITLE
Issue/987 refactor closing of void elements

### DIFF
--- a/Aztec/Classes/ElementConverters/Output/Implementations/GenericElementToTagConverter.swift
+++ b/Aztec/Classes/ElementConverters/Output/Implementations/GenericElementToTagConverter.swift
@@ -17,7 +17,7 @@ private extension GenericElementToTagConverter {
     private func openingTag(for node: ElementNode) -> String {
         let attributes = serialize(attributes: node.attributes)
         
-        return "<" + node.name + attributes + ">"
+        return "<" + node.name + attributes + (node.isVoid() ? (attributes.isEmpty ? "/" : " /") : "") + ">"
     }
     
     

--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -19,7 +19,7 @@ public struct Element: RawRepresentable, Hashable {
     ///
     /// Ref. http://w3c.github.io/html/syntax.html#void-elements
     ///
-    public static var voidElements: [Element] = [.area, .base, .br, .col, .embed, .hr, .img, .input, .link, .meta, .param, .source, .track, .wbr]
+    public static var voidElements: Set<Element> = Set<Element>([.area, .base, .br, .col, .embed, .hr, .img, .input, .link, .meta, .param, .source, .track, .wbr])
 
     /// List of block HTML elements that can be merged together when they are sibling to each other
     ///

--- a/AztecTests/HTML/Conversions/DefaultHTMLSerializerTests.swift
+++ b/AztecTests/HTML/Conversions/DefaultHTMLSerializerTests.swift
@@ -56,8 +56,8 @@ class DefaultHTMLSerializerTests: XCTestCase {
     /// Verifies that unknown TAG Attributes do not get removed.
     ///
     func testConverterDoesNotDropProprietaryAttributes() {
-        let sample = "something something <img unknown=\"true\">"
-        let expected =  "something something <img unknown=\"true\">"
+        let sample = "something something <img unknown=\"true\" />"
+        let expected =  "something something <img unknown=\"true\" />"
 
         let inNode = HTMLParser().parse(sample)
         let outHtml = HTMLSerializer().serialize(inNode)

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringSerializerTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringSerializerTests.swift
@@ -101,7 +101,7 @@ class AttributedStringSerializerTests: XCTestCase {
     /// Ref. #658
     ///
     func testLineBreakTagWithinHTMLDivGetsProperlyEncodedAndDecoded() {
-        let inHtml = "<div><br>Aztec, don't forget me!</div>"
+        let inHtml = "<div><br/>Aztec, don't forget me!</div>"
 
         let inNode = HTMLParser().parse(inHtml)
         let attrString = attributedString(from: inNode)
@@ -117,8 +117,8 @@ class AttributedStringSerializerTests: XCTestCase {
     /// Ref. #658
     ///
     func testLineBreakTagWithinUnsupportedHTMLDoesNotCauseDataLoss() {
-        let inHtml = "<span><br>Aztec, don't forget me!</span>"
-        let expectedHtml = "<p><span><br>Aztec, don't forget me!</span></p>"
+        let inHtml = "<span><br/>Aztec, don't forget me!</span>"
+        let expectedHtml = "<p><span><br/>Aztec, don't forget me!</span></p>"
 
         let inNode = HTMLParser().parse(inHtml)
         let attrString = attributedString(from: inNode)
@@ -136,9 +136,9 @@ class AttributedStringSerializerTests: XCTestCase {
     func testMultipleUnrelatedUnsupportedHTMLSnippetsDoNotGetAppliedToTheEntireStringRange() {
         let inHtml = "<div>" +
             "<p><span>One</span></p>" +
-            "<p><span><br></span></p>" +
+            "<p><span><br/></span></p>" +
             "<p><span>Two</span></p>" +
-            "<p><br></p>" +
+            "<p><br/></p>" +
             "<p><span>Three</span><span>Four</span><span>Five</span></p>" +
         "</div>"
 
@@ -154,7 +154,7 @@ class AttributedStringSerializerTests: XCTestCase {
     /// Verifies that a linked image is properly converted from HTML to attributed string and back to HTML.
     ///
     func testLinkedImageGetsProperlyEncodedAndDecoded() {
-        let inHtml = "<p><a href=\"https://wordpress.com\" class=\"alignnone\"><img src=\"https://s.w.org/about/images/wordpress-logo-notext-bg.png\" class=\"alignnone\"></a></p>"
+        let inHtml = "<p><a href=\"https://wordpress.com\" class=\"alignnone\"><img src=\"https://s.w.org/about/images/wordpress-logo-notext-bg.png\" class=\"alignnone\" /></a></p>"
         
         let inNode = HTMLParser().parse(inHtml)
         let attrString = attributedString(from: inNode)

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -130,7 +130,7 @@ class TextStorageTests: XCTestCase {
         let html = storage.getHTML()
 
         XCTAssertEqual(attachment.url, URL(string: "https://wordpress.com"))
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\" /></p>")
     }
 
     /// Verifies that any edition performed on ImageAttachment attributes is properly serialized back during
@@ -147,7 +147,7 @@ class TextStorageTests: XCTestCase {
 
         let html = storage.getHTML()
         XCTAssertEqual(attachment.url, url)
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignleft size-medium\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignleft size-medium\" /></p>")
     }
 
     /// Verifies that any edition performed on HTMLttachment attributes is properly serialized back during
@@ -317,7 +317,7 @@ class TextStorageTests: XCTestCase {
 
         XCTAssertEqual(firstAttachment.url, URL(string: "https://wordpress.com"))
         XCTAssertEqual(secondAttachment.url, URL(string: "https://wordpress.org"))
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"><img src=\"https://wordpress.org\" class=\"alignnone\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\" /><img src=\"https://wordpress.org\" class=\"alignnone\" /></p>")
     }
 
     /// This test check if the insertion of two images one after the other works correctly and to img tag are inserted
@@ -332,7 +332,7 @@ class TextStorageTests: XCTestCase {
 
         XCTAssertEqual(firstAttachment.url, URL(string: "https://wordpress.com"))
         XCTAssertEqual(secondAttachment.url, URL(string: "https://wordpress.com"))
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"><img src=\"https://wordpress.com\" class=\"alignnone\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\" /><img src=\"https://wordpress.com\" class=\"alignnone\" /></p>")
     }
 
     /// This test verifies if the `removeTextAttachements` call effectively nukes all of the TextAttachments present

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -607,7 +607,7 @@ class TextViewTests: XCTestCase {
 
         textView.replace(range, withText: "")
 
-        XCTAssertEqual(textView.getHTML(prettify: false), "<ol><li>First</li><li>SecondAhoi<br>Arr!</li></ol>")
+        XCTAssertEqual(textView.getHTML(prettify: false), "<ol><li>First</li><li>SecondAhoi<br/>Arr!</li></ol>")
     }
 
     /// Tests that deleting a newline works at the end of text with paragraph with header before works.
@@ -1530,7 +1530,7 @@ class TextViewTests: XCTestCase {
         textView.replaceWithHorizontalRuler(at: .zero)
         let html = textView.getHTML(prettify: false)
 
-        XCTAssertEqual(html, "<p><hr></p>")
+        XCTAssertEqual(html, "<p><hr/></p>")
     }
 
     /// This test check if the insertion of antwo horizontal ruler works correctly and the hr tag(s) are inserted
@@ -1542,7 +1542,7 @@ class TextViewTests: XCTestCase {
         textView.replaceWithHorizontalRuler(at: .zero)
         let html = textView.getHTML(prettify: false)
 
-        XCTAssertEqual(html, "<p><hr><hr></p>")
+        XCTAssertEqual(html, "<p><hr/><hr/></p>")
     }
 
     /// This test check if the insertion of an horizontal ruler over an image attachment works correctly and the hr tag is inserted
@@ -1555,7 +1555,7 @@ class TextViewTests: XCTestCase {
 
         let html = textView.getHTML(prettify: false)
         
-        XCTAssertEqual(html, "<p><hr></p>")
+        XCTAssertEqual(html, "<p><hr/></p>")
     }
 
     func testReplaceRangeWithAttachmentDontDisableDefaultParagraph() {
@@ -1565,7 +1565,7 @@ class TextViewTests: XCTestCase {
 
         let html = textView.getHTML()
 
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\" /></p>")
 
         textView.selectedRange = NSRange(location: NSAttributedString.lengthOfTextAttachment, length: 1)
         guard let font = textView.typingAttributesSwifted[.font] as? UIFont else {
@@ -1592,7 +1592,7 @@ class TextViewTests: XCTestCase {
 
         var html = textView.getHTML()
 
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\" /></p>")
 
         textView.remove(attachmentID: attachment.identifier)
 
@@ -1605,10 +1605,10 @@ class TextViewTests: XCTestCase {
     /// It also tests if changes on those attributes is correctly reflected on the generated HTML
     ///
     func testParseImageWithExtraAttributes() {
-        let html = "<img src=\"image.jpg\" class=\"alignnone\" alt=\"Alt\" title=\"Title\">"
+        let html = "<img src=\"image.jpg\" class=\"alignnone\" alt=\"Alt\" title=\"Title\" />"
         let textView = createTextView(withHTML: html)
 
-        XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone\" title=\"Title\" alt=\"Alt\"></p>")
+        XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone\" title=\"Title\" alt=\"Alt\" /></p>")
 
         guard let attachment = textView.storage.mediaAttachments.first as? ImageAttachment else {
             XCTFail("An video attachment should be present")
@@ -1620,7 +1620,7 @@ class TextViewTests: XCTestCase {
         attachment.extraAttributes["alt"] = "Changed Alt"
         attachment.extraAttributes["class"] = "wp-image-169"
 
-        XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone wp-image-169\" title=\"Title\" alt=\"Changed Alt\"></p>")
+        XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone wp-image-169\" title=\"Title\" alt=\"Changed Alt\" /></p>")
     }
 
 
@@ -1633,7 +1633,7 @@ class TextViewTests: XCTestCase {
         let textView = createTextView(withHTML: pristineHTML)
         let generatedHTML = textView.getHTML(prettify: false)
 
-        XCTAssertEqual(generatedHTML, "<p><br><br></p><h1>Header</h1>")
+        XCTAssertEqual(generatedHTML, "<p><br/><br/></p><h1>Header</h1>")
     }
 
     /// This test verifies that the H1 Header does not get lost, in the scenario in which the H1 is contained
@@ -1644,13 +1644,13 @@ class TextViewTests: XCTestCase {
         let textView = createTextView(withHTML: pristineHTML)
         let generatedHTML = textView.getHTML(prettify: false)
 
-        XCTAssertEqual(generatedHTML, "<p><br>1<br>2</p><h1>Heder</h1>")
+        XCTAssertEqual(generatedHTML, "<p><br/>1<br/>2</p><h1>Heder</h1>")
     }
 
     /// This test verifies that img class attributes are not duplicated
     ///
     func testParseImageDoesntDuplicateExtraAttributes() {
-        let html = "<img src=\"image.jpg\" class=\"alignnone wp-image-test\" title=\"Title\" alt=\"Alt\">"
+        let html = "<img src=\"image.jpg\" class=\"alignnone wp-image-test\" title=\"Title\" alt=\"Alt\" />"
         let textView = createTextView(withHTML: html)
         let generatedHTML = textView.getHTML()
 
@@ -1821,7 +1821,7 @@ class TextViewTests: XCTestCase {
     /// of text that never had H1 style, to begin with!.
     ///
     func testAttributesOnMediaAttachmentsAreRemoved() {
-        let textView = createTextView(withHTML: "<img src=\"http://placeholder\" data-wp_upload_id=\"ABCDE\" >")
+        let textView = createTextView(withHTML: "<img src=\"http://placeholder\" data-wp_upload_id=\"ABCDE\" />")
 
         guard let attachment = textView.storage.mediaAttachments.first else {
             XCTFail("There must be an attachment")
@@ -1840,7 +1840,7 @@ class TextViewTests: XCTestCase {
 
         let html = textView.getHTML()
 
-        XCTAssertEqual(html, "<p><img src=\"http://placeholder\" class=\"alignnone\"></p>" )
+        XCTAssertEqual(html, "<p><img src=\"http://placeholder\" class=\"alignnone\" /></p>" )
     }
 
     /// This test makes sure that if an `<hr>` was in the original HTML, it will still get output after our processing.
@@ -1849,7 +1849,7 @@ class TextViewTests: XCTestCase {
 
         let html = textView.getHTML(prettify: false)
 
-        XCTAssertEqual(html, "<h1>Header</h1><p>test</p><p><hr></p>")
+        XCTAssertEqual(html, "<h1>Header</h1><p>test</p><p><hr/></p>")
     }
 
     /// This test makes sure that if an auto replacement is made with smaller text, for example an emoji, things work correctly

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/CaptionShortcode/CaptionShortcodeInputProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/CaptionShortcode/CaptionShortcodeInputProcessorTests.swift
@@ -10,7 +10,7 @@ class CaptionShortcodeInputProcessorTests: XCTestCase {
     ///
     func testCaptionShortcodeIsProperlyConvertedIntoFigureTag() {
         let input = "[caption]<img src=\".\">Text[/caption]"
-        let expected = "<figure><img src=\".\"><figcaption>Text</figcaption></figure>"
+        let expected = "<figure><img src=\".\" /><figcaption>Text</figcaption></figure>"
 
         XCTAssertEqual(processor.process(input), expected)
     }
@@ -20,7 +20,7 @@ class CaptionShortcodeInputProcessorTests: XCTestCase {
     ///
     func testCaptionShortcodeIsProperlyConvertedIntoFigureTagPreservingNestedTags() {
         let input = "[caption]<img src=\".\"><b>Text</b><br><br><br>[/caption]"
-        let expected = "<figure><img src=\".\"><figcaption><b>Text</b><br><br><br></figcaption></figure>"
+        let expected = "<figure><img src=\".\" /><figcaption><b>Text</b><br/><br/><br/></figcaption></figure>"
 
         XCTAssertEqual(processor.process(input), expected)
     }
@@ -34,7 +34,7 @@ class CaptionShortcodeInputProcessorTests: XCTestCase {
                     "[/caption]"
 
         let expected = "<figure id=\"attachment_6\" align=\"alignleft\" width=\"300\" class=\"span data-mce-type=\">" +
-                            "<img src=\".\"><figcaption>Text</figcaption>" +
+                            "<img src=\".\" /><figcaption>Text</figcaption>" +
                         "</figure>"
 
         XCTAssertEqual(processor.process(input), expected)

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/CaptionShortcode/CaptionShortcodeOutputProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/CaptionShortcode/CaptionShortcodeOutputProcessorTests.swift
@@ -10,7 +10,7 @@ class CaptionShortcodeOutputProcessorTests: XCTestCase {
     ///
     func testFigureAndFigcaptionAreProperlyConvertedIntoCaptionShortcode() {
         let input = "<figure><img src=\".\"><figcaption>Text</figcaption></figure>"
-        let expected = "[caption id=\"\"]<img src=\".\">Text[/caption]"
+        let expected = "[caption id=\"\"]<img src=\".\" />Text[/caption]"
 
         XCTAssertEqual(processor.process(input), expected)
     }
@@ -20,7 +20,7 @@ class CaptionShortcodeOutputProcessorTests: XCTestCase {
     ///
     func testFigureTagWithNestedFigcaptionEntitiesIsProperlyConvertedBackIntoCaptionShortcode() {
         let input = "<figure><img src=\".\"><figcaption><b>Text</b><br><br><br></figcaption></figure>"
-        let expected = "[caption id=\"\"]<img src=\".\"><b>Text</b><br><br><br>[/caption]"
+        let expected = "[caption id=\"\"]<img src=\".\" /><b>Text</b><br/><br/><br/>[/caption]"
 
         XCTAssertEqual(processor.process(input), expected)
     }
@@ -34,7 +34,7 @@ class CaptionShortcodeOutputProcessorTests: XCTestCase {
                     "</figure>"
 
         let expected = "[caption id=\"attachment_6\" align=\"alignleft\" class=\"span data-mce-type=\" width=\"300\"]" +
-                            "<img src=\".\">Text" +
+                            "<img src=\".\" />Text" +
                         "[/caption]"
 
         XCTAssertEqual(processor.process(input), expected)
@@ -44,11 +44,11 @@ class CaptionShortcodeOutputProcessorTests: XCTestCase {
     ///
     func testImgTagAttributesAreProperlyPassedOntoTheCaptionShortcode() {
         let input = "<figure>" +
-            "<img src=\".\" class=\"alignleft wp-image-6\" width=\"300\"><figcaption>Text</figcaption>" +
+            "<img src=\".\" class=\"alignleft wp-image-6\" width=\"300\" /><figcaption>Text</figcaption>" +
         "</figure>"
 
         let expected = "[caption align=\"alignleft\" id=\"attachment_6\" width=\"300\"]" +
-            "<img src=\".\" class=\"alignleft wp-image-6\" width=\"300\">Text" +
+            "<img src=\".\" class=\"alignleft wp-image-6\" width=\"300\" />Text" +
         "[/caption]"
 
         XCTAssertEqual(processor.process(input), expected)


### PR DESCRIPTION
Fixes #987 

To test:
 - Open the Gutenberg demo
 - Switch to HTML mode
 - Check that all tags like ```<br/> <img/> <hr/>``` keep the closing forward dash

