### PR TITLE
Implements editing of target attribute in .A elements

### DIFF
--- a/Aztec/Classes/Constants/HTMLConstants.swift
+++ b/Aztec/Classes/Constants/HTMLConstants.swift
@@ -6,4 +6,5 @@ import Foundation
 public enum HTMLLinkAttribute: String {
 
     case Href = "href"
+    case target = "target"
 }

--- a/Aztec/Classes/Formatters/Implementations/LinkFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/LinkFormatter.swift
@@ -2,6 +2,8 @@ import UIKit
 
 class LinkFormatter: StandardAttributeFormatter {
 
+    var target: String?
+
     init() {
         super.init(attributeKey: .link,
                    attributeValue: NSURL(string:"")!,
@@ -9,6 +11,7 @@ class LinkFormatter: StandardAttributeFormatter {
     }
 
     override func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
+        var finalRepresentation: HTMLRepresentation?
 
         if let representation = representation,
             case let .element(element) = representation.kind {
@@ -21,15 +24,27 @@ class LinkFormatter: StandardAttributeFormatter {
                }
             } else {
                 attributeValue = NSURL(string: "")!
-            }            
+            }
+            finalRepresentation = representation
         } else {
 
             // There's no support fora link representation that's not an HTML element, so this
             // scenario should only be possible if `representation == nil`.
             //
             assert(representation == nil)
+            var attributes = [Attribute]()
+            if let url = attributeValue as? URL {
+                let urlValue = Attribute(name: HTMLLinkAttribute.Href.rawValue, value: .string(url.absoluteString))
+                attributes.append(urlValue)
+            }
+            if let target = target {
+                let targetValue = Attribute(name: HTMLLinkAttribute.target.rawValue, value: .string(target))
+                attributes.append(targetValue)
+            }
+            let linkRepresentation = HTMLElementRepresentation(name: Element.a.rawValue, attributes: attributes)
+            finalRepresentation = HTMLRepresentation(for: .element(linkRepresentation))
         }
         
-        return super.apply(to: attributes, andStore: representation)
+        return super.apply(to: attributes, andStore: finalRepresentation)
     }
 }

--- a/Aztec/Classes/Formatters/Implementations/LinkFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/LinkFormatter.swift
@@ -2,9 +2,10 @@ import UIKit
 
 class LinkFormatter: StandardAttributeFormatter {
 
-    var target: String?
+    let target: String?
 
-    init() {
+    init(target: String? = nil) {
+        self.target = target
         super.init(attributeKey: .link,
                    attributeValue: NSURL(string:"")!,
                    htmlRepresentationKey: .linkHtmlRepresentation)
@@ -33,14 +34,17 @@ class LinkFormatter: StandardAttributeFormatter {
             //
             assert(representation == nil)
             var attributes = [Attribute]()
+
             if let url = attributeValue as? URL {
                 let urlValue = Attribute(name: HTMLLinkAttribute.Href.rawValue, value: .string(url.absoluteString))
                 attributes.append(urlValue)
             }
+
             if let target = target {
                 let targetValue = Attribute(name: HTMLLinkAttribute.target.rawValue, value: .string(target))
                 attributes.append(targetValue)
             }
+
             let linkRepresentation = HTMLElementRepresentation(name: Element.a.rawValue, attributes: attributes)
             finalRepresentation = HTMLRepresentation(for: .element(linkRepresentation))
         }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1402,9 +1402,9 @@ open class TextView: UITextView {
             self?.undoTextReplacement(of: originalText, finalRange: finalRange)
         })
 
-        let formatter = LinkFormatter()
+        let formatter = LinkFormatter(target: target)
         formatter.attributeValue = url
-        formatter.target = target
+
         let attributes = formatter.apply(to: typingAttributesSwifted)
         storage.replaceCharacters(in: range, with: NSAttributedString(string: title, attributes: attributes))
 
@@ -1421,9 +1421,9 @@ open class TextView: UITextView {
     ///     - range: The NSRange to edit.
     ///
     open func setLink(_ url: URL, target: String? = nil, inRange range: NSRange) {
-        let formatter = LinkFormatter()
+        let formatter = LinkFormatter(target: target)
         formatter.attributeValue = url
-        formatter.target = target
+
         apply(formatter: formatter, atRange: range, remove: false)
     }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1664,7 +1664,8 @@ open class TextView: UITextView {
         let index = maxIndex(range.location)
         var effectiveRange = NSRange()
         guard index < storage.length,
-            let representation = storage.attribute(.linkHtmlRepresentation, at: index, effectiveRange: &effectiveRange) as? HTMLRepresentation,
+            let _ = storage.attribute(.link, at: index, longestEffectiveRange: &effectiveRange, in: storage.rangeOfEntireString),        
+            let representation = storage.attribute(.linkHtmlRepresentation, at: effectiveRange.location, effectiveRange: nil) as? HTMLRepresentation,
             case .element(let element) = representation.kind
             else {
                 return nil

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -672,6 +672,16 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(textView.getHTML(), html)
     }
 
+    func testParsingOfLinkWithTarget() {
+        let html = "<p><a href=\"http:\\wordpress.com?\" target=\"_blank\">link</a></p>"
+        let textView = TextViewStub(withHTML: html)
+        let insertionRange = NSRange(location: 0, length: 4)
+        let target = textView.linkTarget(forRange: insertionRange)
+        XCTAssertEqual(textView.getHTML(), html)
+
+        XCTAssertEqual(target, "_blank")
+    }
+
     func testToggleBlockquoteWriteOneCharAndDelete() {
         let textView = TextViewStub()
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -800,17 +800,17 @@ extension EditorDemoController {
            linkRange = expandedRange
            linkURL = richTextView.linkURL(forRange: expandedRange)
         }
-
+        let target = richTextView.linkTarget(forRange: richTextView.selectedRange)
         linkTitle = richTextView.attributedText.attributedSubstring(from: linkRange).string
         let allowTextEdit = !richTextView.attributedText.containsAttachments(in: linkRange)
-        showLinkDialog(forURL: linkURL, text: linkTitle, range: linkRange, allowTextEdit: allowTextEdit)
+        showLinkDialog(forURL: linkURL, text: linkTitle, target: target, range: linkRange, allowTextEdit: allowTextEdit)
     }
 
     func insertMoreAttachment() {
         richTextView.replace(richTextView.selectedRange, withComment: Constants.moreAttachmentText)
     }
 
-    func showLinkDialog(forURL url: URL?, text: String?, range: NSRange, allowTextEdit: Bool = true) {
+    func showLinkDialog(forURL url: URL?, text: String?, target: String?, range: NSRange, allowTextEdit: Bool = true) {
 
         let isInsertingNewLink = (url == nil)
         var urlToUse = url
@@ -834,7 +834,10 @@ extension EditorDemoController {
         alertController.addTextField(configurationHandler: { [weak self]textField in
             textField.clearButtonMode = UITextFieldViewMode.always;
             textField.placeholder = NSLocalizedString("URL", comment:"URL text field placeholder");
-            
+            textField.keyboardType = .URL
+            if #available(iOS 10, *) {
+                textField.textContentType = .URL
+            }
             textField.text = urlToUse?.absoluteString
 
             textField.addTarget(self,
@@ -859,13 +862,35 @@ extension EditorDemoController {
 
                 })
         }
+
+        alertController.addTextField(configurationHandler: { textField in
+            textField.clearButtonMode = UITextFieldViewMode.always
+            textField.placeholder = NSLocalizedString("Target", comment:"Link text field placeholder")
+            textField.isSecureTextEntry = false
+            textField.autocapitalizationType = UITextAutocapitalizationType.sentences
+            textField.autocorrectionType = UITextAutocorrectionType.default
+            textField.spellCheckingType = UITextSpellCheckingType.default
+
+            textField.text = target;
+
+            textField.accessibilityIdentifier = "linkModalTarget"
+
+        })
+
         let insertAction = UIAlertAction(title:insertButtonTitle,
                                          style:UIAlertActionStyle.default,
                                          handler:{ [weak self]action in
 
                                             self?.richTextView.becomeFirstResponder()
-                                            let linkURLString = alertController.textFields?.first?.text
-                                            var linkTitle = alertController.textFields?.last?.text
+                                            guard let textFields = alertController.textFields else {
+                                                    return
+                                            }
+                                            let linkURLField = textFields[0]
+                                            let linkTextField = textFields[1]
+                                            let linkTargetField = textFields[2]
+                                            let linkURLString = linkURLField.text
+                                            var linkTitle = linkTextField.text
+                                            let target = linkTargetField.text
 
                                             if  linkTitle == nil  || linkTitle!.isEmpty {
                                                 linkTitle = linkURLString
@@ -879,10 +904,10 @@ extension EditorDemoController {
                                             }
                                             if allowTextEdit {
                                                 if let title = linkTitle {
-                                                    self?.richTextView.setLink(url, title:title, inRange: range)
+                                                    self?.richTextView.setLink(url, title: title, target: target, inRange: range)
                                                 }
                                             } else {
-                                                self?.richTextView.setLink(url, inRange: range)
+                                                self?.richTextView.setLink(url, target: target, inRange: range)
                                             }
                                             })
         

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -14,7 +14,7 @@ Underline: <u>Underlined text</u><br/>
 Strikethrough: <del>Strikethrough</del><br/>
 Colors: <span style="color: #ff0000;">Colors</span><br/>
 Undeline with CSS: <span style="text-decoration: underline;">Alternative underline text</span><br/>
-Links: <a href="http://www.wordpress.com">I'm a link!</a><br/>
+Links: <a href="http://www.wordpress.com">I'm a link!</a><br/> <a href="http://www.wordpress.com" target="_blank">Open in new window link!</a> <br/>
 Code: <code>print("Hello world")</code>
 
 <hr/>


### PR DESCRIPTION
Refs: https://github.com/wordpress-mobile/WordPress-iOS/pull/10059 and https://github.com/wordpress-mobile/WordPress-iOS/issues/7670

This PR adds support for the target attribute on `a` elements.

This is implemented using the already existing HTMLRepresentation element.

To test:
 - Open the demo app.
 - Open the demo with content
 - Select the links provided in the sample content
 - Tap on the link button
 - see if the target shows correctly
 - Edit the target and change the value
 - Switch to HTML 
 - Check the value is updated correctly.

