### PR TITLE
Gutenberg code block delimiters are no longer removed.

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
@@ -35,7 +35,7 @@ open class PreFormatter: ParagraphAttributeFormatter {
 
     func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
         var resultingAttributes = attributes
-        let newParagraphStyle = ParagraphStyle()
+        let newParagraphStyle = attributes.paragraphStyle()
 
         newParagraphStyle.appendProperty(HTMLPre(with: representation))
 

--- a/AztecTests/Formatters/PreFormaterTests.swift
+++ b/AztecTests/Formatters/PreFormaterTests.swift
@@ -27,4 +27,35 @@ class PreFormatterTests: XCTestCase {
 
         XCTAssert(updatedValue == expectedValue)
     }
+    
+    /// Tests that the Pre formatter doesn't drop the inherited ParagraphStyle.
+    ///
+    /// Issue:
+    /// https://github.com/wordpress-mobile/AztecEditor-iOS/issues/993
+    ///
+    func testPreFormatterDoesNotDropInheritedParagraphStyle(){
+        let placeholderAttributes: [NSAttributedStringKey: Any] = [
+            .font: "Value",
+            .paragraphStyle: NSParagraphStyle()
+        ]
+        
+        let div = HTMLDiv(with: nil)
+        let paragraphStyle = ParagraphStyle()
+        
+        paragraphStyle.appendProperty(div)
+        
+        let previousAttributes: [NSAttributedStringKey: Any] = [.paragraphStyle: paragraphStyle]
+        
+        let formatter = PreFormatter(placeholderAttributes: placeholderAttributes)
+        let newAttributes = formatter.apply(to: previousAttributes, andStore: nil)
+        
+        guard let newParagraphStyle = newAttributes[.paragraphStyle] as? ParagraphStyle else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssert(newParagraphStyle.hasProperty(where: { property -> Bool in
+            return property === div
+        }))
+    }
 }


### PR DESCRIPTION
### Description:

Addresses part of #993 .

Gutenberg code block delimiters are being removed by our WordPressEditor library.  This PR ensures that the delimiters are maintained.

It also adds a unit test to make sure there are no regressions.

### Details:

This issue does NOT address the fractioning of the `<code>` tags.

### Testing:

- Launch the empty Gutenberg / Calypso demo editor.
- Switch to HTML and paste this

```html
<!-- wp:code -->
<pre class="wp-block-code"><code>testing
test.   ing
     testing some more</code></pre>
<!-- /wp:code -->
```

- Switch to visual mode and back to HTML mode and make sure the Gutenberg code block delimiters are not removed.