### PR TITLE
Better support for pasting HTML in Aztec.

### DIFF
--- a/Aztec/Classes/Extensions/UIPasteboard+Helpers.swift
+++ b/Aztec/Classes/Extensions/UIPasteboard+Helpers.swift
@@ -7,67 +7,86 @@ import UIKit
 //
 extension UIPasteboard {
 
-    /// Attempts to load the Pasteboard's contents into a NSAttributedString Instance, if possible.
+    /// Attempts to retrieve the Pasteboard's contents as an attributed string, if possible.
     ///
-    func loadAttributedString() -> NSAttributedString? {
-
-        if let string = aztecAttributedString {
+    func attributedString() -> NSAttributedString? {
+        
+        if let string = aztecAttributedString() {
             return string
         }
 
-        if let string = RTFDAttributedString {
+        if let string = rtfdAttributedString() {
             return string
         }
 
-        if let string = RTFAttributedString {
+        if let string = rtfAttributedString() {
             return string
         }
 
-        if let string = richTextAttributedString {
+        if let string = richTextAttributedString() {
             return string
         }
 
-        return plainTextAttributedString
+        return plainTextAttributedString()
+    }
+    
+    func html() -> String? {
+        guard let htmlData = data(forPasteboardType: String(kUTTypeHTML)) else {
+            return nil
+        }
+        
+        return String(data: htmlData, encoding: .utf8)
+    }
+    
+    func url() -> URL? {
+        guard let urlTypes = UIPasteboardTypeListURL as? [String],
+            UIPasteboard.general.contains(pasteboardTypes: urlTypes),
+            let url = UIPasteboard.general.url else {
+                return nil
+        }
+        
+        return url
     }
 }
 
+// MARK: - Attributed String Conversion
 
-// MARK: - Pasteboard Private Helpers
-//
 private extension UIPasteboard {
 
+    // MARK: -
+    
+    /// Attempts to unarchive the Pasteboard's Aztec-Archived String
+    ///
+    func aztecAttributedString() -> NSAttributedString? {
+        guard let data = data(forPasteboardType: NSAttributedString.pastesboardUTI) else {
+            return nil
+        }
+        
+        return NSAttributedString.unarchive(with: data)
+    }
+    
+    /// Attempts to unarchive the Pasteboard's Plain Text contents into an Attributed String
+    ///
+    func plainTextAttributedString() -> NSAttributedString? {
+        return unarchiveAttributedString(fromPasteboardCFType: kUTTypePlainText, with: StringOptions.plainText)
+    }
+    
+    /// Attempts to unarchive the Pasteboard's Text contents into an Attributed String
+    ///
+    func richTextAttributedString() -> NSAttributedString? {
+        return unarchiveAttributedString(fromPasteboardCFType: kUTTypeText, with: StringOptions.RTFText)
+    }
+    
     /// Attempts to unarchive the Pasteboard's RTF contents into an Attributed String
     ///
-    var RTFAttributedString: NSAttributedString? {
+    func rtfAttributedString() -> NSAttributedString? {
         return unarchiveAttributedString(fromPasteboardCFType: kUTTypeRTF, with: StringOptions.RTFText)
     }
 
     /// Attempts to unarchive the Pasteboard's RTFD contents into an Attributed String
     ///
-    var RTFDAttributedString: NSAttributedString? {
+    func rtfdAttributedString() -> NSAttributedString? {
         return unarchiveAttributedString(fromPasteboardCFType: kUTTypeFlatRTFD, with: StringOptions.RTFDText)
-    }
-
-    /// Attempts to unarchive the Pasteboard's Text contents into an Attributed String
-    ///
-    var richTextAttributedString: NSAttributedString? {
-        return unarchiveAttributedString(fromPasteboardCFType: kUTTypeText, with: StringOptions.RTFText)
-    }
-
-    /// Attempts to unarchive the Pasteboard's Plain Text contents into an Attributed String
-    ///
-    var plainTextAttributedString: NSAttributedString? {
-        return unarchiveAttributedString(fromPasteboardCFType: kUTTypePlainText, with: StringOptions.plainText)
-    }
-
-    /// Attempts to unarchive the Pasteboard's Aztec-Archived String
-    ///
-    var aztecAttributedString: NSAttributedString? {
-        guard let data = data(forPasteboardType: NSAttributedString.pastesboardUTI) else {
-            return nil
-        }
-
-        return NSAttributedString.unarchive(with: data)
     }
 
     // MARK: - Helpers
@@ -75,9 +94,10 @@ private extension UIPasteboard {
     /// String Initialization Options
     ///
     private struct StringOptions {
+        static let html: [DocumentReadingOptionKey: DocumentType] = [.documentType: .html]
+        static let plainText: [DocumentReadingOptionKey: DocumentType] = [.documentType: .plain]
         static let RTFText: [DocumentReadingOptionKey: DocumentType] = [.documentType: .rtf]
         static let RTFDText: [DocumentReadingOptionKey: DocumentType] = [.documentType: .rtfd]
-        static let plainText: [DocumentReadingOptionKey: DocumentType] = [.documentType: .plain]
     }
 
     /// Attempts to unarchive a Pasteboard's Entry into a NSAttributedString Instance.
@@ -93,6 +113,6 @@ private extension UIPasteboard {
             return nil
         }
         
-        return try? NSAttributedString.init(data: data, options: options, documentAttributes: nil)
+        return try? NSAttributedString(data: data, options: options, documentAttributes: nil)
     }
 }

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -81,7 +81,7 @@ open class TextStorage: NSTextStorage {
     
     // MARK: - HTML Conversion
     
-    private let htmlConverter = HTMLConverter()
+    let htmlConverter = HTMLConverter()
     
     // MARK: - PluginManager
     
@@ -367,6 +367,21 @@ open class TextStorage: NSTextStorage {
         return htmlConverter.html(from: self, prettify: prettify)
     }
 
+    func insert(html: String, at characterPosition: Int, defaultAttributes: [NSAttributedStringKey: Any]) {
+        let attrString = htmlConverter.attributedString(from: html, defaultAttributes: defaultAttributes)
+        
+        insert(attrString, at: characterPosition)
+        setupAttachmentDelegates()
+    }
+    
+    func replace(range: NSRange, withHTML html: String, defaultAttributes: [NSAttributedStringKey: Any]) {
+        if range.length > 0 {
+            deleteCharacters(in: range)
+        }
+        
+        insert(html: html, at: range.location, defaultAttributes: defaultAttributes)
+    }
+    
     func setHTML(_ html: String, defaultAttributes: [NSAttributedStringKey: Any]) {
         let originalLength = length
         let attrString = htmlConverter.attributedString(from: html, defaultAttributes: defaultAttributes)

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -366,21 +366,6 @@ open class TextStorage: NSTextStorage {
     open func getHTML(prettify: Bool = false) -> String {
         return htmlConverter.html(from: self, prettify: prettify)
     }
-
-    func insert(html: String, at characterPosition: Int, defaultAttributes: [NSAttributedStringKey: Any]) {
-        let attrString = htmlConverter.attributedString(from: html, defaultAttributes: defaultAttributes)
-        
-        insert(attrString, at: characterPosition)
-        setupAttachmentDelegates()
-    }
-    
-    func replace(range: NSRange, withHTML html: String, defaultAttributes: [NSAttributedStringKey: Any]) {
-        if range.length > 0 {
-            deleteCharacters(in: range)
-        }
-        
-        insert(html: html, at: range.location, defaultAttributes: defaultAttributes)
-    }
     
     func setHTML(_ html: String, defaultAttributes: [NSAttributedStringKey: Any]) {
         let originalLength = length


### PR DESCRIPTION
### Description:

This PR improves drastically our support for pasting HTML content in Aztec.

Moves forward #1024.
Fixes #1020.

### Details:

In this PR I:

- Cleaned up the `UIPasterboard+Helpers.swift` code a bit.
     - Converted some calculated properties into methods, since the `Data` -> `NSAttributedString` conversion is most likely `O(n)` at least.
     - Reordered some methods alphabetically, to make it easier to look them up.
- Added some extra methods to `UIPasteboard` for handling URLs and HTML.
- Improved the pasting logic and cleaned up its code a bit.
- Added a method to be able to replace ranges in the attributed string with new HTML content.

Here's an example of how this looks:

![pastehtml](https://user-images.githubusercontent.com/1836005/44287160-29586400-a242-11e8-91b9-cefd8a18f992.gif)

### Known issues / limitations:

The pasted HTML can contain a lot of information (CSS inline styles, IDs, etc).

We'll add a customization step in the plugin so that each app can define if there's any HTML content than should be stripped when pasting (most likely attributes that the app doesn't want to use).

### Testing:

Note: for all tests use the standard empty editor and the Gutenberg / Calypso one.

**Test for regressions:**

1. Make sure pasting URLs work.  Try to undo the operation.
2. Make sure pasting regular text works.  Try to undo the operation.
3. Run the unit tests.

**Test pasting HTML content:**

1. Open Safari, and go to the Wikipedia page for WordPress.
2. Copy any chunk of text.
3. Paste it anywhere in the editor.
4. Switch to HTML and back, and make sure the content looks the same as when you pasted it.
