### PR TITLE
Fixes drag and drop images do not get `size-full` CSS class upon posting

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -201,6 +201,7 @@ open class TextStorage: NSTextStorage {
                 let replacementAttachment = ImageAttachment(identifier: NSUUID().uuidString)
                 replacementAttachment.delegate = self
                 replacementAttachment.image = image
+                replacementAttachment.size = .full
 
                 let imageURL = delegate.storage(self, urlFor: replacementAttachment)
                 replacementAttachment.updateURL(imageURL)


### PR DESCRIPTION
Fixes # 
https://github.com/wordpress-mobile/WordPress-iOS/issues/9887

To test:
- On an iPad or an iPad simulator, launch Photos, then go Home. 
- Launch WordPress and start a new post. Swipe up from the bottom, revealing the dock.
- Long press and drag the photo app to the right or left side of the WordPress app. Wait for photos to outline its window and let go.
- In Photos > album view, long press a photo and drag it to WordPress, in the main post body area. When you see a green plus icon in the corner of the photo, let go of the photo to drop it into the post. Wait for it to upload.
- Using the toolbar, tap the plus button to add media. Select an image to add.
- Publish the post.
- Visit /wp-admin/ and find the published post. Use the code view to verify that the `size-full` CSS class has been assigned to the drag & drop image, like the media upload image already has.