### PR TITLE
Try/reorganize sample content

### DIFF
--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		F1D3610920929EBD00B4E7A5 /* WordPressEditor.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = F1D3610420929E6D00B4E7A5 /* WordPressEditor.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F1D3610A20929EF700B4E7A5 /* Aztec.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 599F25771D8BD045002871D6 /* Aztec.framework */; };
 		F1D3610B20929F0200B4E7A5 /* WordPressEditor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1D3610420929E6D00B4E7A5 /* WordPressEditor.framework */; };
+		FF149F4A20E3C49A0070FECB /* imagesOverlays.html in Resources */ = {isa = PBXBuildFile; fileRef = FF149F4920E3C49A0070FECB /* imagesOverlays.html */; };
 		FF1FD05C20932EDE00186384 /* gutenberg.html in Resources */ = {isa = PBXBuildFile; fileRef = FF1FD05B20932EDE00186384 /* gutenberg.html */; };
 		FF6691C21E76CF9200C6A703 /* OptionsTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */; };
 		FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */; };
@@ -150,6 +151,7 @@
 		E63EF92A1D36A60B00B5BA4B /* EditorDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorDemoController.swift; sourceTree = "<group>"; };
 		F122C2502072AE190018ED06 /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = usr/lib/libxml2.tbd; sourceTree = SDKROOT; };
 		F1D360FC20929E6D00B4E7A5 /* WordPressEditor.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = WordPressEditor.xcodeproj; path = ../WordPressEditor/WordPressEditor.xcodeproj; sourceTree = "<group>"; };
+		FF149F4920E3C49A0070FECB /* imagesOverlays.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = imagesOverlays.html; sourceTree = "<group>"; };
 		FF1FD05B20932EDE00186384 /* gutenberg.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = gutenberg.html; sourceTree = "<group>"; };
 		FF6691C11E76CF9200C6A703 /* OptionsTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionsTableView.swift; sourceTree = "<group>"; };
 		FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AttachmentDetailsViewController.storyboard; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 			children = (
 				59280F281D47CAF40083FB59 /* content.html */,
 				B5FB21271FEC37DB0067D597 /* captions.html */,
+				FF149F4920E3C49A0070FECB /* imagesOverlays.html */,
 				59280F291D47CAF40083FB59 /* SampleText.rtf */,
 				FF1FD05B20932EDE00186384 /* gutenberg.html */,
 				FFC41BDD20DBC7BA004DFB4D /* video.html */,
@@ -439,6 +442,7 @@
 				FF1FD05C20932EDE00186384 /* gutenberg.html in Resources */,
 				59280F2B1D47CAF40083FB59 /* SampleText.rtf in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
+				FF149F4A20E3C49A0070FECB /* imagesOverlays.html in Resources */,
 				FFC41BDE20DBC7BA004DFB4D /* video.html in Resources */,
 				FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */,
 			);

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -123,23 +123,6 @@ Block Quote:
 <video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg" alt="Video about bunnies" />
 </p>
 
-<h4>Overlay on Media:</h4>
-<p>
-20px Wide Image:
-<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,20px,20px" alt="Plane"/><br/><br/>
-50px Wide Image:
-<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,50px,50px" alt="Plane"/><br/><br/>
-70px Wide Image:
-<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,70px,70px" alt="Plane"/><br/><br/>
-90px Wide Image:
-<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,90px,90px" alt="Plane"/><br/><br/>
-120px Wide Image:
-<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,120px,120px" alt="Plane"/><br/><br/>
-200px Wide Image:
-<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,200px,200px" alt="Plane"/><br/><br/>
-300px Wide Image:
-<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,300px,300px" alt="Plane"/>
-</p>
 <p>
 Fanny pack Odd Future Intelligentsia lo-fi semiotics whatever. Selvage keffiyeh mustache sustainable ethnic, chambray mumblecore McSweeney's biodiesel Pitchfork four loko disrupt post-ironic art party American Apparel. Kitsch umami beard salvia, Vice before they sold out vegan tousled lomo jean shorts pickled PBR&amp;B. Tousled Wes Anderson Shoreditch flannel, 90's XOXO quinoa whatever mumblecore cliche Truffaut stumptown. Photo booth crucifix plaid Brooklyn. Authentic letterpress PBR&amp;B, sustainable VHS master cleanse ethnic High Life. Messenger bag umami pug flannel.
 </p>

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -1,46 +1,44 @@
-<h1>Sample HTML content</h1>
+<h1>Welcome To Aztec</h1>
 
-<p>
-    this is some text
-    that is spread out
-    across several lines
-    but is rendered on a
-    single line in a browser
+<p>Aztec goal is to be an component that allows display and editition of HTML. <br/>
+It aims to supports the most common character styles, paragraph styles and multimedia elements.
 </p>
-
-<h2>Character Styles</h2>
-
-<strong>Bold text</strong><br/>
-<em>Italic text</em><br/>
-<u>Underlined text</u><br/>
-<del>Strikethrough</del><br/>
-<span style="color: #ff0000;">Colors</span><br/>
-<span style="text-decoration: underline;">Alternative underline text</span><br/>
-<a href="http://www.wordpress.com">I'm a link!</a><br/>
-<code>print("Hello world")</code>
 
 <!--more-->
 
-<p>
-Text after the more break
-</p>
+<h2>Character Styles</h2>
 
-<h2>Lists</h2>
+Bold: <strong>Bold text</strong><br/>
+Italic: <em>Italic text</em><br/>
+Underline: <u>Underlined text</u><br/>
+Strikethrough: <del>Strikethrough</del><br/>
+Colors: <span style="color: #ff0000;">Colors</span><br/>
+Undeline with CSS: <span style="text-decoration: underline;">Alternative underline text</span><br/>
+Links: <a href="http://www.wordpress.com">I'm a link!</a><br/>
+Code: <code>print("Hello world")</code>
 
-<h3>Unordered List:</h3>
+<hr/>
+
+<h2>Paragraph Styles</h2>
+
+<h3>Lists</h3>
+
+<h4>Unordered List:</h4>
 <ul>
     <li>One</li>
     <li>Two</li>
     <li>Three</li>
 </ul>
-<h3>Ordered List:</h3>
+
+<h4>Ordered List:</h4>
 <ol>
     <li>One</li>
     <li>Two</li>
     <li>Three</li>
 </ol>
 
-<h3>Nested lists:</h3>
+<h4>Nested lists:</h4>
+
 <ol>
     <li>One
         <ol>
@@ -58,9 +56,10 @@ Text after the more break
 </ol>
 </p>
 
-<hr/>
+<hr />
 
-<p>Headings:</p>
+<h3>Headings:</h3>
+
 <h1>H1 Heading</h1>
 <h2>H2 Heading</h2>
 <h3>H3 Heading</h3>
@@ -70,15 +69,42 @@ Text after the more break
 <p>Paragraph</p>
 
 <hr />
-<p>
-Pre-formatted code:
+
+<h3>Pre-formatted code:</h3>
+
 <pre>
     10 PRINT "HOWDY WORLD"
     20 GOTO 21<br>    21 PRINT "END!"
 </pre>
-</p>
+
+<hr />
+
+<h3>Blockquote</h3>
+
+<blockquote>Kale chips Schlitz forage irony, kogi Tumblr Carles chillwave Etsy pug photo booth YOLO biodiesel tote bag actually. PBR Portland yr pickled, bespoke meggings selvage letterpress kitsch plaid before they sold out put a bird on it you probably haven't heard of them. Yr master cleanse slow-carb crucifix, sustainable keytar Helvetica Tumblr High Life mumblecore narwhal cornhole deep v craft beer. Portland forage hashtag locavore, before they sold out put a bird on it irony hella. Godard kale chips street art tote bag cardigan. Church-key next level seitan keytar meggings Portland. Keffiyeh flexitarian post-ironic drinking vinegar wayfarers.<cite>by Unknow Author</cite>
+</blockquote>
+<br/>
+<hr/>
+<h3>Multimedia</h3>
+
+<h4>Image:</h4>
 <p>
-Blockquote and Ordered List:
+<figure custom-figure-attribute>
+    <a href="www.automattic.com"><img src="https://httpbin.org/image/jpeg" alt="Coyote" /></a>
+    <figcaption custom-figcaption-attribute>Coyote</figcaption>
+</figure>
+</p>
+
+<h4>Video:</h4>
+<p>
+<video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg" alt="Video about bunnies" />
+</p>
+
+<hr/>
+
+<h2>Mixed Styles</h2>
+
+<h3>Blockquote with list inside</h3>
 <blockquote>
 <ol>
     <li>One</li>
@@ -86,55 +112,28 @@ Blockquote and Ordered List:
     <li>Three</li>
 </ol>
 </blockquote>
-</p>
-<p>
-List with Blockquotes inside:
-    <ol>
-        <li><blockquote>One</blockquote></li>
-        <li><blockquote>Two</blockquote></li>
-        <li><blockquote>Three</blockquote></li>
-    </ol>
-</p>
+
+<h3>List with Blockquotes inside: </h3>
+<ol>
+    <li><blockquote>One</blockquote></li>
+    <li><blockquote>Two</blockquote></li>
+    <li><blockquote>Three</blockquote></li>
+</ol>
 
 <p>
 Master cleanse Intelligentsia butcher Brooklyn Tumblr. Etsy lo-fi Marfa bicycle rights. Intelligentsia Helvetica fanny pack, normcore Odd Future fixie brunch mustache aesthetic kitsch artisan cardigan mlkshk. Pour-over hashtag selfies pug Tumblr mlkshk. Food truck small batch McSweeney's trust fund, Intelligentsia bitters Brooklyn twee meh authentic. Normcore distillery American Apparel single-origin coffee artisan try-hard, stumptown XOXO tote bag fanny pack Blue Bottle Shoreditch food truck Banksy. Church-key American Apparel Blue Bottle, swag try-hard Odd Future mustache chia iPhone.
-</p>
-<p>
-Block Quote:
-<blockquote>Kale chips Schlitz forage irony, kogi Tumblr Carles chillwave Etsy pug photo booth YOLO biodiesel tote bag actually. PBR Portland yr pickled, bespoke meggings selvage letterpress kitsch plaid before they sold out put a bird on it you probably haven't heard of them. Yr master cleanse slow-carb crucifix, sustainable keytar Helvetica Tumblr High Life mumblecore narwhal cornhole deep v craft beer. Portland forage hashtag locavore, before they sold out put a bird on it irony hella. Godard kale chips street art tote bag cardigan. Church-key next level seitan keytar meggings Portland. Keffiyeh flexitarian post-ironic drinking vinegar wayfarers.<cite>by Unknow Author</cite></blockquote>
-</p>
-<h4>Image:</h4>
-<p>
-<img src="https://httpbin.org/image/jpeg" alt="Coyote" />
-</p>
-<h4>Image with link:</h4>
-<p>
-<a href="www.automattic.com"><img src="https://httpbin.org/image/jpeg" alt="Coyote" /></a>
-</p>
-<h4>Image with caption:</h4>
-<p>
-<figure custom-figure-attribute>
-    <img src="https://httpbin.org/image/jpeg" alt="Coyote" />
-    <figcaption custom-figcaption-attribute>I'm a very, very, very long figcaption, written in a galaxy far, far, far away. Moo to you!</figcaption>
-</figure>
-</p>
-<h4>Video:</h4>
-<p>
-<video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg" alt="Video about bunnies" />
 </p>
 
 <p>
 Fanny pack Odd Future Intelligentsia lo-fi semiotics whatever. Selvage keffiyeh mustache sustainable ethnic, chambray mumblecore McSweeney's biodiesel Pitchfork four loko disrupt post-ironic art party American Apparel. Kitsch umami beard salvia, Vice before they sold out vegan tousled lomo jean shorts pickled PBR&amp;B. Tousled Wes Anderson Shoreditch flannel, 90's XOXO quinoa whatever mumblecore cliche Truffaut stumptown. Photo booth crucifix plaid Brooklyn. Authentic letterpress PBR&amp;B, sustainable VHS master cleanse ethnic High Life. Messenger bag umami pug flannel.
 </p>
 
+<hr/>
 
-<br/><br/>
-
-<p>
-Unsupported HTML
+<h3>Unsupported HTML</h3>
 
 <table>
 <tr><td></td></tr>
 </table>
 
-</p>
+<hr/>

--- a/Example/Example/SampleContent/imagesOverlays.html
+++ b/Example/Example/SampleContent/imagesOverlays.html
@@ -1,0 +1,17 @@
+<h4>Overlay on Media:</h4>
+<p>
+20px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,20px,20px" alt="Plane"/><br/><br/>
+50px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,50px,50px" alt="Plane"/><br/><br/>
+70px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,70px,70px" alt="Plane"/><br/><br/>
+90px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,90px,90px" alt="Plane"/><br/><br/>
+120px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,120px,120px" alt="Plane"/><br/><br/>
+200px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,200px,200px" alt="Plane"/><br/><br/>
+300px Wide Image:
+<img src="http://i0.wp.com/s.ma.tt/files/2011/06/MCM_9230-1600x1064.jpg?crop=160px,160px,300px,300px" alt="Plane"/>
+</p>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -17,6 +17,7 @@ class ViewController: UITableViewController
             DemoSection(title: "Plain HTML Editor", rows: [
                 DemoRow(title: "Standard Demo", action: { self.showEditorDemo(filename: "content") }),
                 DemoRow(title: "Captions Demo", action: { self.showEditorDemo(filename: "captions") }),
+                DemoRow(title: "Image Overlays", action: { self.showEditorDemo(filename: "imagesOverlays") }),
                 DemoRow(title: "Empty Demo", action: { self.showEditorDemo() })
                 ]
             ),


### PR DESCRIPTION
This PR just reorganizes and cleans up the HTML sample content to make it more streamlined and show better examples.

Doing this I found out that we have two examples for this things that we supported on the past but at the moment are not supported:

 - Color attributes on CSS
 - Underlines define on CSS

