### PR TITLE
Add no opener attribute when adding targets.

### DIFF
--- a/Aztec/Classes/Constants/HTMLConstants.swift
+++ b/Aztec/Classes/Constants/HTMLConstants.swift
@@ -7,4 +7,5 @@ public enum HTMLLinkAttribute: String {
 
     case Href = "href"
     case target = "target"
+    case rel = "rel"
 }

--- a/Aztec/Classes/Formatters/Implementations/LinkFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/LinkFormatter.swift
@@ -43,6 +43,8 @@ class LinkFormatter: StandardAttributeFormatter {
             if let target = target {
                 let targetValue = Attribute(name: HTMLLinkAttribute.target.rawValue, value: .string(target))
                 attributes.append(targetValue)
+                let norel = Attribute(name: HTMLLinkAttribute.rel.rawValue, value: .string("noopener"))
+                attributes.append(norel)
             }
 
             let linkRepresentation = HTMLElementRepresentation(name: Element.a.rawValue, attributes: attributes)


### PR DESCRIPTION
Fixes #1041 

To test:
 - Check that inserted or update link always set the `rel=noopener` attribute

