### PR TITLE
Replaces the paragraph properties output conversion and merging logic.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		F1C05B991E37F99D007510EA /* Character+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B981E37F99D007510EA /* Character+Name.swift */; };
 		F1C05B9D1E37FA77007510EA /* String+CharacterName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B9C1E37FA77007510EA /* String+CharacterName.swift */; };
 		F1C05B9F1E37FD2F007510EA /* NSAttributedString+CharacterName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B9E1E37FD2F007510EA /* NSAttributedString+CharacterName.swift */; };
+		F1CF7F9020E14E2200B24173 /* NewAttributedStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CF7F8F20E14E2200B24173 /* NewAttributedStringParser.swift */; };
 		F1DE83D51EF20493009269E6 /* UIColor+Parsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DE83D41EF20493009269E6 /* UIColor+Parsers.swift */; };
 		F1E1B7762062BD47004642BB /* NSMutableAttributedStringParagraphProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E1B7752062BD47004642BB /* NSMutableAttributedStringParagraphProperty.swift */; };
 		F1E1B7782062BE6B004642BB /* ParagraphStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E1B7772062BE6B004642BB /* ParagraphStyleTests.swift */; };
@@ -376,6 +377,7 @@
 		F1C05B981E37F99D007510EA /* Character+Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Character+Name.swift"; sourceTree = "<group>"; };
 		F1C05B9C1E37FA77007510EA /* String+CharacterName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+CharacterName.swift"; sourceTree = "<group>"; };
 		F1C05B9E1E37FD2F007510EA /* NSAttributedString+CharacterName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+CharacterName.swift"; sourceTree = "<group>"; };
+		F1CF7F8F20E14E2200B24173 /* NewAttributedStringParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewAttributedStringParser.swift; sourceTree = "<group>"; };
 		F1DE83D41EF20493009269E6 /* UIColor+Parsers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Parsers.swift"; sourceTree = "<group>"; };
 		F1E1B7752062BD47004642BB /* NSMutableAttributedStringParagraphProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringParagraphProperty.swift; sourceTree = "<group>"; };
 		F1E1B7772062BE6B004642BB /* ParagraphStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParagraphStyleTests.swift; sourceTree = "<group>"; };
@@ -958,6 +960,7 @@
 				F14C4D2520C076EA007CBC57 /* HTMLConverter.swift */,
 				F17BC8A81F4E512800398E2B /* AttributedStringParser.swift */,
 				F17BC8A91F4E512800398E2B /* AttributedStringSerializer.swift */,
+				F1CF7F8F20E14E2200B24173 /* NewAttributedStringParser.swift */,
 				F16A2AD020CC426400BF3A0A /* AttachmentToElementConverter */,
 				F15A8B6220BED08900C57ED2 /* ParagraphPropertyConverters */,
 			);
@@ -1332,6 +1335,7 @@
 				B5B86D371DA3EC250083DB3F /* NSRange+Helpers.swift in Sources */,
 				F1E2323420C18055008DA49F /* FormatterElementConverter.swift in Sources */,
 				F12328771FB638C6001E35EF /* NSAttributedStringKey+Aztec.swift in Sources */,
+				F1CF7F9020E14E2200B24173 /* NewAttributedStringParser.swift in Sources */,
 				599F25501D8BC9A1002871D6 /* FormattingIdentifier.swift in Sources */,
 				B524228F1F30C098002E7C6C /* HTMLDivFormatter.swift in Sources */,
 				F1079D67208F80FE009717FA /* EditorView.swift in Sources */,

--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -20,6 +20,10 @@ public struct Element: RawRepresentable, Hashable {
     /// Ref. http://w3c.github.io/html/syntax.html#void-elements
     ///
     public static var voidElements: [Element] = [.area, .base, .br, .col, .embed, .hr, .img, .input, .link, .meta, .param, .source, .track, .wbr]
+    
+    /// This should hardly be anything other than .pre, but has been made customizable anyway.
+    ///
+    public static var preformattedElements: [Element] = [.pre]
 
     /// List of block HTML elements that can be merged together when they are sibling to each other
     ///

--- a/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
@@ -29,8 +29,8 @@ public class HTMLConverter {
     
     // MARK: - Converters: AttributedString -> HTML
     
-    private(set) lazy var attributedStringToTree: AttributedStringParser = {
-        return AttributedStringParser(customizer: pluginManager)
+    private(set) lazy var attributedStringToTree: NewAttributedStringParser = {
+        return NewAttributedStringParser(customizer: pluginManager)
     }()
     
     private(set) lazy var treeToHTML: HTMLSerializer = {

--- a/Aztec/Classes/NSAttributedString/Conversions/NewAttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/NewAttributedStringParser.swift
@@ -35,14 +35,6 @@ class NewAttributedStringParser {
     }
     
     // MARK: - Parsing
-    
-    private func append(_ nodes: [Node], to conversions: [ParagraphPropertyConversion]) {
-        precondition(conversions.count > 0)
-        
-        let lastConversion = conversions.last!
-        
-        lastConversion.elementNode.children.append(contentsOf: nodes)
-    }
 
     /// Parses an attributed string and returns the corresponding HTML tree.
     ///
@@ -472,6 +464,21 @@ private extension NewAttributedStringParser {
 // MARK: - Paragraph Properties Conversion
 //
 extension NewAttributedStringParser {
+    
+    /// Appends the provided nodes to the last element in a list of conversions.
+    /// Used mainly for adding sub-paragraph style nodes.
+    ///
+    /// - Parameters:
+    ///     - nodes: the nodes to append
+    ///     - conversions: the conversions to append the nodes to.
+    ///
+    private func append(_ nodes: [Node], to conversions: [ParagraphPropertyConversion]) {
+        precondition(conversions.count > 0)
+        
+        let lastConversion = conversions.last!
+        
+        lastConversion.elementNode.children.append(contentsOf: nodes)
+    }
     
     /// Converts paragraph properties
     ///

--- a/Aztec/Classes/NSAttributedString/Conversions/NewAttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/NewAttributedStringParser.swift
@@ -182,14 +182,13 @@ class NewAttributedStringParser {
         
         let mergeableCount = lastMergeableIndex + 1
         
-        // There are certain scenarios in which the last element that's mergeable has to remain unmerged.
-        // The way to represent a newline (a paragraph interruption) is by interrupting the last
-        // block-level HTML element either in the previous conversion or in the current conversions.
-        // So if the last merged block-level element has no block-level element children in either side
-        // it needs to be broken.
+        // There are certain scenarios in which the last block-level element that's mergeable has to remain unmerged.
         //
-        // Also, preformatted blocks don't suffer from this because they respect their whitespace, so adding a
-        // newline character is enough to break the paragraph.
+        // The first way to represent a newline (a paragraph interruption) in HTML is by interrupting the "lowest" / "last"
+        // block-level element in a tree.
+        //
+        // As an alternative, preformatted blocks don't need to be broken because they respect their whitespace.  This means
+        // that a regular newline character is enough to break the paragraph.
         //
         let canKeepLastConversion =
             mergeableCount < previousConversions.count // If the previous conversions have a block-level child, we can avoid breaking

--- a/Aztec/Classes/NSAttributedString/Conversions/NewAttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/NewAttributedStringParser.swift
@@ -1,0 +1,1246 @@
+import Foundation
+import UIKit
+import libxml2
+
+/// Parses an attributed string into an HTML tree.
+///
+class NewAttributedStringParser {
+    
+    // MARK: - Plugin Manager
+    
+    let customizer: AttributedStringParserCustomizer?
+    
+    // MARK: - Initializers
+    
+    init(customizer: AttributedStringParserCustomizer? = nil) {
+        self.customizer = customizer
+    }
+    
+    // MARK: - Attachment Converters
+    
+    private let attachmentConverters: [BaseAttachmentToElementConverter] = [
+        CommentAttachmentToElementConverter(),
+        HTMLAttachmentToElementConverter(),
+        ImageAttachmentToElementConverter(),
+        LineAttachmentToElementConverter(),
+        VideoAttachmentToElementConverter(),
+    ]
+    
+    // MARK: - Parsing
+    
+    struct ParagraphPropertyConversion {
+        let property: ParagraphProperty
+        let elementNode: ElementNode
+        let preformatted: Bool
+    }
+    
+    private func paragraphProperties(from attributes: [NSAttributedStringKey: Any]) -> [ParagraphProperty] {
+        guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle else {
+            return []
+        }
+        
+        return paragraphStyle.properties
+    }
+    
+    private func paragraphProperties(from conversions: [ParagraphPropertyConversion]) -> [ParagraphProperty] {
+        return conversions.map({ (conversion) -> ParagraphProperty in
+            return conversion.property
+        })
+    }
+    
+    private func append(_ nodes: [Node], to conversions: [ParagraphPropertyConversion]) {
+        precondition(conversions.count > 0)
+        
+        let lastConversion = conversions.last!
+        
+        lastConversion.elementNode.children.append(contentsOf: nodes)
+    }
+    
+    private func convert(_ properties: ArraySlice<ParagraphProperty>) -> [ParagraphPropertyConversion] {
+        var preformatted = false
+        var parentElementNode: ElementNode?
+        
+        /// Updates the parent.
+        ///
+        func updateParent(for elementNode: ElementNode) {
+            defer {
+                // No matter what exit point we take, the provided element will
+                // be set as the parent after this method is executed.
+                parentElementNode = elementNode
+            }
+            
+            guard let previousParentElementNode = parentElementNode else {
+                return
+            }
+            
+            previousParentElementNode.children.append(elementNode)
+        }
+        
+        let conversions = properties.compactMap({ (property) -> ParagraphPropertyConversion? in
+            guard let conversion = convert(property, preformatted: &preformatted) else {
+                return nil
+            }
+            
+            updateParent(for: conversion.elementNode)
+            return conversion
+        })
+        
+        // We don't allow not having at least 1 block-level element, so we enforce a
+        // paragraph element in that case.
+        guard conversions.count > 0 else {
+            let defaultConversion = ParagraphPropertyConversion(property: HTMLParagraph(with: nil), elementNode: ElementNode(type: .p), preformatted: false)
+            return [defaultConversion]
+        }
+        
+        return conversions
+    }
+    
+    private func convert(_ property: ParagraphProperty, preformatted: inout Bool) -> ParagraphPropertyConversion? {
+        guard let elementNode = convert(property) else {
+            return nil
+        }
+        
+        preformatted = Element.preformattedElements.contains(elementNode.type)
+        
+        return ParagraphPropertyConversion(property: property, elementNode: elementNode, preformatted: preformatted)
+    }
+    
+    private func convert(_ property: ParagraphProperty) -> ElementNode? {
+        // The customizer overrides any default behaviour, which is the reason why it's run first.
+        if let element = customizer?.convert(property) {
+            return element
+        }
+        
+        switch property {
+        case let blockquote as Blockquote:
+            let element = processBlockquoteStyle(blockquote: blockquote)
+            return element
+            
+        case let figcaption as Figcaption:
+            let element = processFigcaptionStyle(figcaption: figcaption)
+            return element
+            
+        case let figure as Figure:
+            let element = processFigureStyle(figure: figure)
+            return element
+            
+        case let header as Header:
+            guard let element = processHeaderStyle(header: header) else {
+                return nil
+            }
+            return element
+            
+        case let list as TextList:
+            let element = processListStyle(list: list)
+            return element
+            
+        case let listItem as HTMLLi:
+            let element = processListItem(listItem: listItem)
+            return element
+            
+        case let div as HTMLDiv:
+            let element = processDivStyle(div: div)
+            return element
+            
+        case let paragraph as HTMLParagraph:
+            let element = processParagraphStyle(paragraph: paragraph)
+            return element
+            
+        case let pre as HTMLPre:
+            let element = processPreStyle(pre: pre)
+            return element
+            
+        default:
+            return nil
+        }
+    }
+    
+    /// Calculates which previous conversions can be merged for the new properties.
+    ///
+    private func mergeableConversions(from previousConversions: [ParagraphPropertyConversion], for newProperties: [ParagraphProperty]) -> ArraySlice<ParagraphPropertyConversion>? {
+        
+        var lastMergeableIndex = -1
+        
+        for (index, conversion) in previousConversions.enumerated() {
+            guard newProperties.count > index else {
+                break
+            }
+            
+            let previousProperty = conversion.property
+            let newProperty = newProperties[index]
+            
+            guard newProperty.isEqual(previousProperty) else {
+                break
+            }
+            
+            lastMergeableIndex = index
+        }
+        
+        guard lastMergeableIndex >= 0 else {
+            return nil
+        }
+        
+        // If the last element is not preformatted, it needs to be dropped because the only
+        // way to represent a newline (a paragraph interruption) is by interrupting the last
+        // block-level HTML element (or in this case, by not merging it).
+        //
+        // If the last element is preformatted, we can just output a regular newline character,
+        // since it won't be sanitized by the HTML parsers, so there's no need to interrupt the
+        // last block-level element.
+        //
+        if !previousConversions[lastMergeableIndex].preformatted {
+            guard lastMergeableIndex > 0 else {
+                return nil
+            }
+            
+            lastMergeableIndex -= 1
+        }
+        
+        return previousConversions.prefix(through: lastMergeableIndex)
+    }
+    
+    private func merge(_ newProperties: [ParagraphProperty], into previousConversions: [ParagraphPropertyConversion]) -> [ParagraphPropertyConversion]? {
+        guard let mergeableConversions = self.mergeableConversions(from: previousConversions, for: newProperties),
+            let lastMergeableElementNode = mergeableConversions.last?.elementNode else {
+                return nil
+        }
+        
+        let unmergeableConversions: [ParagraphPropertyConversion]
+        
+        if mergeableConversions.count < newProperties.count {
+            let firstUnmergedIndex = mergeableConversions.count
+            
+            unmergeableConversions = convert(newProperties[firstUnmergedIndex ..< newProperties.count])
+        } else {
+            unmergeableConversions = []
+        }
+        
+        if let firstUnmergeableElementNode = unmergeableConversions.first?.elementNode {
+            lastMergeableElementNode.children.append(firstUnmergeableElementNode)
+        }
+        
+        return mergeableConversions + unmergeableConversions
+    }
+
+    /// Parses an attributed string and returns the corresponding HTML tree.
+    ///
+    /// - Parameters:
+    ///     - attrString: the attributed string to parse
+    ///
+    /// - Returns: the HTML tree.
+    ///
+    func parse(_ attrString: NSAttributedString) -> RootNode {
+        var nodes = [Node]()
+        var previousParagraphConversions = [ParagraphPropertyConversion]()
+        
+        /// This internal mini-method just "submits" the previous conversions.
+        /// It appends the root element from that conversion into the result.
+        func submitPreviousConversions() {
+            if let firstConversion = previousParagraphConversions.first {
+                nodes.append(firstConversion.elementNode)
+            }
+        }
+
+        attrString.enumerateParagraphRanges(spanning: attrString.rangeOfEntireString) { (paragraphRange, enclosingRange) in
+            
+            let attributes = attrString.attributes(at: paragraphRange.location, effectiveRange: nil)
+            let newProperties = self.paragraphProperties(from: attributes)
+            
+            if let mergedConversions = merge(newProperties, into: previousParagraphConversions) {
+                previousParagraphConversions = mergedConversions
+            } else {
+                submitPreviousConversions()
+                
+                previousParagraphConversions = convert(ArraySlice(newProperties))
+            }
+            
+            let styleNodes = createNodes(from: attrString, paragraphRange: paragraphRange, enclosingRange: enclosingRange)
+            append(styleNodes, to: previousParagraphConversions)
+        }
+        
+        submitPreviousConversions()
+
+        return RootNode(children: nodes)
+    }
+
+
+    /// Converts a Substring, defined by it's paragraphRange and enclosingRange, into a collection of Nodes,
+    /// representing the internal HTML Entities.
+    ///
+    /// Note:
+    /// Whenever the paragraph defined by the paragraphRange is zero, we'll proceed extracting all of the attributes
+    /// present in the Enclosing Range. Otherwise, we might loose data!
+    ///
+    /// - Parameter:
+    ///     - attrString: Reference to the document to be converted.
+    ///     - paragraphRange: Defines the Paragraph Range to be converted into Nodes.
+    ///     - enclosingRange: Defines the Paragraph's Enclosing Range (containing newline characters).
+    ///
+    /// - Returns: Array of Node instances.
+    ///
+    private func createNodes(from attrString: NSAttributedString, paragraphRange: NSRange, enclosingRange: NSRange) -> [Node] {
+        guard paragraphRange.length > 0 else {
+            let attributes = attrString.attributes(at: enclosingRange.location, longestEffectiveRange: nil, in: enclosingRange)
+            return createNodes(from: attributes)
+        }
+
+        let paragraph = attrString.attributedSubstring(from: paragraphRange)
+        return createNodes(from: paragraph)
+    }
+
+
+    /// Converts a *Paragraph* into a collection of Nodes, representing the internal HTML Entities.
+    ///
+    /// - Parameter paragraph: Paragraph's Attributed String that should be converted.
+    ///
+    /// - Returns: Array of Node instances.
+    ///
+    private func createNodes(from paragraph: NSAttributedString) -> [Node] {
+        guard paragraph.length > 0 else {
+            return []
+        }
+
+        var branches = [Branch]()
+
+        paragraph.enumerateAttributes(in: paragraph.rangeOfEntireString, options: []) { (attrs, range, _) in
+
+            let substring = paragraph.attributedSubstring(from: range)
+            let leafNodes = createLeafNodes(from: substring)
+            let styleNodes = createStyleNodes(from: attrs)
+
+            let branch = Branch(nodes: styleNodes, leaves: leafNodes)
+            branches.append(branch)
+        }
+
+        return process(branches: branches)
+    }
+
+
+    /// Converts a collection of Attributes into their Node(s) representation.
+    ///
+    /// - Parameter attributes: Attributes to be mapped into nodes
+    ///
+    /// - Returns: Array of Node instances.
+    ///
+    private func createNodes(from attributes: [NSAttributedStringKey: Any]) -> [Node] {
+        let nodes = createParagraphNodes(from: attributes) + createStyleNodes(from: attributes)
+
+        return nodes.reversed().reduce([]) { (result, node) in
+            node.children = result
+            return [node]
+        }
+    }
+}
+
+
+// MARK: - Merge: Helpers
+//
+private extension NewAttributedStringParser {
+
+    /// Defines a Tree Branch: Collection of Nodes, with a set of Leaves
+    ///
+    typealias Branch = (nodes: [ElementNode], leaves: [Node])
+
+
+    /// Defines a pair of Nodes that can be merged
+    ///
+    private struct MergeablePair {
+        let left: ElementNode
+        let right: ElementNode
+        let preformatted: Bool
+    }
+
+
+    /// Sets Up a collection of Nodes and Leaves as a chain of Parent-Children, and returns the root node.and
+    /// If the collection of nodes is empty, will return the leaves parameters 'as is'.
+    ///
+    func reduce(nodes: [ElementNode], leaves: [Node]) -> [Node] {
+        return nodes.reduce(leaves) { (result, node) in
+            node.children = result
+            return [node]
+        }
+    }
+
+
+    /// Finds the Deepest node that can be merged "Right to Left", and returns the Left / Right matching touple, if any.
+    ///
+    private func findMergeableNodes(left leftElements: [ElementNode], right rightElements: [ElementNode], blocklevelEnforced: Bool = true) -> [MergeablePair]? {
+        var currentIndex = 0
+        var matching = [MergeablePair]()
+        var preformatted = false
+
+        while currentIndex < leftElements.count && currentIndex < rightElements.count {
+            let left = leftElements[currentIndex]
+            let right = rightElements[currentIndex]
+
+            guard canMergeNodes(left:left, right: right, blocklevelEnforced: blocklevelEnforced) else {
+                break
+            }
+            
+            if left.type == .pre {
+                // Once we find a `<pre>` node, all children become preformatted.
+                preformatted = true
+            }
+
+            let pair = MergeablePair(left: left, right: right, preformatted: preformatted)
+            matching.append(pair)
+            currentIndex += 1
+        }
+
+        return matching.isEmpty ? nil : matching
+    }
+
+    /// Indicates whether the children of the specified node can be merged in, or not.
+    ///
+    /// - Parameters:
+    ///     - node: Target node for which we'll determine Merge-ability status.
+    ///
+    /// - Returns: true if both nodes can be merged, or not.
+    ///
+    func canMergeNodes(left: ElementNode, right: ElementNode, blocklevelEnforced: Bool) -> Bool {
+        guard left.name == right.name && Set(left.attributes) == Set(right.attributes) else {
+            return false
+        }
+
+        guard blocklevelEnforced else {
+            return Element.mergeableStyleElements.contains(left.type)
+        }
+
+        return Element.mergeableBlockLevelElements.contains(left.type)
+    }
+}
+
+
+// MARK: - Merge: Styles
+//
+private extension NewAttributedStringParser {
+
+    /// Given a collection of branches, this method will iterate branch by branch and will:
+    ///
+    /// A. Reduce the Nodes: An actuall Parent/Child relationship will be set
+    /// B. Attempt to merge the current Branch with the Previous Branch
+    /// C. Return the collection of Reduced + Merged Nodes
+    ///
+    func process(branches: [Branch]) -> [Node] {
+        let sorted = sort(branches: branches)
+        var merged = [Node]()
+        var previous: Branch?
+
+        for branch in sorted {
+            if let left = previous , let current = merge(left: left, right: branch) {
+                previous = current
+                continue
+            }
+
+            let reduced = reduce(nodes: branch.nodes.reversed(), leaves: branch.leaves)
+            merged.append(contentsOf: reduced)
+            previous = branch
+        }
+
+        return merged
+    }
+
+
+    /// Attempts to merge the Right Branch into the Left Branch. On success, we'll return a newly created
+    /// branch, containing the 'Left-Matched-Elements' + 'Right-Unmathed-Elements' + 'Right-Leaves'.
+    ///
+    private func merge(left: Branch, right: Branch) -> Branch? {
+        guard let mergeableCandidate = findMergeableNodes(left: left.nodes, right: right.nodes, blocklevelEnforced: false),
+            let target = mergeableCandidate.last?.left
+        else {
+            return nil
+        }
+
+        let mergeableLeftNodes = mergeableCandidate.compactMap { $0.left }
+        let mergeableRightNodes = mergeableCandidate.compactMap { $0.right }
+
+        // Reduce: Non Mergeable Right Subtree
+        let nonMergeableRightNodesSet = Set(right.nodes).subtracting(mergeableRightNodes)
+        let nonMergeableRightNodes = Array(nonMergeableRightNodesSet)
+
+        let source = reduce(nodes: nonMergeableRightNodes, leaves: right.leaves)
+
+        // Merge: Move the 'Non Mergeable Right Subtree' to the left merging spot
+        target.children += source
+
+        // Regen: Branch with the actual used instances!
+        let mergedNodes = mergeableLeftNodes + nonMergeableRightNodes
+        return Branch(nodes: mergedNodes, leaves: right.leaves)
+    }
+
+
+    /// Arranges a collection of Branches in a (Hopefully) "Defragmented" way:
+    ///
+    /// - Nodes will be sorted 'By Length'. Longer nodes will appear on top
+    /// - Nodes that existed in the previous branch are expected to maintain the exact same position
+    ///
+    private func sort(branches: [Branch]) -> [Branch] {
+        var output = [Branch]()
+        var previous = [ElementNode]()
+
+        for (index, branch) in branches.enumerated() {
+            let lengths = lengthOfElements(atColumnIndex: index, in: branches)
+
+            // Split Duplicates: Nodes that existed in the previous collection (while retaining their original position!)
+            let (sorted, unsorted) = splitDuplicateNodes(in: branch.nodes, comparingWith: previous)
+
+            // Sort 'Branch New Items' + Consolidate
+            let consolidated = sorted + unsorted.sorted(by: { lengths[$0]! > lengths[$1]! })
+
+            let updated = Branch(nodes: consolidated, leaves: branch.leaves)
+            output.append(updated)
+            previous = consolidated
+        }
+
+        return output
+    }
+
+
+    /// Splits a collection of Nodes in two groups: 'Nodes that also exist in a Reference Collection', and
+    /// 'Completely New Nodes'. 
+    ///
+    /// *Note*: The order of those Pre Existing nodes will be arranged in the exact same way as they appear
+    /// in the reference collection.
+    ///
+    @inline(__always)
+    private func splitDuplicateNodes(in current: [ElementNode], comparingWith previous: [ElementNode]) -> ([ElementNode], [ElementNode]) {
+        var duplicates = [ElementNode]()
+        var nonDuplicates = [ElementNode]()
+
+        for node in previous where current.contains(node) {
+            guard let index = current.index(of: node) else {
+                continue
+            }
+
+            let target = current[index]
+            duplicates.append(target)
+        }
+
+        for node in current where !duplicates.contains(node) {
+            nonDuplicates.append(node)
+        }
+
+        return (duplicates, nonDuplicates)
+    }
+
+
+    /// Determines the length of (ALL) of the Nodes at a specified Column, given a collection of Branches.
+    ///
+    @inline(__always)
+    private func lengthOfElements(atColumnIndex index: Int, in branches: [Branch]) -> [ElementNode: Int] {
+        var lengths = [ElementNode: Int]()
+        var rightmost = branches
+        rightmost.removeFirst(index)
+
+        for node in branches[index].nodes {
+            lengths[node] = length(of: node, in: rightmost)
+        }
+
+        return lengths
+    }
+
+
+    /// Determines the length of a Node, given a collection of branches.
+    ///
+    @inline(__always)
+    private func length(of element: ElementNode, in branches: [Branch]) -> Int {
+        var length = 0
+
+        for branch in branches {
+            if !branch.nodes.contains(element) {
+                break
+            }
+
+            length += 1
+        }
+
+        return length
+    }
+}
+
+
+// MARK: - Merge: Paragraphs
+//
+private extension NewAttributedStringParser {
+
+    /// Attempts to merge the Right array of Element Nodes (Paragraph Level) into the Left array of Nodes.
+    ///
+    func merge(left: [ElementNode], right: [ElementNode]) -> Bool {
+        guard let mergeableCandidates = findMergeableNodes(left: left, right: right) else {
+            return false
+        }
+
+        guard let mergeablePair = mergeablePair(from: mergeableCandidates) else {
+            return false
+        }
+
+        // Pre has a custom joining logic because it joins different paragraphs without removing the paragraph separator.
+        let junctureNodes: [Node] = mergeablePair.preformatted ? [TextNode(text: String(.paragraphSeparator))] : []
+        
+        mergeablePair.left.children = mergeablePair.left.children + junctureNodes + mergeablePair.right.children
+
+        return true
+    }
+
+
+    /// Finds the last valid Mergeable Pair within a collection of mergeable nodes
+    ///
+    /// - Last LI item is never merged
+    /// - Last 'Mergeable' element is never merged (ie. <h1>Hello\nWorld</h1> >> <h1>Hello</h1><h1>World</h1>
+    ///
+    private func mergeablePair(from mergeableNodes: [MergeablePair]) -> MergeablePair? {
+        assert(mergeableNodes.count > 0)
+        
+        guard let lastMergeablePair = mergeableNodes.last else {
+            return nil
+        }
+        
+        let lastNodeName = lastMergeablePair.left.name
+        var mergeCandidates: ArraySlice<MergeablePair>
+        
+        // Whenever the last mergeable nodes are preformatted (either because they're `<pre>` or a child
+        // of a `<pre>` element), they can be merged without dropping the last mergeable pair.  This is because
+        // they'll be joined with an actual paragraph separator character.
+        if lastMergeablePair.preformatted || lastMergeablePair.left.type == .figure {
+            mergeCandidates = ArraySlice<MergeablePair>(mergeableNodes)
+        } else {
+            mergeCandidates = mergeableNodes.dropLast()
+            
+            if let last = mergeCandidates.last,
+                Element.mergeableBlocklevelElementsSingleChildren.contains(last.left.type) {
+                
+                mergeCandidates = mergeCandidates.dropLast()
+            }
+        }
+
+        if lastNodeName != Element.li.rawValue {
+            mergeCandidates = prefix(upToLast: Element.li.rawValue, from: mergeCandidates)
+        }
+        
+        return mergeCandidates.last
+    }
+
+
+    /// Slices the specified array until the last LI node. For instance:
+    ///
+    /// - Input: [.ul, .li, .h1]
+    ///
+    /// - Output: [.ul]
+    ///
+    private func prefix(upToLast name: String, from nodes: ArraySlice<MergeablePair>) -> ArraySlice<MergeablePair> {
+        var lastItemIndex: Int?
+        for (index, node) in nodes.enumerated().reversed() where node.left.name == name {
+            lastItemIndex = index
+            break
+        }
+
+        guard let sliceIndex = lastItemIndex else {
+            return nodes
+        }
+
+        return nodes[0..<sliceIndex]
+    }
+}
+
+
+// MARK: - Paragraph Nodes Extraction
+//
+extension NewAttributedStringParser {
+
+    /// Returns the "Rightmost" Blocklevel Node from a collection fo nodes.
+    ///
+    func rightmostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
+        return paragraphStyleElements(from: nodes) { children in
+            return children.last
+        }
+    }
+
+
+    /// Returns the "Leftmost" Blocklevel Node from a collection fo nodes.
+    ///
+    func leftmostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
+        return paragraphStyleElements(from: nodes) { children in
+            return children.first
+        }
+    }
+
+
+    /// Returns a children Blocklevel Node from a collection of nodes, using a Child Picker to determine the
+    /// navigational-direction.
+    ///
+    private func paragraphStyleElements(from nodes: [Node], childPicker: (([Node]) -> Node?)) -> [ElementNode] {
+        var elements = [ElementNode]()
+        var nextElement = childPicker(nodes) as? ElementNode
+
+        while let currentElement = nextElement {
+            guard currentElement.isBlockLevel() else {
+                break
+            }
+
+            elements.append(currentElement)
+            nextElement = childPicker(currentElement.children) as? ElementNode
+        }
+
+        return elements
+    }
+}
+
+
+// MARK: - Paragraph Nodes: Allocation
+//
+private extension NewAttributedStringParser {
+
+    /// Extracts the ElementNodes contained within a Paragraph's AttributedString.
+    ///
+    /// - Parameters:
+    ///     - attrString: Paragraph's AttributedString from which we intend to extract the ElementNode
+    ///
+    /// - Returns: ElementNode representing the specified Paragraph.
+    ///
+    func createParagraphNodes(from paragraph: NSAttributedString) -> [ElementNode] {
+        let paragraphStyle = (paragraph.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? ParagraphStyle) ?? ParagraphStyle()
+
+        return createParagraphNodes(from: paragraphStyle)
+    }
+
+
+    /// Extracts the ElementNodes contained within a Paragraph's AttributedString.
+    ///
+    /// - Parameters:
+    ///     - attributes: Paragraph's Attributes from which we intend to extract the ElementNode
+    ///
+    /// - Returns: ElementNode representing the specified Paragraph.
+    ///
+    func createParagraphNodes(from attributes: [NSAttributedStringKey: Any]) -> [ElementNode] {
+        let paragraphStyle = (attributes[.paragraphStyle] as? ParagraphStyle) ?? ParagraphStyle()
+
+        return createParagraphNodes(from: paragraphStyle)
+    }
+
+
+    /// Extracts the ElementNodes contained within a ParagraphStyle Instance.
+    ///
+    /// - Parameters:
+    ///     - paragraphStyle: ParagraphStyle from which we intend to extract the ElementNode
+    ///
+    /// - Returns: ElementNode representing the specified Paragraph.
+    ///
+    private func createParagraphNodes(from paragraphStyle: ParagraphStyle) -> [ElementNode] {
+        let extraAttributes = attributes(for: paragraphStyle)
+        
+        // If we're unable to find any paragraph-level styles, we return an HTML paragraph element as
+        // default.  The reason behind this decision is that no text can exist outside block-level
+        // elements in Aztec.
+        //
+        // See here for more info:
+        // https://github.com/wordpress-mobile/AztecEditor-iOS/issues/667
+        //
+        guard paragraphStyle.properties.count > 0 else {
+            return [ElementNode(type: .p, attributes: extraAttributes)]
+        }
+        
+        var paragraphNodes = [ElementNode]()
+        
+        for property in paragraphStyle.properties.reversed() {
+            
+            // The customizer overrides any default behaviour, which is the reason why it's run first.
+            if let element = customizer?.convert(property) {
+                paragraphNodes.append(element)
+                continue
+            }
+            
+            switch property {
+            case let blockquote as Blockquote:
+                let element = processBlockquoteStyle(blockquote: blockquote)
+                paragraphNodes.append(element)
+                
+            case let figcaption as Figcaption:
+                let element = processFigcaptionStyle(figcaption: figcaption)
+                paragraphNodes.append(element)
+
+            case let figure as Figure:
+                let element = processFigureStyle(figure: figure)
+                paragraphNodes.append(element)
+                
+            case let header as Header:
+                guard let element = processHeaderStyle(header: header) else {
+                    continue
+                }
+                paragraphNodes.append(element)
+
+            case let list as TextList:
+                let element = processListStyle(list: list)
+                paragraphNodes.append(element)
+
+            case let listItem as HTMLLi:
+                let element = processListItem(listItem: listItem)
+                paragraphNodes.append(element)
+
+            case let div as HTMLDiv:
+                let element = processDivStyle(div: div)
+                paragraphNodes.append(element)
+
+            case let paragraph as HTMLParagraph:
+                let element = processParagraphStyle(paragraph: paragraph)
+                paragraphNodes.append(element)
+
+            case let pre as HTMLPre:
+                let element = processPreStyle(pre: pre)
+                paragraphNodes.append(element)
+
+            default:
+                continue
+            }
+        }
+        
+        if let lastElement = paragraphNodes.last {
+            lastElement.attributes.append(contentsOf: extraAttributes)
+        }
+        
+        return paragraphNodes
+    }
+    
+    private func createParagraphElementNodes(from properties: [ParagraphProperty]) -> [ElementNode] {
+        return properties.compactMap({ (property) -> ElementNode? in
+            
+            // The customizer overrides any default behaviour, which is the reason why it's run first.
+            if let element = customizer?.convert(property) {
+                return element
+            }
+            
+            switch property {
+            case let blockquote as Blockquote:
+                let element = processBlockquoteStyle(blockquote: blockquote)
+                return element
+                
+            case let figcaption as Figcaption:
+                let element = processFigcaptionStyle(figcaption: figcaption)
+                return element
+                
+            case let figure as Figure:
+                let element = processFigureStyle(figure: figure)
+                return element
+                
+            case let header as Header:
+                guard let element = processHeaderStyle(header: header) else {
+                    return nil
+                }
+                return element
+                
+            case let list as TextList:
+                let element = processListStyle(list: list)
+                return element
+                
+            case let listItem as HTMLLi:
+                let element = processListItem(listItem: listItem)
+                return element
+                
+            case let div as HTMLDiv:
+                let element = processDivStyle(div: div)
+                return element
+                
+            case let paragraph as HTMLParagraph:
+                let element = processParagraphStyle(paragraph: paragraph)
+                return element
+                
+            case let pre as HTMLPre:
+                let element = processPreStyle(pre: pre)
+                return element
+                
+            default:
+                return nil
+            }
+        })
+    }
+    
+    /// Processes the paragraph style to figure out the attributes that will be applied to the outermost Element
+    /// produced from it.
+    ///
+    /// - Parameters:
+    ///     - paragraphStyle: the paragraph style to process.
+    ///
+    /// - Returns: any attributes necessary to represent the paragraph values.
+    ///
+    private func attributes(for paragraphStyle: ParagraphStyle) -> [Attribute] {
+        var attributes = [Attribute]()
+        
+        if paragraphStyle.baseWritingDirection == .rightToLeft {
+            let rtlAttribute = Attribute(name: "dir", value: .string("rtl"))
+            
+            attributes.append(rtlAttribute)
+        }
+        
+        return attributes
+    }
+
+
+    /// Extracts all of the Blockquote Elements contained within a collection of Attributes.
+    ///
+    private func processBlockquoteStyle(blockquote: Blockquote) -> ElementNode {
+
+        guard let representation = blockquote.representation,
+            case let .element(element) = representation.kind else {
+
+            return ElementNode(type: .blockquote)
+        }
+
+        return element.toElementNode()
+    }
+
+
+    /// Extracts all of the Div Elements contained within a collection of Attributes.
+    ///
+    private func processDivStyle(div: HTMLDiv) -> ElementNode {
+
+        guard let representation = div.representation,
+            case let .element(representationElement) = representation.kind
+        else {
+            return ElementNode(type: .div)
+        }
+
+        return representationElement.toElementNode()
+    }
+    
+    
+    private func processFigcaptionStyle(figcaption: Figcaption) -> ElementNode {
+        
+        let element: ElementNode
+        
+        if let representation = figcaption.representation,
+            case let .element(representationElement) = representation.kind {
+            
+            element = representationElement.toElementNode()
+        } else {
+            element = ElementNode(type: .figcaption)
+        }
+        
+        return element
+    }
+    
+    
+    private func processFigureStyle(figure: Figure) -> ElementNode {
+        
+        let element: ElementNode
+        
+        if let representation = figure.representation,
+            case let .element(representationElement) = representation.kind {
+            
+            element = representationElement.toElementNode()
+        } else {
+            element = ElementNode(type: .figure)
+        }
+        
+        return element
+    }
+
+
+    /// Extracts all of the Header Elements contained within a collection of Attributes.
+    ///
+    private func processHeaderStyle(header: Header) -> ElementNode? {
+        guard let type = ElementNode.elementTypeForHeaderLevel(header.level.rawValue) else {
+            return nil
+        }
+
+        guard let representation = header.representation,
+            case let .element(element) = representation.kind else {
+
+                return ElementNode(type: type)
+        }
+
+        return element.toElementNode()
+    }
+
+
+    /// Extracts all of the List Elements contained within a collection of Attributes.
+    ///
+    private func processListStyle(list: TextList) -> ElementNode {
+        let listType = list.style == .ordered ? Element.ol : Element.ul
+
+        let listElement: ElementNode
+
+        if let representation = list.representation,
+            case let .element(element) = representation.kind {
+
+            listElement = element.toElementNode()
+        } else {
+            listElement = ElementNode(type: listType)
+        }
+
+        return listElement
+    }
+
+    private func processListItem(listItem: HTMLLi) -> ElementNode {
+
+        let lineElement: ElementNode
+
+        if let representation = listItem.representation,
+            case let .element(element) = representation.kind {
+
+            lineElement = element.toElementNode()
+        } else {
+            lineElement = ElementNode(type: .li)
+        }
+
+        return lineElement
+    }
+
+
+    /// Extracts all of the Paragraph Elements contained within a collection of Attributes.
+    ///
+    private func processParagraphStyle(paragraph: HTMLParagraph) -> ElementNode {
+
+        let element: ElementNode
+
+        if let representation = paragraph.representation,
+            case let .element(representationElement) = representation.kind {
+
+            element = representationElement.toElementNode()
+        } else {
+            element = ElementNode(type: .p)
+        }
+
+        return element
+    }
+
+
+    /// Extracts all of the Pre Elements contained within a collection of Attributes.
+    ///
+    private func processPreStyle(pre: HTMLPre) -> ElementNode {
+
+        let element: ElementNode
+
+        if let representation = pre.representation,
+            case let .element(representationElement) = representation.kind {
+
+            element = representationElement.toElementNode()
+        } else {
+            element = ElementNode(type: .pre)
+        }
+
+        return element
+    }
+}
+
+
+// MARK: - Style Nodes: Allocation
+//
+private extension NewAttributedStringParser {
+
+    /// Extracts all of the Style Nodes contained within a collection of AttributedString Attributes.
+    ///
+    /// - Parameters:
+    ///     - attrs: Collection of attributes that should be converted.
+    ///
+    /// - Returns: Style Nodes contained within the specified collection of attributes
+    ///
+    func createStyleNodes(from attributes: [NSAttributedStringKey: Any]) -> [ElementNode] {
+        var nodes = [ElementNode]()
+
+        if let element = processBold(in: attributes) {
+            nodes.append(element)
+        }
+
+        if let element = processItalic(in: attributes) {
+            nodes.append(element)
+        }
+
+        if let element = processLinkStyle(in: attributes) {
+            nodes.append(element)
+        }
+
+        if let element = processStrikethruStyle(in: attributes) {
+            nodes.append(element)
+        }
+
+        if let element = processUnderlineStyle(in: attributes) {
+            nodes.append(element)
+        }
+
+        if let element = processCodeStyle(in: attributes) {
+            nodes.append(element)
+        }        
+
+        nodes += processUnsupportedHTML(in: attributes)
+
+        return nodes
+    }
+
+    private func processBold(in attributes: [NSAttributedStringKey: Any]) -> ElementNode? {
+        guard let font = attributes[.font] as? UIFont,
+            font.containsTraits(.traitBold) else {
+                return nil
+        }
+
+        let element: ElementNode
+
+        if let representation = attributes[NSAttributedStringKey.boldHtmlRepresentation] as? HTMLRepresentation,
+            case let .element(representationElement) = representation.kind {
+
+            element = representationElement.toElementNode()
+        } else {
+            element = ElementNode(type: .strong)
+        }
+
+        return element
+    }
+
+
+    private func processItalic(in attributes: [NSAttributedStringKey: Any]) -> ElementNode? {
+        guard let font = attributes[.font] as? UIFont,
+            font.containsTraits(.traitItalic) else {
+                return nil
+        }
+
+        let element: ElementNode
+
+        if let representation = attributes[NSAttributedStringKey.italicHtmlRepresentation] as? HTMLRepresentation,
+            case let .element(representationElement) = representation.kind {
+
+            element = representationElement.toElementNode()
+        } else if let representation = attributes[NSAttributedStringKey.citeHtmlRepresentation] as? HTMLRepresentation,
+            case let .element(representationElement) = representation.kind {
+
+            element = representationElement.toElementNode()
+        } else {
+            element = ElementNode(type: .em)
+        }
+
+        return element
+    }
+
+    /// Extracts all of the Link Elements contained within a collection of Attributes.
+    ///
+    private func processLinkStyle(in attributes: [NSAttributedStringKey: Any]) -> ElementNode? {
+        var urlString = ""
+        if let url = attributes[NSAttributedStringKey.link] as? URL {
+            urlString = url.absoluteString
+        } else if let link = attributes[NSAttributedStringKey.link] as? String {
+            urlString = link
+        } else {
+            return nil
+        }
+
+        let element: ElementNode
+
+        if let representation = attributes[.linkHtmlRepresentation] as? HTMLRepresentation,
+            case let .element(representationElement) = representation.kind {
+
+            element = representationElement.toElementNode()
+        } else {
+            element = ElementNode(type: .a)
+        }
+
+        element.updateAttribute(named: HTMLLinkAttribute.Href.rawValue, value: .string(urlString))
+
+        return element
+    }
+
+
+    /// Extracts all of the Strike Elements contained within a collection of Attributes.
+    ///
+    private func processStrikethruStyle(in attributes: [NSAttributedStringKey: Any]) -> ElementNode? {
+        guard attributes[NSAttributedStringKey.strikethroughStyle] != nil else {
+            return nil
+        }
+
+        if let representation = attributes[NSAttributedStringKey.strikethroughHtmlRepresentation] as? HTMLRepresentation,
+            case let .element(representationElement) = representation.kind {
+
+            return representationElement.toElementNode()
+        }
+
+        return ElementNode(type: .strike)
+    }
+
+
+    /// Extracts all of the Underline Elements contained within a collection of Attributes.
+    ///
+    private func processUnderlineStyle(in attributes: [NSAttributedStringKey: Any]) -> ElementNode? {
+        guard attributes[.underlineStyle] != nil else {
+            return nil
+        }
+
+        if let representation = attributes[.underlineHtmlRepresentation] as? HTMLRepresentation,
+            case let .element(representationElement) = representation.kind {
+
+            return representationElement.toElementNode()
+        }
+
+        return ElementNode(type: .u)
+    }
+
+    /// Extracts all of the Code Elements contained within a collection of Attributes.
+    ///
+    private func processCodeStyle(in attributes: [NSAttributedStringKey: Any]) -> ElementNode? {
+        guard attributes[.codeHtmlRepresentation] is HTMLRepresentation else {
+            return nil
+        }
+
+        return ElementNode(type: .code)
+    }
+
+    /// Extracts all of the Unsupported HTML Snippets contained within a collection of Attributes.
+    ///
+    private func processUnsupportedHTML(in attributes: [NSAttributedStringKey: Any]) -> [ElementNode] {
+        guard let unsupportedHTML = attributes[.unsupportedHtml] as? UnsupportedHTML else {
+            return []
+        }
+
+        return unsupportedHTML.representations.map { representation in
+            return representation.toElementNode()
+        }
+    }
+}
+
+
+// MARK: - Leaf Nodes: Allocation
+//
+private extension NewAttributedStringParser {
+
+    /// Extract all of the Leaf Nodes contained within an Attributed String. We consider the following as Leaf:
+    /// Plain Text, Attachments of any kind [Line, Comment, HTML, Image].
+    ///
+    /// - Parameter attrString: AttributedString that should be converted.
+    ///
+    /// - Returns: Leaf Nodes contained within the specified collection of attributes
+    ///
+    func createLeafNodes(from attrString: NSAttributedString) -> [Node] {
+        
+        var nodes = [Node]()
+        
+        if let attachment = attrString.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment {
+            let attributes = attrString.attributes(at: 0, effectiveRange: nil)
+            
+            if let newNodes = customizer?.convert(attachment, attributes: attributes) {
+                nodes += newNodes
+            } else {
+                for converter in attachmentConverters {
+                    if let newNodes = converter.convert(attachment, attributes: attributes) {
+                        nodes += newNodes
+                        break
+                    }
+                }
+            }
+        }
+
+        return nodes.isEmpty ? processTextNodes(from: attrString.string) : nodes
+    }
+
+    /// Converts a String into it's representing nodes.
+    ///
+    private func processTextNodes(from text: String) -> [Node] {
+        let substrings = text.components(separatedBy: String(.lineSeparator))
+        var output = [Node]()
+
+        for (index, substring) in substrings.enumerated() {
+
+            output.append(TextNode(text: substring))
+
+            if index < substrings.count - 1 {
+                output.append(ElementNode(type: .br))
+            }
+        }
+        
+        return output
+    }
+}

--- a/Aztec/Classes/NSAttributedString/Conversions/NewAttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/NewAttributedStringParser.swift
@@ -26,27 +26,15 @@ class NewAttributedStringParser {
         VideoAttachmentToElementConverter(),
     ]
     
-    // MARK: - Parsing
+    // MARK: - Internal Data Structures
     
-    struct ParagraphPropertyConversion {
+    private struct ParagraphPropertyConversion {
         let property: ParagraphProperty
         let elementNode: ElementNode
         let preformatted: Bool
     }
     
-    private func paragraphProperties(from attributes: [NSAttributedStringKey: Any]) -> [ParagraphProperty] {
-        guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle else {
-            return []
-        }
-        
-        return paragraphStyle.properties
-    }
-    
-    private func paragraphProperties(from conversions: [ParagraphPropertyConversion]) -> [ParagraphProperty] {
-        return conversions.map({ (conversion) -> ParagraphProperty in
-            return conversion.property
-        })
-    }
+    // MARK: - Parsing
     
     private func append(_ nodes: [Node], to conversions: [ParagraphPropertyConversion]) {
         precondition(conversions.count > 0)
@@ -54,179 +42,6 @@ class NewAttributedStringParser {
         let lastConversion = conversions.last!
         
         lastConversion.elementNode.children.append(contentsOf: nodes)
-    }
-    
-    private func convert(_ properties: ArraySlice<ParagraphProperty>) -> [ParagraphPropertyConversion] {
-        var preformatted = false
-        var parentElementNode: ElementNode?
-        
-        /// Updates the parent.
-        ///
-        func updateParent(for elementNode: ElementNode) {
-            defer {
-                // No matter what exit point we take, the provided element will
-                // be set as the parent after this method is executed.
-                parentElementNode = elementNode
-            }
-            
-            guard let previousParentElementNode = parentElementNode else {
-                return
-            }
-            
-            previousParentElementNode.children.append(elementNode)
-        }
-        
-        let conversions = properties.compactMap({ (property) -> ParagraphPropertyConversion? in
-            guard let conversion = convert(property, preformatted: &preformatted) else {
-                return nil
-            }
-            
-            updateParent(for: conversion.elementNode)
-            return conversion
-        })
-        
-        // We don't allow not having at least 1 block-level element, so we enforce a
-        // paragraph element in that case.
-        guard conversions.count > 0 else {
-            let defaultConversion = ParagraphPropertyConversion(property: HTMLParagraph(with: nil), elementNode: ElementNode(type: .p), preformatted: false)
-            return [defaultConversion]
-        }
-        
-        return conversions
-    }
-    
-    private func convert(_ property: ParagraphProperty, preformatted: inout Bool) -> ParagraphPropertyConversion? {
-        guard let elementNode = convert(property) else {
-            return nil
-        }
-        
-        preformatted = Element.preformattedElements.contains(elementNode.type)
-        
-        return ParagraphPropertyConversion(property: property, elementNode: elementNode, preformatted: preformatted)
-    }
-    
-    private func convert(_ property: ParagraphProperty) -> ElementNode? {
-        // The customizer overrides any default behaviour, which is the reason why it's run first.
-        if let element = customizer?.convert(property) {
-            return element
-        }
-        
-        switch property {
-        case let blockquote as Blockquote:
-            let element = processBlockquoteStyle(blockquote: blockquote)
-            return element
-            
-        case let figcaption as Figcaption:
-            let element = processFigcaptionStyle(figcaption: figcaption)
-            return element
-            
-        case let figure as Figure:
-            let element = processFigureStyle(figure: figure)
-            return element
-            
-        case let header as Header:
-            guard let element = processHeaderStyle(header: header) else {
-                return nil
-            }
-            return element
-            
-        case let list as TextList:
-            let element = processListStyle(list: list)
-            return element
-            
-        case let listItem as HTMLLi:
-            let element = processListItem(listItem: listItem)
-            return element
-            
-        case let div as HTMLDiv:
-            let element = processDivStyle(div: div)
-            return element
-            
-        case let paragraph as HTMLParagraph:
-            let element = processParagraphStyle(paragraph: paragraph)
-            return element
-            
-        case let pre as HTMLPre:
-            let element = processPreStyle(pre: pre)
-            return element
-            
-        default:
-            return nil
-        }
-    }
-    
-    /// Calculates which previous conversions can be merged for the new properties.
-    ///
-    private func mergeableConversions(from previousConversions: [ParagraphPropertyConversion], for newProperties: [ParagraphProperty]) -> ArraySlice<ParagraphPropertyConversion>? {
-        
-        var lastMergeableIndex = -1
-        
-        for (index, conversion) in previousConversions.enumerated() {
-            guard newProperties.count > index else {
-                break
-            }
-            
-            let previousProperty = conversion.property
-            let newProperty = newProperties[index]
-            
-            guard newProperty.isEqual(previousProperty) else {
-                break
-            }
-            
-            lastMergeableIndex = index
-        }
-        
-        guard lastMergeableIndex >= 0 else {
-            return nil
-        }
-        
-        let mergeableCount = lastMergeableIndex + 1
-        
-        // There are certain scenarios in which the last block-level element that's mergeable has to remain unmerged.
-        //
-        // The first way to represent a newline (a paragraph interruption) in HTML is by interrupting the "lowest" / "last"
-        // block-level element in a tree.
-        //
-        // As an alternative, preformatted blocks don't need to be broken because they respect their whitespace.  This means
-        // that a regular newline character is enough to break the paragraph.
-        //
-        let canKeepLastConversion =
-            mergeableCount < previousConversions.count // If the previous conversions have a block-level child, we can avoid breaking
-                || mergeableCount < newProperties.count // If the current conversions have a block-level child, we can avoid breaking
-                || previousConversions[lastMergeableIndex].preformatted // Preformatted blocks can be broken by a regular newline character
-
-        if !canKeepLastConversion {
-            guard lastMergeableIndex > 0 else {
-                return nil
-            }
-            
-            lastMergeableIndex -= 1
-        }
-        
-        return previousConversions.prefix(through: lastMergeableIndex)
-    }
-    
-    private func merge(_ newProperties: [ParagraphProperty], into previousConversions: [ParagraphPropertyConversion]) -> [ParagraphPropertyConversion]? {
-        guard let mergeableConversions = self.mergeableConversions(from: previousConversions, for: newProperties),
-            let lastMergeableElementNode = mergeableConversions.last?.elementNode else {
-                return nil
-        }
-        
-        let unmergeableConversions: [ParagraphPropertyConversion]
-        
-        if mergeableConversions.count < newProperties.count {
-            let firstUnmergedIndex = mergeableConversions.count
-            
-            unmergeableConversions = convert(newProperties[firstUnmergedIndex ..< newProperties.count])
-        } else {
-            unmergeableConversions = []
-        }
-        
-        if let firstUnmergeableElementNode = unmergeableConversions.first?.elementNode {
-            lastMergeableElementNode.children.append(firstUnmergeableElementNode)
-        }
-        
-        return mergeableConversions + unmergeableConversions
     }
 
     /// Parses an attributed string and returns the corresponding HTML tree.
@@ -251,14 +66,14 @@ class NewAttributedStringParser {
         attrString.enumerateParagraphRanges(spanning: attrString.rangeOfEntireString) { (paragraphRange, enclosingRange) in
             
             let attributes = attrString.attributes(at: paragraphRange.location, effectiveRange: nil)
-            let newProperties = self.paragraphProperties(from: attributes)
+            let paragraphStyle = attributes.paragraphStyle()
             
-            if let mergedConversions = merge(newProperties, into: previousParagraphConversions) {
+            if let mergedConversions = merge(paragraphStyle.properties, into: previousParagraphConversions) {
                 previousParagraphConversions = mergedConversions
             } else {
                 submitPreviousConversions()
                 
-                previousParagraphConversions = convert(ArraySlice(newProperties))
+                previousParagraphConversions = convert(ArraySlice(paragraphStyle.properties))
             }
             
             let styleNodes = createNodes(from: attrString, paragraphRange: paragraphRange, enclosingRange: enclosingRange)
@@ -330,7 +145,7 @@ class NewAttributedStringParser {
     /// - Returns: Array of Node instances.
     ///
     private func createNodes(from attributes: [NSAttributedStringKey: Any]) -> [Node] {
-        let nodes = createParagraphNodes(from: attributes) + createStyleNodes(from: attributes)
+        let nodes = createStyleNodes(from: attributes)
 
         return nodes.reversed().reduce([]) { (result, node) in
             node.children = result
@@ -569,126 +384,214 @@ private extension NewAttributedStringParser {
 // MARK: - Merge: Paragraphs
 //
 private extension NewAttributedStringParser {
-
-    /// Attempts to merge the Right array of Element Nodes (Paragraph Level) into the Left array of Nodes.
+    
+    /// Tries to merge an array of properties with the (property -> elementNode) conversions form the previous paragraph.
     ///
-    func merge(left: [ElementNode], right: [ElementNode]) -> Bool {
-        guard let mergeableCandidates = findMergeableNodes(left: left, right: right) else {
-            return false
+    /// - Parameters:
+    ///     - newProperties: the properties from the paragraph being converted.
+    ///     - previousConversions: the conversions used for the previous paragraph.
+    ///
+    /// -Returns: `nil` if no previous conversion can be re-used.
+    ///
+    private func merge(_ newProperties: [ParagraphProperty], into previousConversions: [ParagraphPropertyConversion]) -> [ParagraphPropertyConversion]? {
+        guard let mergeableConversions = self.mergeableConversions(from: previousConversions, for: newProperties),
+            let lastMergeableElementNode = mergeableConversions.last?.elementNode else {
+                return nil
         }
-
-        guard let mergeablePair = mergeablePair(from: mergeableCandidates) else {
-            return false
-        }
-
-        // Pre has a custom joining logic because it joins different paragraphs without removing the paragraph separator.
-        let junctureNodes: [Node] = mergeablePair.preformatted ? [TextNode(text: String(.paragraphSeparator))] : []
         
-        mergeablePair.left.children = mergeablePair.left.children + junctureNodes + mergeablePair.right.children
-
-        return true
+        let unmergeableConversions: [ParagraphPropertyConversion]
+        
+        if mergeableConversions.count < newProperties.count {
+            let firstUnmergedIndex = mergeableConversions.count
+            
+            unmergeableConversions = convert(newProperties[firstUnmergedIndex ..< newProperties.count])
+        } else {
+            unmergeableConversions = []
+        }
+        
+        if let firstUnmergeableElementNode = unmergeableConversions.first?.elementNode {
+            lastMergeableElementNode.children.append(firstUnmergeableElementNode)
+        }
+        
+        return mergeableConversions + unmergeableConversions
     }
-
-
-    /// Finds the last valid Mergeable Pair within a collection of mergeable nodes
+    
+    /// Calculates which previous conversions can be merged for the new properties.
     ///
-    /// - Last LI item is never merged
-    /// - Last 'Mergeable' element is never merged (ie. <h1>Hello\nWorld</h1> >> <h1>Hello</h1><h1>World</h1>
-    ///
-    private func mergeablePair(from mergeableNodes: [MergeablePair]) -> MergeablePair? {
-        assert(mergeableNodes.count > 0)
+    private func mergeableConversions(from previousConversions: [ParagraphPropertyConversion], for newProperties: [ParagraphProperty]) -> ArraySlice<ParagraphPropertyConversion>? {
         
-        guard let lastMergeablePair = mergeableNodes.last else {
+        var lastMergeableIndex = -1
+        
+        for (index, conversion) in previousConversions.enumerated() {
+            guard newProperties.count > index else {
+                break
+            }
+            
+            let previousProperty = conversion.property
+            let newProperty = newProperties[index]
+            
+            guard newProperty.isEqual(previousProperty) else {
+                break
+            }
+            
+            lastMergeableIndex = index
+        }
+        
+        guard lastMergeableIndex >= 0 else {
             return nil
         }
         
-        let lastNodeName = lastMergeablePair.left.name
-        var mergeCandidates: ArraySlice<MergeablePair>
+        let mergeableCount = lastMergeableIndex + 1
         
-        // Whenever the last mergeable nodes are preformatted (either because they're `<pre>` or a child
-        // of a `<pre>` element), they can be merged without dropping the last mergeable pair.  This is because
-        // they'll be joined with an actual paragraph separator character.
-        if lastMergeablePair.preformatted || lastMergeablePair.left.type == .figure {
-            mergeCandidates = ArraySlice<MergeablePair>(mergeableNodes)
-        } else {
-            mergeCandidates = mergeableNodes.dropLast()
-            
-            if let last = mergeCandidates.last,
-                Element.mergeableBlocklevelElementsSingleChildren.contains(last.left.type) {
-                
-                mergeCandidates = mergeCandidates.dropLast()
+        // There are certain scenarios in which the last block-level element that's mergeable has to remain unmerged.
+        //
+        // The first way to represent a newline (a paragraph interruption) in HTML is by interrupting the "lowest" / "last"
+        // block-level element in a tree.
+        //
+        // As an alternative, preformatted blocks don't need to be broken because they respect their whitespace.  This means
+        // that a regular newline character is enough to break the paragraph.
+        //
+        let canKeepLastConversion =
+            mergeableCount < previousConversions.count // If the previous conversions have a block-level child, we can avoid breaking
+                || mergeableCount < newProperties.count // If the current conversions have a block-level child, we can avoid breaking
+                || previousConversions[lastMergeableIndex].preformatted // Preformatted blocks can be broken by a regular newline character
+        
+        if !canKeepLastConversion {
+            guard lastMergeableIndex > 0 else {
+                return nil
             }
-        }
-
-        if lastNodeName != Element.li.rawValue {
-            mergeCandidates = prefix(upToLast: Element.li.rawValue, from: mergeCandidates)
+            
+            lastMergeableIndex -= 1
         }
         
-        return mergeCandidates.last
-    }
-
-
-    /// Slices the specified array until the last LI node. For instance:
-    ///
-    /// - Input: [.ul, .li, .h1]
-    ///
-    /// - Output: [.ul]
-    ///
-    private func prefix(upToLast name: String, from nodes: ArraySlice<MergeablePair>) -> ArraySlice<MergeablePair> {
-        var lastItemIndex: Int?
-        for (index, node) in nodes.enumerated().reversed() where node.left.name == name {
-            lastItemIndex = index
-            break
-        }
-
-        guard let sliceIndex = lastItemIndex else {
-            return nodes
-        }
-
-        return nodes[0..<sliceIndex]
+        return previousConversions.prefix(through: lastMergeableIndex)
     }
 }
 
 
-// MARK: - Paragraph Nodes Extraction
+// MARK: - Paragraph Properties Conversion
 //
 extension NewAttributedStringParser {
-
-    /// Returns the "Rightmost" Blocklevel Node from a collection fo nodes.
+    
+    /// Converts paragraph properties
     ///
-    func rightmostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
-        return paragraphStyleElements(from: nodes) { children in
-            return children.last
-        }
-    }
-
-
-    /// Returns the "Leftmost" Blocklevel Node from a collection fo nodes.
+    /// - Parameters:
+    ///     - properties: the properties to convert.
     ///
-    func leftmostParagraphStyleElements(from nodes: [Node]) -> [ElementNode] {
-        return paragraphStyleElements(from: nodes) { children in
-            return children.first
-        }
-    }
-
-
-    /// Returns a children Blocklevel Node from a collection of nodes, using a Child Picker to determine the
-    /// navigational-direction.
+    /// - Returns: the conversions for the provided properties.
     ///
-    private func paragraphStyleElements(from nodes: [Node], childPicker: (([Node]) -> Node?)) -> [ElementNode] {
-        var elements = [ElementNode]()
-        var nextElement = childPicker(nodes) as? ElementNode
-
-        while let currentElement = nextElement {
-            guard currentElement.isBlockLevel() else {
-                break
+    private func convert(_ properties: ArraySlice<ParagraphProperty>) -> [ParagraphPropertyConversion] {
+        var preformatted = false
+        var parentElementNode: ElementNode?
+        
+        /// Updates the parent.
+        ///
+        func updateParent(for elementNode: ElementNode) {
+            defer {
+                // No matter what exit point we take, the provided element will
+                // be set as the parent after this method is executed.
+                parentElementNode = elementNode
             }
-
-            elements.append(currentElement)
-            nextElement = childPicker(currentElement.children) as? ElementNode
+            
+            guard let previousParentElementNode = parentElementNode else {
+                return
+            }
+            
+            previousParentElementNode.children.append(elementNode)
         }
-
-        return elements
+        
+        let conversions = properties.compactMap({ (property) -> ParagraphPropertyConversion? in
+            guard let conversion = convert(property, preformatted: &preformatted) else {
+                return nil
+            }
+            
+            updateParent(for: conversion.elementNode)
+            return conversion
+        })
+        
+        // We don't allow not having at least 1 block-level element, so we enforce a
+        // paragraph element in that case.
+        guard conversions.count > 0 else {
+            let defaultConversion = ParagraphPropertyConversion(property: HTMLParagraph(with: nil), elementNode: ElementNode(type: .p), preformatted: false)
+            return [defaultConversion]
+        }
+        
+        return conversions
+    }
+    
+    /// Converts a paragraph property.
+    ///
+    /// - Parameters:
+    ///     - property: the property to convert.
+    ///     - preformatted: whether the property is preformatted, or a child of a preformatted property.
+    ///
+    /// - Returns: the conversion.
+    ///
+    private func convert(_ property: ParagraphProperty, preformatted: inout Bool) -> ParagraphPropertyConversion? {
+        guard let elementNode = convert(property) else {
+            return nil
+        }
+        
+        preformatted = Element.preformattedElements.contains(elementNode.type)
+        
+        return ParagraphPropertyConversion(property: property, elementNode: elementNode, preformatted: preformatted)
+    }
+    
+    /// Converts a paragraph property into an `ElementNode`.
+    ///
+    /// - Parameters:
+    ///     - property: the property to convert.
+    ///
+    /// - Returns: an `ElementNode` to represent the property.
+    ///
+    private func convert(_ property: ParagraphProperty) -> ElementNode? {
+        // The customizer overrides any default behaviour, which is the reason why it's run first.
+        if let element = customizer?.convert(property) {
+            return element
+        }
+        
+        switch property {
+        case let blockquote as Blockquote:
+            let element = processBlockquoteStyle(blockquote: blockquote)
+            return element
+            
+        case let figcaption as Figcaption:
+            let element = processFigcaptionStyle(figcaption: figcaption)
+            return element
+            
+        case let figure as Figure:
+            let element = processFigureStyle(figure: figure)
+            return element
+            
+        case let header as Header:
+            guard let element = processHeaderStyle(header: header) else {
+                return nil
+            }
+            return element
+            
+        case let list as TextList:
+            let element = processListStyle(list: list)
+            return element
+            
+        case let listItem as HTMLLi:
+            let element = processListItem(listItem: listItem)
+            return element
+            
+        case let div as HTMLDiv:
+            let element = processDivStyle(div: div)
+            return element
+            
+        case let paragraph as HTMLParagraph:
+            let element = processParagraphStyle(paragraph: paragraph)
+            return element
+            
+        case let pre as HTMLPre:
+            let element = processPreStyle(pre: pre)
+            return element
+            
+        default:
+            return nil
+        }
     }
 }
 
@@ -696,189 +599,6 @@ extension NewAttributedStringParser {
 // MARK: - Paragraph Nodes: Allocation
 //
 private extension NewAttributedStringParser {
-
-    /// Extracts the ElementNodes contained within a Paragraph's AttributedString.
-    ///
-    /// - Parameters:
-    ///     - attrString: Paragraph's AttributedString from which we intend to extract the ElementNode
-    ///
-    /// - Returns: ElementNode representing the specified Paragraph.
-    ///
-    func createParagraphNodes(from paragraph: NSAttributedString) -> [ElementNode] {
-        let paragraphStyle = (paragraph.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? ParagraphStyle) ?? ParagraphStyle()
-
-        return createParagraphNodes(from: paragraphStyle)
-    }
-
-
-    /// Extracts the ElementNodes contained within a Paragraph's AttributedString.
-    ///
-    /// - Parameters:
-    ///     - attributes: Paragraph's Attributes from which we intend to extract the ElementNode
-    ///
-    /// - Returns: ElementNode representing the specified Paragraph.
-    ///
-    func createParagraphNodes(from attributes: [NSAttributedStringKey: Any]) -> [ElementNode] {
-        let paragraphStyle = (attributes[.paragraphStyle] as? ParagraphStyle) ?? ParagraphStyle()
-
-        return createParagraphNodes(from: paragraphStyle)
-    }
-
-
-    /// Extracts the ElementNodes contained within a ParagraphStyle Instance.
-    ///
-    /// - Parameters:
-    ///     - paragraphStyle: ParagraphStyle from which we intend to extract the ElementNode
-    ///
-    /// - Returns: ElementNode representing the specified Paragraph.
-    ///
-    private func createParagraphNodes(from paragraphStyle: ParagraphStyle) -> [ElementNode] {
-        let extraAttributes = attributes(for: paragraphStyle)
-        
-        // If we're unable to find any paragraph-level styles, we return an HTML paragraph element as
-        // default.  The reason behind this decision is that no text can exist outside block-level
-        // elements in Aztec.
-        //
-        // See here for more info:
-        // https://github.com/wordpress-mobile/AztecEditor-iOS/issues/667
-        //
-        guard paragraphStyle.properties.count > 0 else {
-            return [ElementNode(type: .p, attributes: extraAttributes)]
-        }
-        
-        var paragraphNodes = [ElementNode]()
-        
-        for property in paragraphStyle.properties.reversed() {
-            
-            // The customizer overrides any default behaviour, which is the reason why it's run first.
-            if let element = customizer?.convert(property) {
-                paragraphNodes.append(element)
-                continue
-            }
-            
-            switch property {
-            case let blockquote as Blockquote:
-                let element = processBlockquoteStyle(blockquote: blockquote)
-                paragraphNodes.append(element)
-                
-            case let figcaption as Figcaption:
-                let element = processFigcaptionStyle(figcaption: figcaption)
-                paragraphNodes.append(element)
-
-            case let figure as Figure:
-                let element = processFigureStyle(figure: figure)
-                paragraphNodes.append(element)
-                
-            case let header as Header:
-                guard let element = processHeaderStyle(header: header) else {
-                    continue
-                }
-                paragraphNodes.append(element)
-
-            case let list as TextList:
-                let element = processListStyle(list: list)
-                paragraphNodes.append(element)
-
-            case let listItem as HTMLLi:
-                let element = processListItem(listItem: listItem)
-                paragraphNodes.append(element)
-
-            case let div as HTMLDiv:
-                let element = processDivStyle(div: div)
-                paragraphNodes.append(element)
-
-            case let paragraph as HTMLParagraph:
-                let element = processParagraphStyle(paragraph: paragraph)
-                paragraphNodes.append(element)
-
-            case let pre as HTMLPre:
-                let element = processPreStyle(pre: pre)
-                paragraphNodes.append(element)
-
-            default:
-                continue
-            }
-        }
-        
-        if let lastElement = paragraphNodes.last {
-            lastElement.attributes.append(contentsOf: extraAttributes)
-        }
-        
-        return paragraphNodes
-    }
-    
-    private func createParagraphElementNodes(from properties: [ParagraphProperty]) -> [ElementNode] {
-        return properties.compactMap({ (property) -> ElementNode? in
-            
-            // The customizer overrides any default behaviour, which is the reason why it's run first.
-            if let element = customizer?.convert(property) {
-                return element
-            }
-            
-            switch property {
-            case let blockquote as Blockquote:
-                let element = processBlockquoteStyle(blockquote: blockquote)
-                return element
-                
-            case let figcaption as Figcaption:
-                let element = processFigcaptionStyle(figcaption: figcaption)
-                return element
-                
-            case let figure as Figure:
-                let element = processFigureStyle(figure: figure)
-                return element
-                
-            case let header as Header:
-                guard let element = processHeaderStyle(header: header) else {
-                    return nil
-                }
-                return element
-                
-            case let list as TextList:
-                let element = processListStyle(list: list)
-                return element
-                
-            case let listItem as HTMLLi:
-                let element = processListItem(listItem: listItem)
-                return element
-                
-            case let div as HTMLDiv:
-                let element = processDivStyle(div: div)
-                return element
-                
-            case let paragraph as HTMLParagraph:
-                let element = processParagraphStyle(paragraph: paragraph)
-                return element
-                
-            case let pre as HTMLPre:
-                let element = processPreStyle(pre: pre)
-                return element
-                
-            default:
-                return nil
-            }
-        })
-    }
-    
-    /// Processes the paragraph style to figure out the attributes that will be applied to the outermost Element
-    /// produced from it.
-    ///
-    /// - Parameters:
-    ///     - paragraphStyle: the paragraph style to process.
-    ///
-    /// - Returns: any attributes necessary to represent the paragraph values.
-    ///
-    private func attributes(for paragraphStyle: ParagraphStyle) -> [Attribute] {
-        var attributes = [Attribute]()
-        
-        if paragraphStyle.baseWritingDirection == .rightToLeft {
-            let rtlAttribute = Attribute(name: "dir", value: .string("rtl"))
-            
-            attributes.append(rtlAttribute)
-        }
-        
-        return attributes
-    }
 
 
     /// Extracts all of the Blockquote Elements contained within a collection of Attributes.

--- a/Aztec/Classes/TextKit/ParagraphProperty/HTMLParagraph.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/HTMLParagraph.swift
@@ -18,6 +18,6 @@ class HTMLParagraph: ParagraphProperty {
     }
 
     static func ==(lhs: HTMLParagraph, rhs: HTMLParagraph) -> Bool {
-        return lhs === rhs
+        return lhs == rhs
     }
 }


### PR DESCRIPTION
### Description:

Replaces the paragraph properties output conversion and merging logic.

This will allow us to fix #993 and #934.

### Details:

The reason why this change is important is that we can now customize how paragraph-styles are merged on a case by case basis.  Meaning we can decide to support merging two adjacent paragraph styles based on any kind of equality we want to implement.

Right now supporting captions is impossible without these changes.

### Testing:

Run the unit tests.
Open the content samples and convert to visual and back to HTML.
