### PR TITLE
Issue/993 code blocks broken 2

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
@@ -35,7 +35,7 @@ open class PreFormatter: ParagraphAttributeFormatter {
 
     func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
         var resultingAttributes = attributes
-        let newParagraphStyle = ParagraphStyle()
+        let newParagraphStyle = attributes.paragraphStyle()
 
         newParagraphStyle.appendProperty(HTMLPre(with: representation))
 

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -413,14 +413,14 @@ private extension AttributedStringParser {
                 previousStyleNode.children.append(contentsOf: children)
                 
                 if styleNodes.count > 1 {
-                    append(styleNodes[1 ... styleNodes.count - 1], to: mergeableConversions)
+                    append(styleNodes[1 ..< styleNodes.endIndex], to: mergeableConversions)
                 }
             } else {
                 // If all properties are merged and the last mergeable conversion is preformatted, we should prepend the
                 // styleNodes with a paragraph separator text node.
                 let finalStyleNodes = lastMergeableConversion.preformatted ? prependParagraphSeparatorTextNode(to: styleNodes) : styleNodes
                 
-                append(finalStyleNodes[0 ... finalStyleNodes.count - 1], to: mergeableConversions)
+                append(finalStyleNodes[0 ..< finalStyleNodes.endIndex], to: mergeableConversions)
             }
             
             return Array(mergeableConversions)
@@ -570,7 +570,7 @@ extension AttributedStringParser {
             return [defaultParagraphPropertyConversion(styleNodes: styleNodes)]
         }
         
-        append(styleNodes[0 ... styleNodes.count - 1], to: ArraySlice(conversions))
+        append(styleNodes[0 ..< styleNodes.endIndex], to: ArraySlice(conversions))
         return conversions
     }
     

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -403,12 +403,25 @@ private extension AttributedStringParser {
         let somePropertiesAreNotMergeable = newProperties.count > mergeableConversions.count
         
         guard somePropertiesAreNotMergeable else {
-            
-            // If all properties are merged and the last mergeable conversion is preformatted, we should prepend the
-            // styleNodes with a paragraph separator text node.
-            let finalStyleNodes = lastMergeableConversion.preformatted ? prependParagraphSeparatorTextNode(to: styleNodes) : styleNodes
-            
-            append(finalStyleNodes, to: mergeableConversions)
+            // At this point we gotta check if we can merge the last style element from the left with the first style element from the right.
+            if let previousStyleNode = lastMergeableConversion.elementNode.children.last as? ElementNode,
+                let styleNode = styleNodes.first as? ElementNode,
+                canMergeNodes(left: previousStyleNode, right: styleNode, blocklevelEnforced: false) {
+                
+                let children = lastMergeableConversion.preformatted ? prependParagraphSeparatorTextNode(to: styleNode.children) : styleNode.children
+                
+                previousStyleNode.children.append(contentsOf: children)
+                
+                if styleNodes.count > 1 {
+                    append(styleNodes[1 ... styleNodes.count - 1], to: mergeableConversions)
+                }
+            } else {
+                // If all properties are merged and the last mergeable conversion is preformatted, we should prepend the
+                // styleNodes with a paragraph separator text node.
+                let finalStyleNodes = lastMergeableConversion.preformatted ? prependParagraphSeparatorTextNode(to: styleNodes) : styleNodes
+                
+                append(finalStyleNodes[0 ... finalStyleNodes.count - 1], to: mergeableConversions)
+            }
             
             return Array(mergeableConversions)
         }
@@ -490,7 +503,7 @@ extension AttributedStringParser {
     ///     - conversions: the conversions to append the nodes to.
     ///
     private func append(
-        _ nodes: [Node],
+        _ nodes: ArraySlice<Node>,
         to conversions: ArraySlice<ParagraphPropertyConversion>) {
         
         precondition(conversions.count > 0)
@@ -557,7 +570,7 @@ extension AttributedStringParser {
             return [defaultParagraphPropertyConversion(styleNodes: styleNodes)]
         }
         
-        append(styleNodes, to: ArraySlice(conversions))
+        append(styleNodes[0 ... styleNodes.count - 1], to: ArraySlice(conversions))
         return conversions
     }
     

--- a/AztecTests/Formatters/PreFormaterTests.swift
+++ b/AztecTests/Formatters/PreFormaterTests.swift
@@ -27,4 +27,35 @@ class PreFormatterTests: XCTestCase {
 
         XCTAssert(updatedValue == expectedValue)
     }
+    
+    /// Tests that the Pre formatter doesn't drop the inherited ParagraphStyle.
+    ///
+    /// Issue:
+    /// https://github.com/wordpress-mobile/AztecEditor-iOS/issues/993
+    ///
+    func testPreFormatterDoesNotDropInheritedParagraphStyle(){
+        let placeholderAttributes: [NSAttributedStringKey: Any] = [
+            .font: "Value",
+            .paragraphStyle: NSParagraphStyle()
+        ]
+        
+        let div = HTMLDiv(with: nil)
+        let paragraphStyle = ParagraphStyle()
+        
+        paragraphStyle.appendProperty(div)
+        
+        let previousAttributes: [NSAttributedStringKey: Any] = [.paragraphStyle: paragraphStyle]
+        
+        let formatter = PreFormatter(placeholderAttributes: placeholderAttributes)
+        let newAttributes = formatter.apply(to: previousAttributes, andStore: nil)
+        
+        guard let newParagraphStyle = newAttributes[.paragraphStyle] as? ParagraphStyle else {
+            XCTFail()
+            return
+        }
+        
+        XCTAssert(newParagraphStyle.hasProperty(where: { property -> Bool in
+            return property === div
+        }))
+    }
 }


### PR DESCRIPTION
### Description:

Fixes #993.

Code blocks are now properly merged, when appropriate.

### Dependencies:

This PR has a dependency on #1014, so let's make sure it's only merged after that one.

### Testing:

- Launch the empty Gutenberg / Calypso demo editor.
- Switch to HTML and paste this

```html
<!-- wp:code -->
<pre class="wp-block-code"><code>testing
test.   ing
     testing some more</code></pre>
<!-- /wp:code -->
```

- Switch to visual mode and back to HTML mode and make sure the Gutenberg code tags are properly merged, and not broken at each line.