### PR TITLE
Improve gb closing logic

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -31,8 +31,6 @@ public struct Element: RawRepresentable, Hashable {
     /// List of block level elements that can be merged but only when they have a single children that is also mergeable
     ///
     public static var mergeableBlocklevelElementsSingleChildren =  Set<Element>()
-    
-    public static var mergeableBlockLevelElementWithoutBlockLevelChildren = Set<Element>([.figure, .pre])
 
     // MARK: - Initializers
     

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -317,6 +317,12 @@ public class ElementNode: Node {
 
         return siblingNode as? T
     }
+    
+    override func rawText() -> String {
+        return children.reduce("", { (previous, node) -> String in
+            return previous + node.rawText()
+        })
+    }
 }
 
 

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -318,7 +318,7 @@ public class ElementNode: Node {
         return siblingNode as? T
     }
     
-    override func rawText() -> String {
+    override public func rawText() -> String {
         return children.reduce("", { (previous, node) -> String in
             return previous + node.rawText()
         })

--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -193,4 +193,10 @@ public class Node: Equatable, CustomReflectable, Hashable {
 
         return lhs.isEqual(rhs)
     }
+    
+    // MARK: - Raw text representation of nodes
+    
+    func rawText() -> String {
+        return ""
+    }
 }

--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -196,7 +196,7 @@ public class Node: Equatable, CustomReflectable, Hashable {
     
     // MARK: - Raw text representation of nodes
     
-    func rawText() -> String {
+    public func rawText() -> String {
         return ""
     }
 }

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -40,6 +40,10 @@ public class TextNode: Node {
 
         return super.needsClosingParagraphSeparator()
     }
+    
+    override func rawText() -> String {
+        return contents
+    }
 
     // MARK: - LeafNode
     

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -41,7 +41,7 @@ public class TextNode: Node {
         return super.needsClosingParagraphSeparator()
     }
     
-    override func rawText() -> String {
+    override public func rawText() -> String {
         return contents
     }
 

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
@@ -1019,6 +1019,27 @@ class AttributedStringParserTests: XCTestCase {
         
         XCTAssertEqual(textNode.text(), captionText)
     }
+    
+    // MARK: - Pre
+    
+    func testPreParagraphsAreMergedRight() {
+        let formatter = PreFormatter(monospaceFont: UIFont.systemFont(ofSize: 14.0), placeholderAttributes: [:])
+        let attributes = formatter.apply(to: Constants.sampleAttributes)
+        let string = NSMutableAttributedString(string: "Hello 🌍!\nHello 🌎!", attributes: attributes)
+        
+        let rootNode = AttributedStringParser().parse(string)
+        XCTAssertEqual(rootNode.children.count, 1)
+        
+        guard let pre = rootNode.firstChild(ofType: .pre) else {
+            XCTFail()
+            return
+        }
+        
+        // Aztec normalizes newlines to paragraph separators.
+        let expected = string.string.replacingOccurrences(of: "\n", with: String(.paragraphSeparator))
+        
+        XCTAssertEqual(pre.rawText(), expected)
+    }
 }
 
 // MARK: - Helpers

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/CommentNode+Gutenberg.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/CommentNode+Gutenberg.swift
@@ -12,7 +12,7 @@ public extension CommentNode {
         return isGutenbergBlockCloser() && opener.canBeClosedBy(self)
     }
     
-    private func isGutenbergBlockCloser() -> Bool {
+    func isGutenbergBlockCloser() -> Bool {
         let prefix = CommentNode.closerPrefix
         
         return comment.trimmingCharacters(in: .whitespaces).prefix(prefix.count) == prefix

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
@@ -31,9 +31,54 @@ public class GutenbergInputHTMLTreeProcessor: HTMLTreeProcessor {
     typealias Replacement = (range: Range<Int>, nodes: [Node])
     
     public func process(_ rootNode: RootNode) {
-        process(elementNode: rootNode)
+        process(rootNode as ElementNode)
     }
     
+    public func process(_ elementNode: ElementNode) {
+        elementNode.children = process(elementNode.children)
+    }
+/*
+    typealias GutenbergCommentMatch = (index: Int, commentNode: CommentNode)
+    typealias GutenbergCommentMatches = (openers: GutenbergCommentMatch, closers: GutenbergCommentMatch)
+    typealias GutenbergCommentMatchPair = (openerMatch: GutenbergCommentMatch, closerMatch: GutenbergCommentMatch)
+    
+    private func pairedGutenbergComments(in nodes: [Node]) -> [GutenbergCommentMatchPair] {
+        let gutenbergCommentMatches = findGutenbergComments(in: nodes)
+        var currentIndex = 0
+        var pairs = [GutenbergCommentMatchPair]()
+        
+        while currentIndex + 1 < gutenbergCommentMatches.count {
+            let possibleOpenerMatch = gutenbergCommentMatches[currentIndex]
+            let possibleCloserMatch = gutenbergCommentMatches[currentIndex + 1]
+            
+            let possibleOpener = possibleOpenerMatch.commentNode
+            let possibleCloser = possibleCloserMatch.commentNode
+            
+            guard possibleOpener.isGutenbergBlockOpener()
+                && possibleCloser.isGutenbergBlockCloser(forOpener: possibleOpener) else {
+                    currentIndex += 1
+                    continue
+            }
+            
+            let newPair = GutenbergCommentMatchPair(openerMatch: possibleOpenerMatch, closerMatch: possibleCloserMatch)
+            pairs.append(newPair)
+            
+            currentIndex += 2
+        }
+    }
+    
+    private func findGutenbergComments(in nodes: [Node]) -> [GutenbergCommentMatch] {
+        return nodes.enumerated().compactMap { value -> GutenbergCommentMatch? in
+            guard let commentNode = value.element as? CommentNode,
+                commentNode.isGutenbergBlockOpener() || commentNode.isGutenbergBlockCloser() else {
+                    return nil
+            }
+            
+            return GutenbergCommentMatch(index: value.offset, commentNode: commentNode)
+        }
+    }
+*/
+    /*
     private func process(elementNode: ElementNode) {
         var state: State = .noBlock
         
@@ -57,8 +102,81 @@ public class GutenbergInputHTMLTreeProcessor: HTMLTreeProcessor {
                 return nil
             }
         }
+        
+        if case let .blockInProgress(opener, gutenblock) = state {
+            
+        }
+    }*/
+    
+    typealias OpenerMatch = (offset: Int, opener: CommentNode)
+    typealias CloserMatch = (offset: Int, closer: CommentNode)
+    
+    private func nextOpener(in nodes: ArraySlice<Node>) -> OpenerMatch? {
+        for (index, node) in nodes.enumerated() {
+            guard let commentNode = node as? CommentNode,
+                commentNode.isGutenbergBlockOpener() else {
+                    continue
+            }
+            
+            return OpenerMatch(offset: index, opener: commentNode)
+        }
+        
+        return nil
     }
 
+    private func nextCloser(in nodes: ArraySlice<Node>, forOpener opener: CommentNode) -> CloserMatch? {
+        for (index, node) in nodes.enumerated() {
+            guard let commentNode = node as? CommentNode,
+                commentNode.isGutenbergBlockCloser(forOpener: opener) else {
+                    continue
+            }
+            
+            return CloserMatch(offset: index, closer: commentNode)
+        }
+        
+        return nil
+    }
+    
+    private func process(_ nodes: [Node]) -> [Node] {
+        var result = [Node]()
+        var openerSlice = nodes[0 ..< nodes.count]
+        
+        while let (relativeOpenerOffset, opener) = self.nextOpener(in: openerSlice) {
+            let openerOffset = openerSlice.startIndex + relativeOpenerOffset
+            
+            result += nodes[openerSlice.startIndex ..< openerOffset]
+            
+            let nextOffset = openerOffset + 1
+            let closerSlice = nodes[nextOffset ..< nodes.count]
+            
+            guard let (relativeCloserOffset, closer) = nextCloser(in: closerSlice, forOpener: opener) else {
+                result.append(opener)
+                openerSlice = closerSlice
+                
+                continue
+            }
+            
+            let closerOffset = closerSlice.startIndex + relativeCloserOffset
+            
+            let attributes = openerAttributes(for: opener) + closerAttributes(for: closer)
+            let children = [Node](nodes[closerSlice.startIndex ..< closerOffset])
+            let gutenblock = ElementNode(type: .gutenblock, attributes: attributes, children: children)
+            
+            result.append(gutenblock)
+            
+            process(gutenblock)
+            
+            openerSlice = nodes[closerOffset + 1 ..< nodes.count]
+        }
+        
+        if openerSlice.count > 0 {
+            result += [Node](openerSlice)
+        }
+        
+        return result
+    }
+    
+/*
     private func process(_ node: Node) -> (newState: State, nodeToAppend: Node) {
         if let commentNode = node as? CommentNode {
             if commentNode.isGutenbergBlockOpener() {
@@ -92,6 +210,7 @@ public class GutenbergInputHTMLTreeProcessor: HTMLTreeProcessor {
         
         return .noBlock
     }
+ */
 }
 
 // MARK: - Gutenblock attributes

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessor.swift
@@ -42,11 +42,11 @@ public class GutenbergInputHTMLTreeProcessor: HTMLTreeProcessor {
         while let (relativeOpenerOffset, match) = self.nextOpenerOrSelfClosing(in: openerSlice) {
             let openerOffset = openerSlice.startIndex + relativeOpenerOffset
             
+            // Any nodes before the first match found are immediately added to the results.
+            result += nodes[openerSlice.startIndex ..< openerOffset]
+            
             if match.isGutenbergBlockOpener() {
                 let opener = match
-
-                // Any nodes before the first starter found are immediately added to the results.
-                result += nodes[openerSlice.startIndex ..< openerOffset]
 
                 let nextOffset = openerOffset + 1
                 let closerSlice = nodes[nextOffset ..< nodes.count]

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessor.swift
@@ -31,13 +31,10 @@ public class GutenbergOutputHTMLTreeProcessor: HTMLTreeProcessor {
         
         let openingComment = gutenbergOpener(for: gutenblock)
         let containedNodes = gutenblock.children
+        let closingComment = gutenbergCloser(for: gutenblock)
+        let closingNewline = TextNode(text: "\n")
 
-        var result = [openingComment] + containedNodes
-        if let closingComment = gutenbergCloser(for: gutenblock) {
-            let closingNewline = TextNode(text: "\n")
-            result += [closingComment, closingNewline]
-        }
-        return result
+        return [openingComment] + containedNodes + [closingComment, closingNewline]
     }
     
     private func process(gutenpack: ElementNode) -> [Node] {
@@ -105,9 +102,9 @@ public class GutenbergOutputHTMLTreeProcessor: HTMLTreeProcessor {
 
 private extension GutenbergOutputHTMLTreeProcessor {
     
-    func gutenbergCloser(for element: ElementNode) -> CommentNode? {
+    func gutenbergCloser(for element: ElementNode) -> CommentNode {
         guard let closer = gutenblockCloserData(for: element) else {
-            return nil
+            fatalError("There's no scenario in which this information missing can make sense.  Review the logic.")
         }
         
         return CommentNode(text: closer)

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
@@ -76,7 +76,7 @@ class GutenbergInputHTMLTreeProcessorTests: XCTestCase {
     /// Verifies that a Gutenberg paragraph block with attributes is properly encoded.
     ///
     func testParagraphBlockWithAttributes() {
-        let openingCommentText = " wp:paragraph {\"fontColor\": red, \"fontSize\": 12}"
+        let openingCommentText = " wp:paragraph {\"fontColor\": red, \"fontSize\": 12} "
         let closingCommentText = " /wp:paragraph "
         let openingGutentag = htmlComment(withContent: openingCommentText)
         let closingGutentag = htmlComment(withContent: closingCommentText)
@@ -121,104 +121,52 @@ class GutenbergInputHTMLTreeProcessorTests: XCTestCase {
         
         XCTAssertEqual(textNode.text(), text)
     }
-    /*
-    /// Verifies that multiple Gutenberg paragraph blocks with attributes are properly encoded.
+    
+    // MARK: - Self-Closing Gutenberg Tags
+    
+    /// Verifies that a self closing block is properly processed
     ///
-    func testMultipleParagraphBlocksWithAttributes() {
-        let openingCommentText = " wp:paragraph {\"fontColor\": red, \"fontSize\": 12}"
+    func testSelfClosedBlock() {
+        let selfClosingCommentText = " wp:latest-posts "
+        let openingCommentText = " wp:paragraph {\"fontColor\": red, \"fontSize\": 12} "
         let closingCommentText = " /wp:paragraph "
+        let selfClosingGutentag = htmlComment(withContent: selfClosingCommentText)
         let openingGutentag = htmlComment(withContent: openingCommentText)
         let closingGutentag = htmlComment(withContent: closingCommentText)
-        let text = "Hello 🌎!"
+        let text = "Hello there!"
         
-        let singleInputParagraph = "\(openingGutentag)\n<p>\(text)</p>\n\(closingGutentag)"
-        let input = String(format: "%@\n%@\n%@", singleInputParagraph, singleInputParagraph, singleInputParagraph)
+        let input = "\(openingGutentag)\n<p>\(text)</p>\(selfClosingGutentag)\n\(closingGutentag)"
         
+        let selfClosingComment = encode(blockString: selfClosingCommentText)
         let encodedOpeningComment = encode(blockString: openingCommentText)
         let encodedClosingComment = encode(blockString: closingCommentText)
         
         let rootNode = parser.parse(input)
         processor.process(rootNode)
         
-        XCTAssertEqual(rootNode.children.count, 3)
-        
-        for child in rootNode.children {
-            guard let gutenblock = child as? ElementNode,
-                gutenblock.type == .gutenblock else {
-                    XCTFail()
-                    return
-            }
-            
-            XCTAssert(gutenblock.attributes.contains(where: { (attribute) -> Bool in
-                return attribute.name == GutenbergAttributeNames.blockOpener
-                    && attribute.value.toString() == encodedOpeningComment
-            }))
-            
-            XCTAssert(gutenblock.attributes.contains(where: { (attribute) -> Bool in
-                return attribute.name == GutenbergAttributeNames.blockCloser
-                    && attribute.value.toString() == encodedClosingComment
-            }))
-            
-            XCTAssertEqual(gutenblock.children.count, 2)
-            guard let paragraph = gutenblock.children[0] as? ElementNode else {
+        XCTAssertEqual(rootNode.children.count, 1)
+        guard let gutenblock = rootNode.children[0] as? ElementNode,
+            gutenblock.type == .gutenblock else {
                 XCTFail()
                 return
-            }
-            
-            XCTAssertEqual(paragraph.children.count, 1)
-            guard let textNode = paragraph.children[0] as? TextNode else {
-                XCTFail()
-                return
-            }
-            
-            XCTAssertEqual(textNode.text(), text)
         }
+        
+        XCTAssert(gutenblock.attributes.contains(where: { (attribute) -> Bool in
+            return attribute.name == GutenbergAttributeNames.blockOpener
+                && attribute.value.toString() == encodedOpeningComment
+        }))
+        
+        XCTAssert(gutenblock.attributes.contains(where: { (attribute) -> Bool in
+            return attribute.name == GutenbergAttributeNames.blockCloser
+                && attribute.value.toString() == encodedClosingComment
+        }))
+        
+        XCTAssertEqual(gutenblock.children.count, 3)
+        guard let paragraph = gutenblock.children[0] as? ElementNode else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssertEqual(paragraph.rawText(), text)
     }
-
-    // MARK: - Self-Closing Gutenberg Tags
-    
-    /// Verifies that a self closing block is properly processed
-    ///
-    func testSelfClosedBlock() {
-        let input = "<!-- wp:latest-posts /-->"
-        
-        let encodedGutentag = encode(blockString: input)
-        let expected = "<gutenblock data=\"\(encodedGutentag)\">"
-        
-        let output = processor.process(input)
-        let rootNode = parser.parse(input)
-        processor.process(rootNode)
-        
-        XCTAssertEqual(output, expected)
-    }
-    
-    /// Verifies that a self closing block with attributes is properly processed
-    ///
-    func testSelfClosedBlockWithAttributes() {
-        let input = "<!-- wp:latest-posts {\"postsToShow\":4,\"displayPostDate\":true} /-->"
-        
-        let encodedGutentag = encode(blockString: input)
-        let expected = "<gutenblock data=\"\(encodedGutentag)\">"
-        
-        let output = processor.process(input)
-        
-        XCTAssertEqual(output, expected)
-    }
-    
-    
-    /// Verifies that multiple self closing blocks with attributes are properly processed
-    ///
-    func testMultipleSelfClosedBlockWithAttributes() {
-        let singleGutentag = "<!-- wp:latest-posts {\"postsToShow\":4,\"displayPostDate\":true} /-->"
-        let input = String(format: "%@\n%@\n%@", singleGutentag, singleGutentag, singleGutentag)
-        
-        let encodedGutentag = encode(blockString: singleGutentag)
-        let singleExpectedElement = "<gutenblock data=\"\(encodedGutentag)\">"
-        let expected = String(format: "%@\n%@\n%@", singleExpectedElement, singleExpectedElement, singleExpectedElement)
-        
-        let output = processor.process(input)
-        
-        XCTAssertEqual(output, expected)
-    }
- */
 }

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
@@ -127,7 +127,7 @@ class GutenbergInputHTMLTreeProcessorTests: XCTestCase {
     /// Verifies that a self closing block is properly processed
     ///
     func testSelfClosedBlock() {
-        let selfClosingCommentText = " wp:latest-posts "
+        let selfClosingCommentText = " wp:latest-posts /"
         let openingCommentText = " wp:paragraph {\"fontColor\": red, \"fontSize\": 12} "
         let closingCommentText = " /wp:paragraph "
         let selfClosingGutentag = htmlComment(withContent: selfClosingCommentText)
@@ -168,5 +168,16 @@ class GutenbergInputHTMLTreeProcessorTests: XCTestCase {
         }
         
         XCTAssertEqual(paragraph.rawText(), text)
+        
+        guard let gutenpack = gutenblock.children[1] as? ElementNode else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(gutenpack.type, .gutenpack)
+        
+        XCTAssert(gutenpack.attributes.contains(where: { (attribute) -> Bool in
+            return attribute.name == GutenbergAttributeNames.selfCloser
+                && attribute.value.toString() == selfClosingComment
+        }))
     }
 }


### PR DESCRIPTION
### Description:

This PR proposed an alternative fix to #996.

Unfortunately the initial proposal worked fine for a single tag, but failed when removing a tag from a larger post (sample content).

This PR proposes a more solid parsing mechanism to avoid problems with missing tags.  Opening tags without a closing match are output as regular comments.

### Details:

The solution proposed in this PR changes the delimiter parsing logic entirely, to a much more robust mechanism.

One of the things that pushed me to push this is that I realized today that the previous mechanism would have failed miserably with Gutenberg block embedding other blocks (which will be a requirement moving forward).

### Testing:

Try removing any closing or opening tag from the Gutenberg sample content.
Also try using this content in the empty editor, in HTML mode:

```
<!-- wp:list -->
<ul>
    <li>Media library/HTML for images, multimedia and approved files.</li>
    <li>Pasted links for embeds.</li>
    <li>Shortcodes for specialized assets from plugins.</li>
    <li>Featured images for the image at the top of a post or page.</li>
    <li>Excerpts for subheads.</li>
    <li>Widgets for content on the side of a page.</li>
</ul>
```