### PR TITLE
Fixes an issue with lists not being interrupted on double enter.

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
@@ -56,7 +56,8 @@ class TextListFormatter: ParagraphAttributeFormatter {
         }
 
         let newParagraphStyle = ParagraphStyle()
-        newParagraphStyle.setParagraphStyle(paragraphStyle)       
+        newParagraphStyle.setParagraphStyle(paragraphStyle)
+        newParagraphStyle.removeProperty(ofType: HTMLLi.self)
         newParagraphStyle.removeProperty(ofType: TextList.self)
 
         var resultingAttributes = attributes


### PR DESCRIPTION
### Description:

Fixes #1012 

### Testing:

To test:

- Open the empty editor.
- Create a list of any kind.
- Enter a few bullets into the list.
- Double ENTER to finish the list.
- Write some more text.
- Switch to HTML mode.

Expected result: make sure the text that is outside the list is not wrapped by `<li>` tags.
