### PR TITLE
Improves merging logic.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -31,8 +31,6 @@ public struct Element: RawRepresentable, Hashable {
     /// List of block level elements that can be merged but only when they have a single children that is also mergeable
     ///
     public static var mergeableBlocklevelElementsSingleChildren =  Set<Element>()
-    
-    public static var mergeableBlockLevelElementWithoutBlockLevelChildren = Set<Element>([.figure, .pre])
 
     // MARK: - Initializers
     

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -317,6 +317,12 @@ public class ElementNode: Node {
 
         return siblingNode as? T
     }
+    
+    override func rawText() -> String {
+        return children.reduce("", { (previous, node) -> String in
+            return previous + node.rawText()
+        })
+    }
 }
 
 

--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -193,4 +193,10 @@ public class Node: Equatable, CustomReflectable, Hashable {
 
         return lhs.isEqual(rhs)
     }
+    
+    // MARK: - Raw text representation of nodes
+    
+    func rawText() -> String {
+        return ""
+    }
 }

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -40,6 +40,10 @@ public class TextNode: Node {
 
         return super.needsClosingParagraphSeparator()
     }
+    
+    override func rawText() -> String {
+        return contents
+    }
 
     // MARK: - LeafNode
     

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
@@ -1019,6 +1019,27 @@ class AttributedStringParserTests: XCTestCase {
         
         XCTAssertEqual(textNode.text(), captionText)
     }
+    
+    // MARK: - Pre
+    
+    func testPreParagraphsAreMergedRight() {
+        let formatter = PreFormatter(monospaceFont: UIFont.systemFont(ofSize: 14.0), placeholderAttributes: [:])
+        let attributes = formatter.apply(to: Constants.sampleAttributes)
+        let string = NSMutableAttributedString(string: "Hello 🌍!\nHello 🌎!", attributes: attributes)
+        
+        let rootNode = AttributedStringParser().parse(string)
+        XCTAssertEqual(rootNode.children.count, 1)
+        
+        guard let pre = rootNode.firstChild(ofType: .pre) else {
+            XCTFail()
+            return
+        }
+        
+        // Aztec normalizes newlines to paragraph separators.
+        let expected = string.string.replacingOccurrences(of: "\n", with: String(.paragraphSeparator))
+        
+        XCTAssertEqual(pre.rawText(), expected)
+    }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
### Description:

This PR improves the merging logic slightly.

It was initially intended to resolve #993, but turned out not to, since code blocks are not block-level elements.  Still this PR contains a few improvements I'd like to bring in.

1. We now have a method to [make it easier to check the raw-textNode content of nodes](https://github.com/wordpress-mobile/AztecEditor-iOS/compare/issue/993-code-blocks-broken?expand=1#diff-3b717148f487c5d830376809f559962cR199).
2. It has [better support for `<pre>` elements in the merging logic](https://github.com/wordpress-mobile/AztecEditor-iOS/compare/issue/993-code-blocks-broken?expand=1#diff-3691618ea04c6533e3ab78931758dc50R183).
3. It adds [a unit test for `<pre>` elements](https://github.com/wordpress-mobile/AztecEditor-iOS/compare/issue/993-code-blocks-broken?expand=1#diff-500df526e00d18ca984ad3b925f206b2R1025).

### Testing:

Create `<pre>` elements in the HTML editor, switch back and forth and make sure things work properly.

Also try adding children to the `<pre>` element.