### PR TITLE
Issue/989 img alignment

### DIFF
--- a/Aztec/Classes/NSAttributedString/Conversions/AttachmentToElementConverter/ImageAttachmentToElementConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttachmentToElementConverter/ImageAttachmentToElementConverter.swift
@@ -42,7 +42,10 @@ class ImageAttachmentToElementConverter: AttachmentToElementConverter {
     ///
     private func imageClassAttribute(from attachment: ImageAttachment) -> Attribute? {
         var style = String()
-        style += attachment.alignment.htmlString()
+
+        if let alignment = attachment.alignment {
+            style += alignment.htmlString()
+        }
         
         if attachment.size != .none {
             style += style.isEmpty ? String() : String(.space)

--- a/Aztec/Classes/TextKit/ImageAttachment.swift
+++ b/Aztec/Classes/TextKit/ImageAttachment.swift
@@ -8,7 +8,7 @@ open class ImageAttachment: MediaAttachment {
 
     /// Attachment Alignment
     ///
-    open var alignment: Alignment = .none {
+    open var alignment: Alignment? {
         willSet {
             if newValue != alignment {
                 glyphImage = nil
@@ -68,7 +68,9 @@ open class ImageAttachment: MediaAttachment {
 
     override open func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
-        aCoder.encode(alignment.rawValue, forKey: EncodeKeys.alignment.rawValue)
+        if let alignmentValue = alignment?.rawValue {
+            aCoder.encode(alignmentValue, forKey: EncodeKeys.alignment.rawValue)
+        }
         aCoder.encode(size.rawValue, forKey: EncodeKeys.size.rawValue)
     }
 
@@ -84,8 +86,8 @@ open class ImageAttachment: MediaAttachment {
     ///
     override func imagePositionX(for containerWidth: CGFloat) -> CGFloat {
         let imageWidth = onScreenWidth(for: containerWidth)
-
-        switch alignment {
+        let alignmentValue = alignment ?? .none
+        switch alignmentValue {
         case .center:
             return CGFloat(floor((containerWidth - imageWidth) / 2))
         case .right:

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1397,6 +1397,7 @@ open class TextView: UITextView {
         let attachment = ImageAttachment(identifier: identifier, url: url)
         attachment.delegate = storage
         attachment.image = placeHolderImage
+        attachment.alignment = .none
         replace(at: range, with: attachment)
         return attachment
     }

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -130,7 +130,7 @@ class TextStorageTests: XCTestCase {
         let html = storage.getHTML()
 
         XCTAssertEqual(attachment.url, URL(string: "https://wordpress.com"))
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\"></p>")
     }
 
     /// Verifies that any edition performed on ImageAttachment attributes is properly serialized back during
@@ -317,7 +317,7 @@ class TextStorageTests: XCTestCase {
 
         XCTAssertEqual(firstAttachment.url, URL(string: "https://wordpress.com"))
         XCTAssertEqual(secondAttachment.url, URL(string: "https://wordpress.org"))
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"><img src=\"https://wordpress.org\" class=\"alignnone\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\"><img src=\"https://wordpress.org\"></p>")
     }
 
     /// This test check if the insertion of two images one after the other works correctly and to img tag are inserted
@@ -332,7 +332,7 @@ class TextStorageTests: XCTestCase {
 
         XCTAssertEqual(firstAttachment.url, URL(string: "https://wordpress.com"))
         XCTAssertEqual(secondAttachment.url, URL(string: "https://wordpress.com"))
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"><img src=\"https://wordpress.com\" class=\"alignnone\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\"><img src=\"https://wordpress.com\"></p>")
     }
 
     /// This test verifies if the `removeTextAttachements` call effectively nukes all of the TextAttachments present

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1565,7 +1565,7 @@ class TextViewTests: XCTestCase {
 
         let html = textView.getHTML()
 
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\"></p>")
 
         textView.selectedRange = NSRange(location: NSAttributedString.lengthOfTextAttachment, length: 1)
         guard let font = textView.typingAttributesSwifted[.font] as? UIFont else {
@@ -1592,7 +1592,7 @@ class TextViewTests: XCTestCase {
 
         var html = textView.getHTML()
 
-        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\" class=\"alignnone\"></p>")
+        XCTAssertEqual(html, "<p><img src=\"https://wordpress.com\"></p>")
 
         textView.remove(attachmentID: attachment.identifier)
 
@@ -1840,7 +1840,7 @@ class TextViewTests: XCTestCase {
 
         let html = textView.getHTML()
 
-        XCTAssertEqual(html, "<p><img src=\"http://placeholder\" class=\"alignnone\"></p>" )
+        XCTAssertEqual(html, "<p><img src=\"http://placeholder\"></p>" )
     }
 
     /// This test makes sure that if an `<hr>` was in the original HTML, it will still get output after our processing.

--- a/Example/Example/AttachmentDetailsViewController.swift
+++ b/Example/Example/AttachmentDetailsViewController.swift
@@ -14,7 +14,7 @@ class AttachmentDetailsViewController: UITableViewController
     var attachment: ImageAttachment?
     var caption: NSAttributedString?
     var linkURL: URL?
-    var onUpdate: ((_ alignment: ImageAttachment.Alignment, _ size: ImageAttachment.Size, _ imageURL: URL, _ linkURL: URL?, _ altText: String?, _ captionText: NSAttributedString?) -> Void)?
+    var onUpdate: ((_ alignment: ImageAttachment.Alignment?, _ size: ImageAttachment.Size, _ imageURL: URL, _ linkURL: URL?, _ altText: String?, _ captionText: NSAttributedString?) -> Void)?
     var onDismiss: (() -> ())?
 
 
@@ -48,10 +48,13 @@ class AttachmentDetailsViewController: UITableViewController
             fatalError()
         }
 
-        let alignment = Alignment(attachmentAlignment: attachment.alignment)
-        let size = Size(attachmentSize: attachment.size)
+        alignmentSegmentedControl.selectedSegmentIndex = UISegmentedControlNoSegment
+        if let alignmentValue = attachment.alignment {
+            let alignment = Alignment(attachmentAlignment: alignmentValue)
+            alignmentSegmentedControl.selectedSegmentIndex = alignment.rawValue
+        }
 
-        alignmentSegmentedControl.selectedSegmentIndex = alignment.rawValue
+        let size = Size(attachmentSize: attachment.size)
         sizeSegmentedControl.selectedSegmentIndex = size.rawValue
 
         sourceURLTextField.text = attachment.url?.absoluteString
@@ -67,8 +70,11 @@ class AttachmentDetailsViewController: UITableViewController
     }
 
     @IBAction func doneWasPressed() {
+        var alignment: ImageAttachment.Alignment?
+        if alignmentSegmentedControl.selectedSegmentIndex != UISegmentedControlNoSegment {
+            alignment = Alignment(rawValue: alignmentSegmentedControl.selectedSegmentIndex)?.toAttachmentAlignment()
+        }
         guard
-            let alignment = Alignment(rawValue: alignmentSegmentedControl.selectedSegmentIndex),
             let size = Size(rawValue: sizeSegmentedControl.selectedSegmentIndex)
             else {
             fatalError()
@@ -84,7 +90,7 @@ class AttachmentDetailsViewController: UITableViewController
         let alt = altTextField.text
         let caption = captionTextView.attributedText
         let linkURL = URL(string: linkURLTextField.text ?? "")
-        onUpdate(alignment.toAttachmentAlignment(), size.toAttachmentSize(), url, linkURL, alt, caption)
+        onUpdate(alignment, size.toAttachmentSize(), url, linkURL, alt, caption)
         dismiss(animated: true, completion: onDismiss)
     }
 


### PR DESCRIPTION
Fixes #989 

This PR makes the alignment option in Media Attachments optional in order to cater for cases when no alignment is set on img elements.

To test:
 - Open the Gutenberg demo
 - Switch to HTML mode
 - Make sure no alignment was added to the img elements.
 - Switch to visual again
 - Tap on an image, and select media options
 - Select an alignment option
 - Switch to HTML and see if it was applied.

