### PR TITLE
Issue/997 video poster

### DIFF
--- a/Aztec/Classes/NSAttributedString/Conversions/AttachmentToElementConverter/VideoAttachmentToElementConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttachmentToElementConverter/VideoAttachmentToElementConverter.swift
@@ -31,7 +31,7 @@ class VideoAttachmentToElementConverter: AttachmentToElementConverter {
     /// Extracts the Video Source Attribute from a VideoAttachment Instance.
     ///
     private func videoSourceAttribute(from attachment: VideoAttachment) -> Attribute? {
-        guard let source = attachment.srcURL?.absoluteString else {
+        guard let source = attachment.url?.absoluteString else {
             return nil
         }
         

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -453,37 +453,8 @@ extension TextStorage: MediaAttachmentDelegate {
     }
 }
 
-
-// MARK: - TextStorage: VideoAttachmentDelegate Methods
-//
-extension TextStorage: VideoAttachmentDelegate {
-
-    func videoAttachmentPlaceholderImageFor(attachment: VideoAttachment) -> UIImage {
-        guard let delegate = attachmentsDelegate else {
-            fatalError()
-        }
-
-        return delegate.storage(self, placeholderFor: attachment)
-    }
-
-    func videoAttachment(
-        _ videoAttachment: VideoAttachment,
-        imageForURL url: URL,
-        onSuccess success: @escaping (UIImage) -> (),
-        onFailure failure: @escaping () -> ())
-    {
-        guard let delegate = attachmentsDelegate else {
-            fatalError()
-        }
-
-        delegate.storage(self, attachment: videoAttachment, imageFor: url, onSuccess: success, onFailure: failure)
-    }
-}
-
-
-
 // MARK: - TextStorage: RenderableAttachmentDelegate Methods
-
+//
 extension TextStorage: RenderableAttachmentDelegate {
 
     func attachment(_ attachment: NSTextAttachment, imageForSize size: CGSize) -> UIImage? {

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -15,31 +15,17 @@ protocol VideoAttachmentDelegate: class {
 ///
 open class VideoAttachment: MediaAttachment {
 
-    /// Attachment video URL
-    ///
-    open var srcURL: URL?
-
     /// Video poster image to show, while the video is not played.
     ///
-    open var posterURL: URL? {
-        get {
-            return self.url
-        }
-
-        set {
-            super.updateURL(newValue)
-        }
-    }    
+    open var posterURL: URL?
     
     /// Creates a new attachment
     ///
     /// - parameter identifier: An unique identifier for the attachment
     ///
     required public init(identifier: String, srcURL: URL? = nil, posterURL: URL? = nil) {
-        self.srcURL = srcURL
-        
-        super.init(identifier: identifier, url: posterURL)
-
+        super.init(identifier: identifier, url: srcURL)
+        self.posterURL = posterURL
         self.overlayImage = Assets.playIcon
     }
 
@@ -48,15 +34,14 @@ open class VideoAttachment: MediaAttachment {
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 
-        if aDecoder.containsValue(forKey: EncodeKeys.srcURL.rawValue) {
-            srcURL = aDecoder.decodeObject(forKey: EncodeKeys.srcURL.rawValue) as? URL
+        if aDecoder.containsValue(forKey: EncodeKeys.posterURL.rawValue) {
+            posterURL = aDecoder.decodeObject(forKey: EncodeKeys.posterURL.rawValue) as? URL
         }
     }
 
     /// Required Initializer
     ///
-    required public init(identifier: String, url: URL?) {
-        self.srcURL = nil
+    required public init(identifier: String, url: URL?) {        
         super.init(identifier: identifier, url: url)
     }
 
@@ -82,13 +67,13 @@ open class VideoAttachment: MediaAttachment {
 
     override open func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
-        if let url = self.srcURL {
-            aCoder.encode(url, forKey: EncodeKeys.srcURL.rawValue)
+        if let posterURL = self.posterURL {
+            aCoder.encode(posterURL, forKey: EncodeKeys.posterURL.rawValue)
         }
     }
 
     fileprivate enum EncodeKeys: String {
-        case srcURL
+        case posterURL
     }
 
 
@@ -130,7 +115,6 @@ extension VideoAttachment {
             fatalError()
         }
 
-        clone.srcURL = srcURL
         clone.posterURL = posterURL
 
         return clone

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -22,6 +22,8 @@ open class VideoAttachment: MediaAttachment {
     /// Creates a new attachment
     ///
     /// - parameter identifier: An unique identifier for the attachment
+    /// - parameter srcURL: the url for the video to display
+    /// - parameter posterURL: the url for a poster image for the video
     ///
     required public init(identifier: String, srcURL: URL? = nil, posterURL: URL? = nil) {
         super.init(identifier: identifier, url: srcURL)

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -1,16 +1,6 @@
 import Foundation
 import UIKit
 
-protocol VideoAttachmentDelegate: class {
-    func videoAttachment(
-        _ videoAttachment: VideoAttachment,
-        imageForURL url: URL,
-        onSuccess success: @escaping (UIImage) -> (),
-        onFailure failure: @escaping () -> ())
-
-    func videoAttachmentPlaceholderImageFor(attachment: VideoAttachment) -> UIImage
-}
-
 /// Custom text attachment.
 ///
 open class VideoAttachment: MediaAttachment {

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1469,7 +1469,7 @@ class TextViewTests: XCTestCase {
             fatalError()
         }
 
-        videoAttachment.srcURL = URL(string:"newVideo.mp4")!
+        videoAttachment.updateURL(URL(string:"newVideo.mp4")!)
         textView.refresh(videoAttachment)
 
         XCTAssertEqual(textView.getHTML(), "<p><video src=\"newVideo.mp4\" poster=\"video.jpg\" alt=\"The video\"></video></p>")

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		FF1FD05C20932EDE00186384 /* gutenberg.html in Resources */ = {isa = PBXBuildFile; fileRef = FF1FD05B20932EDE00186384 /* gutenberg.html */; };
 		FF6691C21E76CF9200C6A703 /* OptionsTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */; };
 		FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */; };
+		FFC41BDE20DBC7BA004DFB4D /* video.html in Resources */ = {isa = PBXBuildFile; fileRef = FFC41BDD20DBC7BA004DFB4D /* video.html */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -152,6 +153,7 @@
 		FF1FD05B20932EDE00186384 /* gutenberg.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = gutenberg.html; sourceTree = "<group>"; };
 		FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionsTableView.swift; sourceTree = "<group>"; };
 		FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AttachmentDetailsViewController.storyboard; sourceTree = "<group>"; };
+		FFC41BDD20DBC7BA004DFB4D /* video.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = video.html; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -192,6 +194,7 @@
 				B5FB21271FEC37DB0067D597 /* captions.html */,
 				59280F291D47CAF40083FB59 /* SampleText.rtf */,
 				FF1FD05B20932EDE00186384 /* gutenberg.html */,
+				FFC41BDD20DBC7BA004DFB4D /* video.html */,
 			);
 			path = SampleContent;
 			sourceTree = "<group>";
@@ -436,6 +439,7 @@
 				FF1FD05C20932EDE00186384 /* gutenberg.html in Resources */,
 				59280F2B1D47CAF40083FB59 /* SampleText.rtf in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
+				FFC41BDE20DBC7BA004DFB4D /* video.html in Resources */,
 				FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1032,50 +1032,6 @@ extension EditorDemoController {
 
 extension EditorDemoController: TextViewAttachmentDelegate {
 
-    func exportPreviewImageForVideo(atURL url: URL, onCompletion: @escaping (UIImage) -> (), onError: @escaping () -> ()) {
-        DispatchQueue.global(qos: .background).async {
-            let asset = AVURLAsset(url: url)
-            guard asset.isExportable else {
-                onError()
-                return
-            }
-            let generator = AVAssetImageGenerator(asset: asset)
-            generator.appliesPreferredTrackTransform = true
-            generator.generateCGImagesAsynchronously(forTimes: [NSValue(time: CMTimeMake(2, 1))],
-                                                     completionHandler: { (time, cgImage, actualTime, result, error) in
-                                                        guard let cgImage = cgImage else {
-                                                            DispatchQueue.main.async {
-                                                                onError()
-                                                            }
-                                                            return
-                                                        }
-                                                        let image = UIImage(cgImage: cgImage)
-                                                        DispatchQueue.main.async {
-                                                            onCompletion(image)
-                                                        }
-            })
-        }
-    }
-
-    func downloadImage(from url: URL, success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
-        let task = URLSession.shared.dataTask(with: url) { [weak self] (data, _, error) in
-            DispatchQueue.main.async {
-                guard self != nil else {
-                    return
-                }
-
-                guard error == nil, let data = data, let image = UIImage(data: data, scale: UIScreen.main.scale) else {
-                    failure()
-                    return
-                }
-
-                success(image)
-            }
-        }
-
-        task.resume()
-    }
-
     func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
 
         switch attachment {
@@ -1275,6 +1231,54 @@ extension EditorDemoController: UIPopoverPresentationControllerDelegate {
     }
 }
 
+// MARK: - Media fetch methods
+//
+private extension EditorDemoController {
+
+    func exportPreviewImageForVideo(atURL url: URL, onCompletion: @escaping (UIImage) -> (), onError: @escaping () -> ()) {
+        DispatchQueue.global(qos: .background).async {
+            let asset = AVURLAsset(url: url)
+            guard asset.isExportable else {
+                onError()
+                return
+            }
+            let generator = AVAssetImageGenerator(asset: asset)
+            generator.appliesPreferredTrackTransform = true
+            generator.generateCGImagesAsynchronously(forTimes: [NSValue(time: CMTimeMake(2, 1))],
+                                                     completionHandler: { (time, cgImage, actualTime, result, error) in
+                                                        guard let cgImage = cgImage else {
+                                                            DispatchQueue.main.async {
+                                                                onError()
+                                                            }
+                                                            return
+                                                        }
+                                                        let image = UIImage(cgImage: cgImage)
+                                                        DispatchQueue.main.async {
+                                                            onCompletion(image)
+                                                        }
+            })
+        }
+    }
+
+    func downloadImage(from url: URL, success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
+        let task = URLSession.shared.dataTask(with: url) { [weak self] (data, _, error) in
+            DispatchQueue.main.async {
+                guard self != nil else {
+                    return
+                }
+
+                guard error == nil, let data = data, let image = UIImage(data: data, scale: UIScreen.main.scale) else {
+                    failure()
+                    return
+                }
+
+                success(image)
+            }
+        }
+
+        task.resume()
+    }
+}
 // MARK: - Misc
 //
 private extension EditorDemoController

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1096,7 +1096,7 @@ extension EditorDemoController: TextViewAttachmentDelegate {
     }
 
     func placeholderImage(for attachment: NSTextAttachment) -> UIImage {
-        let imageSize = CGSize(width:32, height:32)
+        let imageSize = CGSize(width:64, height:64)
         let placeholderImage: UIImage
         switch attachment {
         case _ as ImageAttachment:

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -122,10 +122,7 @@ Block Quote:
 <p>
 <video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg" alt="Video about bunnies" />
 </p>
-<h4>Video with Shortcode:</h4>
-<p>
-[video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg" alt="Another video with bunnies"/]
-</p>
+
 <h4>Overlay on Media:</h4>
 <p>
 20px Wide Image:

--- a/Example/Example/SampleContent/gutenberg.html
+++ b/Example/Example/SampleContent/gutenberg.html
@@ -132,7 +132,7 @@
 <!-- /wp:separator -->
 
 <!-- wp:video -->
-<figure class="wp-block-video"><video controls src="https://videos.files.wordpress.com/AvC6H2JI/video-de223da1f6.mp4" poster="https://videos.files.wordpress.com/AvC6H2JI/video-de223da1f6_hd.original.jpg"></video></figure>
+<figure class="wp-block-video"><video controls src="https://videos.files.wordpress.com/AvC6H2JI/video-de223da1f6.mp4"></video></figure>
 <!-- /wp:video -->
 
 <!-- wp:separator -->

--- a/Example/Example/SampleContent/video.html
+++ b/Example/Example/SampleContent/video.html
@@ -1,0 +1,9 @@
+<h1>Standard Video</h1>
+<video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg" alt="Another video with bunnies"></video>
+
+<h1>Standard Video no poster image</h1>
+<video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" alt="Another video with bunnies"></video>
+
+<h1>WordPress Video Shortcode</h1>
+[video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg" alt="Another video with bunnies"/]
+

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -22,6 +22,7 @@ class ViewController: UITableViewController
             ),
             DemoSection(title: "WordPressEditor (Calypso & Gutenberg)", rows: [
                 DemoRow(title: "Gutenberg Demo", action: { self.showEditorDemo(filename: "gutenberg", wordPressMode: true) }),
+                DemoRow(title: "Video Shortcode Demo", action: { self.showEditorDemo(filename: "video", wordPressMode: true) }),
                 DemoRow(title: "Empty Demo", action: { self.showEditorDemo(wordPressMode: true) })
                 ]
             ),


### PR DESCRIPTION
Fixes #997 

This PR changes the way poster images are being implemented on VideoAttachment. So now the src attribute on VideoAttachment represent the video and the posterURL represents the poster image URL if any.

This way when the TextView ask for an image for the attachment we check if it's a video attachment and then use the correct property for the image, according to this:

- If it's a video attachment and we have a poster image, simple use the poster image URL
- If it's a video attachment but not poster is provided try to extract a frame directly from the video url and use it

This could be also a opportunity to do other two things:

- Refactor the `TextViewAttachmentDelegate` method ```func textView(_ textView: TextView,
                  attachment: NSTextAttachment,
                  imageAt url: URL,
                  onSuccess success: @escaping (UIImage) -> Void,
                  onFailure failure: @escaping () -> Void)``` to just sent the attachment object and not the url and depending of the type of attachment use the correct information

- Merge the `TextViewAttachmentDelegate` and `TextViewAttachmentImageProvider` in a single class and avoid to have two ways of fetching images for an attachment.

I simple did the quickest solution but if any of the above is of interest I can go a do follow up PRs

To test:
 - Open the new sample content Videos and see if the video shows correctly even when no poster image is selected.
 - On the clean HTML demo simple insert this on the HTML mode:
```<video src="https://videos.files.wordpress.com/AvC6H2JI/video-de223da1f6.mp4"  />```
 - Check if the video shows correctly in visual mode

