### PR TITLE
Fixes an issue that was causing the default text color to sometimes change.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -163,14 +163,10 @@ open class TextView: UITextView {
     var defaultMissingImage: UIImage
     
     fileprivate var defaultAttributes: [NSAttributedStringKey: Any] {
-        var attributes: [NSAttributedStringKey: Any] = [
+        let attributes: [NSAttributedStringKey: Any] = [
             .font: defaultFont,
             .paragraphStyle: defaultParagraphStyle
         ]
-
-        if let textColor = textColor {
-            attributes[.foregroundColor] = textColor
-        }
 
         return attributes
     }


### PR DESCRIPTION
### Description:

Fixes an issue that was causing the default text color to sometimes change.

### Details:

We no longer copy use `textColor` as the default text color property for `Aztec.TextView`.  The text color can be set through the default attributes directly.

This fix moves us towards resolving #1024.

This is how it looked originally:

![pasteissues](https://user-images.githubusercontent.com/1836005/44211280-fc6f5880-a13e-11e8-8570-f1733cd1995b.gif)

### Testing:

In order to test this properly, you need to copy the "Overview" paragraph shown in this GIF (try to match the copied range), from [the WordPress Wikipedia page](https://en.wikipedia.org/wiki/WordPress).

Then follow the steps shown below and make sure the text is not all blue as it was originally.

![pasteissuessolved](https://user-images.githubusercontent.com/1836005/44211436-5839e180-a13f-11e8-9e33-46a315edf25c.gif)