### PR TITLE
Improve pasting label

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -437,18 +437,17 @@ open class TextView: UITextView {
     }
 
     @objc open func pasteAndMatchStyle(_ sender: Any?) {
-        guard let string = UIPasteboard.general.attributedString()?.mutableCopy() as? NSMutableAttributedString else {
+        guard let string = UIPasteboard.general.string else {
             super.paste(sender)
             return
         }
 
-        let range = string.rangeOfEntireString
-        string.addAttributes(typingAttributesSwifted, range: range)
-        string.loadLazyAttachments()
+        let attributedString = NSMutableAttributedString(string: string, attributes: typingAttributesSwifted)
+        attributedString.loadLazyAttachments()
 
-        storage.replaceCharacters(in: selectedRange, with: string)
+        storage.replaceCharacters(in: selectedRange, with: attributedString)
         notifyTextViewDidChange()
-        selectedRange = NSRange(location: selectedRange.location + string.length, length: 0)
+        selectedRange = NSRange(location: selectedRange.location + attributedString.length, length: 0)
     }
     
     // MARK: - Try Pasting

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -479,6 +479,13 @@ open class TextView: UITextView {
             return false
         }
         
+        let finalRange = NSRange(location: selectedRange.location, length: string.count)
+        let originalText = attributedText.attributedSubstring(from: selectedRange)
+        
+        undoManager?.registerUndo(withTarget: self, handler: { [weak self] target in
+            self?.undoTextReplacement(of: originalText, finalRange: finalRange)
+        })
+        
         let attributedString = NSMutableAttributedString(string: string, attributes: typingAttributesSwifted)
         attributedString.loadLazyAttachments()
         

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -376,7 +376,7 @@ open class TextView: UITextView {
     }
 
     private func setupMenuController() {
-        let pasteAndMatchTitle = NSLocalizedString("Paste and Match Style", comment: "Paste and Match Menu Item")
+        let pasteAndMatchTitle = NSLocalizedString("Paste without Formatting", comment: "Paste without Formatting Menu Item")
         let pasteAndMatchItem = UIMenuItem(title: pasteAndMatchTitle, action: #selector(pasteAndMatchStyle))
         UIMenuController.shared.menuItems = [pasteAndMatchItem]
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -445,6 +445,10 @@ open class TextView: UITextView {
     
     // MARK: - Try Pasting
     
+    /// Tries to paste an attributed string from the clipboard as source, replacing the selected range.
+    ///
+    /// - Returns: True if this method succeeds.
+    ///
     private func tryPastingAttributedString() -> Bool {
         guard let string = UIPasteboard.general.attributedString() else {
             return false
@@ -464,7 +468,11 @@ open class TextView: UITextView {
         selectedRange = NSRange(location: selectedRange.location + string.length, length: 0)
         return true
     }
-    
+
+    /// Tries to paste HTML from the clipboard as source, replacing the selected range.
+    ///
+    /// - Returns: True if this method succeeds.
+    ///
     func tryPastingHTML() -> Bool {
         guard let html = UIPasteboard.general.html() else {
             return false
@@ -473,7 +481,11 @@ open class TextView: UITextView {
         replace(selectedRange, withHTML: html)
         return true
     }
-    
+
+    /// Tries to paste raw text from the clipboard, replacing the selected range.
+    ///
+    /// - Returns: True if this method succeeds.
+    ///
     private func tryPastingString() -> Bool {
         guard let string = UIPasteboard.general.string else {
             return false
@@ -495,10 +507,9 @@ open class TextView: UITextView {
         return true
     }
 
-    /// If there is selected text and a URL is available on the pasteboard,
-    /// this method creates a link to the URL using the selected text.
+    /// Tries to paste a URL from the clipboard as a link applied to the selected range.
     ///
-    /// - returns: True if a link was successfully created
+    /// - Returns: True if this method succeeds.
     ///
     private func tryPastingURL() -> Bool {
         guard selectedRange.length > 0,

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1480,12 +1480,79 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.lineFeed))
     }    
 
-    // MARK: - Media
+    // MARK: - Media: Images
+    
+    
+    func testPasteImage() {
+        let sourceTextView = createTextView(withHTML: "<em>This is an image </em>")
+        let targetTextView = createTextView(withHTML: "<strong>Pasted: </strong>")
+        
+        let videoInsertionRange = NSRange(location: sourceTextView.text.count, length: 0)
+        let _ = sourceTextView.replaceWithImage(at: videoInsertionRange, sourceURL: URL(string: "image.jpg")!, placeHolderImage: nil)
+        
+        sourceTextView.selectedRange = NSRange(location: 0, length: sourceTextView.text.count)
+        sourceTextView.copy(nil)
+        
+        targetTextView.selectedRange = NSRange(location: targetTextView.text.count, length: 0)
+        targetTextView.paste(nil)
+        
+        XCTAssertEqual(targetTextView.getHTML(), "<p><strong>Pasted: </strong><em>This is an image <img src=\"image.jpg\"></em></p>")
+    }
+    
+    func testPasteImageWithoutFormatting() {
+        let sourceTextView = createTextView(withHTML: "<em>This is an image </em>")
+        let targetTextView = createTextView(withHTML: "<strong>Pasted: </strong>")
+        
+        let videoInsertionRange = NSRange(location: sourceTextView.text.count, length: 0)
+        let _ = sourceTextView.replaceWithImage(at: videoInsertionRange, sourceURL: URL(string: "image.jpg")!, placeHolderImage: nil)
+        
+        sourceTextView.selectedRange = NSRange(location: 0, length: sourceTextView.text.count)
+        sourceTextView.copy(nil)
+        
+        targetTextView.selectedRange = NSRange(location: targetTextView.text.count, length: 0)
+        targetTextView.pasteWithoutFormatting(nil)
+        
+        XCTAssertEqual(targetTextView.getHTML(), "<p><strong>Pasted: This is an image <img src=\"image.jpg\"></strong></p>")
+    }
+    
+    // MARK: - Media: Video
 
     func testInsertVideo() {
         let textView = createEmptyTextView()
         let _ = textView.replaceWithVideo(at: NSRange(location:0, length:0), sourceURL: URL(string: "video.mp4")!, posterURL: URL(string: "video.jpg"), placeHolderImage: nil)
         XCTAssertEqual(textView.getHTML(), "<p><video src=\"video.mp4\" poster=\"video.jpg\"></video></p>")
+    }
+    
+    func testPasteVideo() {
+        let sourceTextView = createTextView(withHTML: "<em>This is a video </em>")
+        let targetTextView = createTextView(withHTML: "<strong>Pasted: </strong>")
+        
+        let videoInsertionRange = NSRange(location: sourceTextView.text.count, length: 0)
+        let _ = sourceTextView.replaceWithVideo(at: videoInsertionRange, sourceURL: URL(string: "video.mp4")!, posterURL: URL(string: "video.jpg"), placeHolderImage: nil)
+        
+        sourceTextView.selectedRange = NSRange(location: 0, length: sourceTextView.text.count)
+        sourceTextView.copy(nil)
+        
+        targetTextView.selectedRange = NSRange(location: targetTextView.text.count, length: 0)
+        targetTextView.paste(nil)
+        
+        XCTAssertEqual(targetTextView.getHTML(), "<p><strong>Pasted: </strong><em>This is a video <video src=\"video.mp4\" poster=\"video.jpg\"></video></em></p>")
+    }
+    
+    func testPasteVideoWithoutFormatting() {
+        let sourceTextView = createTextView(withHTML: "<em>This is a video </em>")
+        let targetTextView = createTextView(withHTML: "<strong>Pasted: </strong>")
+        
+        let videoInsertionRange = NSRange(location: sourceTextView.text.count, length: 0)
+        let _ = sourceTextView.replaceWithVideo(at: videoInsertionRange, sourceURL: URL(string: "video.mp4")!, posterURL: URL(string: "video.jpg"), placeHolderImage: nil)
+        
+        sourceTextView.selectedRange = NSRange(location: 0, length: sourceTextView.text.count)
+        sourceTextView.copy(nil)
+        
+        targetTextView.selectedRange = NSRange(location: targetTextView.text.count, length: 0)
+        targetTextView.pasteWithoutFormatting(nil)
+        
+        XCTAssertEqual(targetTextView.getHTML(), "<p><strong>Pasted: This is a video <video src=\"video.mp4\" poster=\"video.jpg\"></video></strong></p>")
     }
 
     /// Verifies that any edition performed on VideoAttachment's srcURL attribute is properly serialized back,


### PR DESCRIPTION
### Description:

"Paste and Match" has been renamed to "Paste without Formatting".
There's also a minor refactor in the code, to make it simpler and to make sure links are stripped when pasting without formatting.

**EDIT:** "Paste without Formatting" didn't have undo support.  I've just added it.

Fixes #1028 

### Testing:

**Test 1:**
- Open the plain HTML standard demo.
- Copy any styled text.
- Move to caret to any other position.
- Paste.

Make sure the original style is maintained in the pasted text.

**Test 2:**

Repeat test 1 but copy styled text from Safari.

**Test 3:**
- Open the plain HTML standard demo.
- Copy any styled text.
- Move to caret to any other position.
- Paste without Formatting.

Make sure the formatting from the caret position is used for the pasted text.

**Test 4:**

Repeat test 3 but copy styled text from Safari.
