### PR TITLE
Adds more unit tests.

### DIFF
--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -39,7 +39,7 @@ class TextViewTests: XCTestCase {
         return richTextView
     }
 
-    // Confirm the composed textView is property configured.
+    // MARK: - Configuration
 
     func testTextViewReferencesStorage() {
 
@@ -1927,5 +1927,4 @@ class TextViewTests: XCTestCase {
 
         XCTAssertEqual(textView.getHTML(prettify: false), originalHTML)
     }
-
 }

--- a/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
+++ b/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		F1FC707221398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC707121398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift */; };
 		F1FC707421398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC707321398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift */; };
 		F1FC7076213991FA007AAFB3 /* MediaAttachmentWordPressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC7075213991FA007AAFB3 /* MediaAttachmentWordPressTests.swift */; };
+		F1FC70782139952C007AAFB3 /* VideoAttachmentWordPressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC70772139952C007AAFB3 /* VideoAttachmentWordPressTests.swift */; };
 		FF72508C20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */; };
 		FFC41BEA20DD04A8004DFB4D /* GutenpackConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */; };
 		FFC41BF620DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */; };
@@ -138,6 +139,7 @@
 		F1FC707121398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryAttachmentToElementConverterTests.swift; sourceTree = "<group>"; };
 		F1FC707321398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentWordPressTests.swift; sourceTree = "<group>"; };
 		F1FC7075213991FA007AAFB3 /* MediaAttachmentWordPressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaAttachmentWordPressTests.swift; sourceTree = "<group>"; };
+		F1FC70772139952C007AAFB3 /* VideoAttachmentWordPressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentWordPressTests.swift; sourceTree = "<group>"; };
 		FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergAttributeDecoder.swift; sourceTree = "<group>"; };
 		FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackConverter.swift; sourceTree = "<group>"; };
 		FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackAttachmentToElementConverter.swift; sourceTree = "<group>"; };
@@ -435,6 +437,7 @@
 				F1FC707321398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift */,
 				F1FC7075213991FA007AAFB3 /* MediaAttachmentWordPressTests.swift */,
 				F1DF4D382123C53A00EAE9F6 /* StringRegExTests.swift */,
+				F1FC70772139952C007AAFB3 /* VideoAttachmentWordPressTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -609,6 +612,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F1FC70782139952C007AAFB3 /* VideoAttachmentWordPressTests.swift in Sources */,
 				F118745320BC41BF0079C631 /* WordPressPluginTests.swift in Sources */,
 				F1D361152092A37600B4E7A5 /* AutoPProcessorTests.swift in Sources */,
 				F1FC707221398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift in Sources */,

--- a/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
+++ b/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		F1FC706E213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC706D213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift */; };
 		F1FC707221398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC707121398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift */; };
 		F1FC707421398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC707321398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift */; };
+		F1FC7076213991FA007AAFB3 /* MediaAttachmentWordPressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC7075213991FA007AAFB3 /* MediaAttachmentWordPressTests.swift */; };
 		FF72508C20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */; };
 		FFC41BEA20DD04A8004DFB4D /* GutenpackConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */; };
 		FFC41BF620DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */; };
@@ -136,6 +137,7 @@
 		F1FC706D213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryElementToTagConverterTests.swift; sourceTree = "<group>"; };
 		F1FC707121398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryAttachmentToElementConverterTests.swift; sourceTree = "<group>"; };
 		F1FC707321398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentWordPressTests.swift; sourceTree = "<group>"; };
+		F1FC7075213991FA007AAFB3 /* MediaAttachmentWordPressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaAttachmentWordPressTests.swift; sourceTree = "<group>"; };
 		FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergAttributeDecoder.swift; sourceTree = "<group>"; };
 		FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackConverter.swift; sourceTree = "<group>"; };
 		FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackAttachmentToElementConverter.swift; sourceTree = "<group>"; };
@@ -431,6 +433,7 @@
 			isa = PBXGroup;
 			children = (
 				F1FC707321398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift */,
+				F1FC7075213991FA007AAFB3 /* MediaAttachmentWordPressTests.swift */,
 				F1DF4D382123C53A00EAE9F6 /* StringRegExTests.swift */,
 			);
 			path = Extensions;
@@ -615,6 +618,7 @@
 				F16A2ACC20CB115900BF3A0A /* GalleryElementConverterTests.swift in Sources */,
 				F1FC707421398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift in Sources */,
 				F1D36126209352A200B4E7A5 /* CaptionShortcodeInputProcessorTests.swift in Sources */,
+				F1FC7076213991FA007AAFB3 /* MediaAttachmentWordPressTests.swift in Sources */,
 				F1D361142092A37600B4E7A5 /* RemovePProcessorTests.swift in Sources */,
 				F1FC706E213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift in Sources */,
 				F1DF4D392123C53A00EAE9F6 /* StringRegExTests.swift in Sources */,

--- a/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
+++ b/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		F1D3612C209352F400B4E7A5 /* MediaAttachment+WordPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D3612A209352F400B4E7A5 /* MediaAttachment+WordPress.swift */; };
 		F1D3612E209352F800B4E7A5 /* VideoAttachment+WordPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D3612D209352F800B4E7A5 /* VideoAttachment+WordPress.swift */; };
 		F1DF4D392123C53A00EAE9F6 /* StringRegExTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DF4D382123C53A00EAE9F6 /* StringRegExTests.swift */; };
+		F1FC706E213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC706D213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift */; };
 		FF72508C20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */; };
 		FFC41BEA20DD04A8004DFB4D /* GutenpackConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */; };
 		FFC41BF620DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */; };
@@ -130,6 +131,7 @@
 		F1D3612D209352F800B4E7A5 /* VideoAttachment+WordPress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VideoAttachment+WordPress.swift"; sourceTree = "<group>"; };
 		F1D91E3220A5D61800E0B7F4 /* GutenbergInputHTMLTreeProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergInputHTMLTreeProcessor.swift; sourceTree = "<group>"; };
 		F1DF4D382123C53A00EAE9F6 /* StringRegExTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringRegExTests.swift; sourceTree = "<group>"; };
+		F1FC706D213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryElementToTagConverterTests.swift; sourceTree = "<group>"; };
 		FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergAttributeDecoder.swift; sourceTree = "<group>"; };
 		FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackConverter.swift; sourceTree = "<group>"; };
 		FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackAttachmentToElementConverter.swift; sourceTree = "<group>"; };
@@ -229,6 +231,7 @@
 			isa = PBXGroup;
 			children = (
 				F16A2ACB20CB115900BF3A0A /* GalleryElementConverterTests.swift */,
+				F1FC706D213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift */,
 				F1B0012C20C5948000612EE9 /* GalleryShortcodeInputProcessorTests.swift */,
 			);
 			path = GalleryShortcode;
@@ -605,6 +608,7 @@
 				F16A2ACC20CB115900BF3A0A /* GalleryElementConverterTests.swift in Sources */,
 				F1D36126209352A200B4E7A5 /* CaptionShortcodeInputProcessorTests.swift in Sources */,
 				F1D361142092A37600B4E7A5 /* RemovePProcessorTests.swift in Sources */,
+				F1FC706E213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift in Sources */,
 				F1DF4D392123C53A00EAE9F6 /* StringRegExTests.swift in Sources */,
 				F1D36128209352AA00B4E7A5 /* ShortcodeProcessorTests.swift in Sources */,
 			);

--- a/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
+++ b/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		F1D3612E209352F800B4E7A5 /* VideoAttachment+WordPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D3612D209352F800B4E7A5 /* VideoAttachment+WordPress.swift */; };
 		F1DF4D392123C53A00EAE9F6 /* StringRegExTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DF4D382123C53A00EAE9F6 /* StringRegExTests.swift */; };
 		F1FC706E213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC706D213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift */; };
+		F1FC707221398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC707121398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift */; };
 		FF72508C20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */; };
 		FFC41BEA20DD04A8004DFB4D /* GutenpackConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */; };
 		FFC41BF620DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */; };
@@ -132,6 +133,7 @@
 		F1D91E3220A5D61800E0B7F4 /* GutenbergInputHTMLTreeProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergInputHTMLTreeProcessor.swift; sourceTree = "<group>"; };
 		F1DF4D382123C53A00EAE9F6 /* StringRegExTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringRegExTests.swift; sourceTree = "<group>"; };
 		F1FC706D213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryElementToTagConverterTests.swift; sourceTree = "<group>"; };
+		F1FC707121398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryAttachmentToElementConverterTests.swift; sourceTree = "<group>"; };
 		FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergAttributeDecoder.swift; sourceTree = "<group>"; };
 		FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackConverter.swift; sourceTree = "<group>"; };
 		FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackAttachmentToElementConverter.swift; sourceTree = "<group>"; };
@@ -230,6 +232,7 @@
 		F16A2AED20CDAB7600BF3A0A /* GalleryShortcode */ = {
 			isa = PBXGroup;
 			children = (
+				F1FC707121398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift */,
 				F16A2ACB20CB115900BF3A0A /* GalleryElementConverterTests.swift */,
 				F1FC706D213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift */,
 				F1B0012C20C5948000612EE9 /* GalleryShortcodeInputProcessorTests.swift */,
@@ -602,6 +605,7 @@
 			files = (
 				F118745320BC41BF0079C631 /* WordPressPluginTests.swift in Sources */,
 				F1D361152092A37600B4E7A5 /* AutoPProcessorTests.swift in Sources */,
+				F1FC707221398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift in Sources */,
 				F1B0012D20C5948000612EE9 /* GalleryShortcodeInputProcessorTests.swift in Sources */,
 				F14C4D2820C0E9AB007CBC57 /* GutenbergInputHTMLTreeProcessorTests.swift in Sources */,
 				F1D36125209352A200B4E7A5 /* CaptionShortcodeOutputProcessorTests.swift in Sources */,

--- a/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
+++ b/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		F1FC707421398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC707321398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift */; };
 		F1FC7076213991FA007AAFB3 /* MediaAttachmentWordPressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC7075213991FA007AAFB3 /* MediaAttachmentWordPressTests.swift */; };
 		F1FC70782139952C007AAFB3 /* VideoAttachmentWordPressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC70772139952C007AAFB3 /* VideoAttachmentWordPressTests.swift */; };
+		F1FC708021399A3B007AAFB3 /* GutenblockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC707F21399A3B007AAFB3 /* GutenblockTests.swift */; };
 		FF72508C20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */; };
 		FFC41BEA20DD04A8004DFB4D /* GutenpackConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */; };
 		FFC41BF620DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */; };
@@ -140,6 +141,7 @@
 		F1FC707321398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentWordPressTests.swift; sourceTree = "<group>"; };
 		F1FC7075213991FA007AAFB3 /* MediaAttachmentWordPressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaAttachmentWordPressTests.swift; sourceTree = "<group>"; };
 		F1FC70772139952C007AAFB3 /* VideoAttachmentWordPressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAttachmentWordPressTests.swift; sourceTree = "<group>"; };
+		F1FC707F21399A3B007AAFB3 /* GutenblockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenblockTests.swift; sourceTree = "<group>"; };
 		FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergAttributeDecoder.swift; sourceTree = "<group>"; };
 		FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackConverter.swift; sourceTree = "<group>"; };
 		FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackAttachmentToElementConverter.swift; sourceTree = "<group>"; };
@@ -267,6 +269,7 @@
 		F16A2AF020CDABB200BF3A0A /* Gutenberg */ = {
 			isa = PBXGroup;
 			children = (
+				F1FC707F21399A3B007AAFB3 /* GutenblockTests.swift */,
 				F14C4D2720C0E9AA007CBC57 /* GutenbergInputHTMLTreeProcessorTests.swift */,
 			);
 			path = Gutenberg;
@@ -613,6 +616,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F1FC70782139952C007AAFB3 /* VideoAttachmentWordPressTests.swift in Sources */,
+				F1FC708021399A3B007AAFB3 /* GutenblockTests.swift in Sources */,
 				F118745320BC41BF0079C631 /* WordPressPluginTests.swift in Sources */,
 				F1D361152092A37600B4E7A5 /* AutoPProcessorTests.swift in Sources */,
 				F1FC707221398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift in Sources */,

--- a/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
+++ b/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		F1DF4D392123C53A00EAE9F6 /* StringRegExTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DF4D382123C53A00EAE9F6 /* StringRegExTests.swift */; };
 		F1FC706E213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC706D213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift */; };
 		F1FC707221398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC707121398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift */; };
+		F1FC707421398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC707321398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift */; };
 		FF72508C20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */; };
 		FFC41BEA20DD04A8004DFB4D /* GutenpackConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */; };
 		FFC41BF620DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */; };
@@ -134,6 +135,7 @@
 		F1DF4D382123C53A00EAE9F6 /* StringRegExTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringRegExTests.swift; sourceTree = "<group>"; };
 		F1FC706D213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryElementToTagConverterTests.swift; sourceTree = "<group>"; };
 		F1FC707121398639007AAFB3 /* GalleryAttachmentToElementConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryAttachmentToElementConverterTests.swift; sourceTree = "<group>"; };
+		F1FC707321398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentWordPressTests.swift; sourceTree = "<group>"; };
 		FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergAttributeDecoder.swift; sourceTree = "<group>"; };
 		FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackConverter.swift; sourceTree = "<group>"; };
 		FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackAttachmentToElementConverter.swift; sourceTree = "<group>"; };
@@ -373,8 +375,8 @@
 		F1D360C72092967E00B4E7A5 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				F1065DB720ADEC1D008C72CC /* Plugins */,
 				F1D360F920929E0700B4E7A5 /* Extensions */,
+				F1065DB720ADEC1D008C72CC /* Plugins */,
 				F1D3610C20929F3A00B4E7A5 /* Processors */,
 				F1AFD65020B45DBB00CB0279 /* Renderers */,
 			);
@@ -428,6 +430,7 @@
 		F1DF4D352123C51900EAE9F6 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				F1FC707321398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift */,
 				F1DF4D382123C53A00EAE9F6 /* StringRegExTests.swift */,
 			);
 			path = Extensions;
@@ -610,6 +613,7 @@
 				F14C4D2820C0E9AB007CBC57 /* GutenbergInputHTMLTreeProcessorTests.swift in Sources */,
 				F1D36125209352A200B4E7A5 /* CaptionShortcodeOutputProcessorTests.swift in Sources */,
 				F16A2ACC20CB115900BF3A0A /* GalleryElementConverterTests.swift in Sources */,
+				F1FC707421398B0A007AAFB3 /* ImageAttachmentWordPressTests.swift in Sources */,
 				F1D36126209352A200B4E7A5 /* CaptionShortcodeInputProcessorTests.swift in Sources */,
 				F1D361142092A37600B4E7A5 /* RemovePProcessorTests.swift in Sources */,
 				F1FC706E213983CE007AAFB3 /* GalleryElementToTagConverterTests.swift in Sources */,

--- a/WordPressEditor/WordPressEditor/Classes/Extensions/ImageAttachment+WordPress.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Extensions/ImageAttachment+WordPress.swift
@@ -55,7 +55,9 @@ extension ImageAttachment {
             guard let classAttribute = extraAttributes["class"] else {
                 return nil
             }
+            
             let attributes = classAttribute.components(separatedBy: " ")
+            
             guard let imageIDAttribute = attributes.filter({ (value) -> Bool in
                 value.hasPrefix("wp-image-")
             }).first else {
@@ -64,20 +66,25 @@ extension ImageAttachment {
 
             let imagePrefix = "wp-image-"
             let imageIDString = String(imageIDAttribute.dropFirst(imagePrefix.count))
+            
             return Int(imageIDString)
         }
         set {
             var attributes = [String]()
+            
             if let classAttribute = extraAttributes["class"] {
                 attributes = classAttribute.components(separatedBy: " ")
             }
+            
             attributes = attributes.filter({ (value) -> Bool in
                 !value.hasPrefix("wp-image-")
             })
+            
             if let nonNilValue = newValue {
                 attributes.append("wp-image-\(nonNilValue)")
             }
-            if extraAttributes.isEmpty {
+            
+            if attributes.isEmpty {
                 extraAttributes.removeValue(forKey: "class")
             } else {
                 extraAttributes["class"] = attributes.joined(separator: " ")

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/GalleryShortcode/GalleryAttachmentToElementConverter.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/GalleryShortcode/GalleryAttachmentToElementConverter.swift
@@ -51,8 +51,8 @@ extension GalleryAttachmentToElementConverter {
     }
     
     private func getColumnsAttribute(from attachment: GalleryAttachment) -> Attribute? {
-        guard let value = attachment.columns  else {
-                return nil
+        guard let value = attachment.columns else {
+            return nil
         }
         
         let stringValue = String(value)

--- a/WordPressEditor/WordPressEditor/Classes/Processors/ShortcodeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Processors/ShortcodeProcessor.swift
@@ -90,7 +90,7 @@ private extension ShortcodeProcessor {
         
         let attributes = self.attributes(from: match, in: text)
         let elementType = self.elementType(from: match, in: text)
-        let content: String? = match.captureGroup(in:CaptureGroups.content.rawValue, text: text)
+        let content: String? = match.captureGroup(in: CaptureGroups.content.rawValue, text: text)
         
         let shortcode = Shortcode(tag: tag, attributes: attributes, type: elementType, content: content)
         

--- a/WordPressEditor/WordPressEditorTests/Extensions/ImageAttachmentWordPressTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Extensions/ImageAttachmentWordPressTests.swift
@@ -2,7 +2,7 @@ import Aztec
 import XCTest
 @testable import WordPressEditor
 
-class ImageAttachmentTests: XCTestCase {
+class ImageAttachmentWordPressTests: XCTestCase {
     
     func testAltSetter() {
         let imageAttachment = ImageAttachment(identifier: "testing")

--- a/WordPressEditor/WordPressEditorTests/Extensions/ImageAttachmentWordPressTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Extensions/ImageAttachmentWordPressTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class ImageAttachmentTests: XCTestCase {
     
-    func testAlt() {
+    func testAltSetter() {
         let imageAttachment = ImageAttachment(identifier: "testing")
         let alt = "Some text"
         
@@ -17,7 +17,20 @@ class ImageAttachmentTests: XCTestCase {
         XCTAssertEqual(imageAttachment.extraAttributes["alt"], nil)
     }
     
-    func testWidth() {
+    func testAltGetter() {
+        let imageAttachment = ImageAttachment(identifier: "testing")
+        let alt = "Some text"
+        
+        XCTAssertEqual(imageAttachment.alt, nil)
+        
+        imageAttachment.extraAttributes["alt"] = alt
+        XCTAssertEqual(imageAttachment.alt, alt)
+        
+        imageAttachment.extraAttributes["alt"] = nil
+        XCTAssertEqual(imageAttachment.alt, nil)
+    }
+    
+    func testWidthSetter() {
         let imageAttachment = ImageAttachment(identifier: "testing")
         let width = 500
         
@@ -30,7 +43,20 @@ class ImageAttachmentTests: XCTestCase {
         XCTAssertEqual(imageAttachment.extraAttributes["width"], nil)
     }
     
-    func testHeight() {
+    func testWidthGetter() {
+        let imageAttachment = ImageAttachment(identifier: "testing")
+        let width = 500
+        
+        XCTAssertEqual(imageAttachment.width, nil)
+        
+        imageAttachment.extraAttributes["width"] = String(width)
+        XCTAssertEqual(imageAttachment.width, width)
+        
+        imageAttachment.extraAttributes["width"] = nil
+        XCTAssertEqual(imageAttachment.width, nil)
+    }
+    
+    func testHeightSetter() {
         let imageAttachment = ImageAttachment(identifier: "testing")
         let height = 500
         
@@ -43,6 +69,19 @@ class ImageAttachmentTests: XCTestCase {
         XCTAssertEqual(imageAttachment.extraAttributes["height"], nil)
     }
     
+    func testHeightGetter() {
+        let imageAttachment = ImageAttachment(identifier: "testing")
+        let height = 500
+        
+        XCTAssertEqual(imageAttachment.height, nil)
+        
+        imageAttachment.extraAttributes["height"] = String(height)
+        XCTAssertEqual(imageAttachment.height, height)
+        
+        imageAttachment.extraAttributes["height"] = nil
+        XCTAssertEqual(imageAttachment.height, nil)
+    }
+    
     func testImageIDNilWhenNotSet() {
         let imageAttachment = ImageAttachment(identifier: "testing")
         
@@ -51,6 +90,11 @@ class ImageAttachmentTests: XCTestCase {
     
     func testImageIDChangesWhenExtraAttributeChanges() {
         let imageAttachment = ImageAttachment(identifier: "testing")
+        
+        XCTAssertEqual(imageAttachment.imageID, nil)
+        
+        imageAttachment.extraAttributes["class"] = "some-class"
+        XCTAssertEqual(imageAttachment.imageID, nil)
         
         imageAttachment.extraAttributes["class"] = "wp-image-200"
         XCTAssertEqual(imageAttachment.imageID, 200)
@@ -62,7 +106,6 @@ class ImageAttachmentTests: XCTestCase {
     func testImageIDChangesExtraAttributes() {
         let imageAttachment = ImageAttachment(identifier: "testing")
         
-
         imageAttachment.extraAttributes["class"] = "some-attributes some-more-attributes"
         
         imageAttachment.imageID = 200

--- a/WordPressEditor/WordPressEditorTests/Extensions/ImageAttachmentWordPressTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Extensions/ImageAttachmentWordPressTests.swift
@@ -1,0 +1,86 @@
+import Aztec
+import XCTest
+@testable import WordPressEditor
+
+class ImageAttachmentTests: XCTestCase {
+    
+    func testAlt() {
+        let imageAttachment = ImageAttachment(identifier: "testing")
+        let alt = "Some text"
+        
+        XCTAssertEqual(imageAttachment.extraAttributes["alt"], nil)
+        
+        imageAttachment.alt = alt
+        XCTAssertEqual(imageAttachment.extraAttributes["alt"], alt)
+        
+        imageAttachment.alt = nil
+        XCTAssertEqual(imageAttachment.extraAttributes["alt"], nil)
+    }
+    
+    func testWidth() {
+        let imageAttachment = ImageAttachment(identifier: "testing")
+        let width = 500
+        
+        XCTAssertEqual(imageAttachment.extraAttributes["width"], nil)
+        
+        imageAttachment.width = width
+        XCTAssertEqual(imageAttachment.extraAttributes["width"], String(width))
+        
+        imageAttachment.width = nil
+        XCTAssertEqual(imageAttachment.extraAttributes["width"], nil)
+    }
+    
+    func testHeight() {
+        let imageAttachment = ImageAttachment(identifier: "testing")
+        let height = 500
+        
+        XCTAssertEqual(imageAttachment.extraAttributes["height"], nil)
+        
+        imageAttachment.height = height
+        XCTAssertEqual(imageAttachment.extraAttributes["height"], String(height))
+        
+        imageAttachment.height = nil
+        XCTAssertEqual(imageAttachment.extraAttributes["height"], nil)
+    }
+    
+    func testImageIDNilWhenNotSet() {
+        let imageAttachment = ImageAttachment(identifier: "testing")
+        
+        XCTAssertEqual(imageAttachment.imageID, nil)
+    }
+    
+    func testImageIDChangesWhenExtraAttributeChanges() {
+        let imageAttachment = ImageAttachment(identifier: "testing")
+        
+        imageAttachment.extraAttributes["class"] = "wp-image-200"
+        XCTAssertEqual(imageAttachment.imageID, 200)
+        
+        imageAttachment.extraAttributes["class"] = "otherclass wp-image-400 ignoredclass"
+        XCTAssertEqual(imageAttachment.imageID, 400)
+    }
+    
+    func testImageIDChangesExtraAttributes() {
+        let imageAttachment = ImageAttachment(identifier: "testing")
+        
+
+        imageAttachment.extraAttributes["class"] = "some-attributes some-more-attributes"
+        
+        imageAttachment.imageID = 200
+        XCTAssertEqual(imageAttachment.extraAttributes["class"], "some-attributes some-more-attributes wp-image-200")
+        
+        imageAttachment.imageID = 400
+        XCTAssertEqual(imageAttachment.extraAttributes["class"], "some-attributes some-more-attributes wp-image-400")
+    }
+    
+    func testImageIDSetToNilChangesExtraAttributes() {
+        let imageAttachment = ImageAttachment(identifier: "testing")
+        
+        imageAttachment.extraAttributes["class"] = "wp-image-200"
+        imageAttachment.imageID = nil
+        XCTAssertEqual(imageAttachment.extraAttributes["class"], nil)
+        
+        imageAttachment.extraAttributes["class"] = "wp-image-200 some-other-class"
+        imageAttachment.imageID = nil
+        XCTAssertEqual(imageAttachment.extraAttributes["class"], "some-other-class")
+    }
+}

--- a/WordPressEditor/WordPressEditorTests/Extensions/MediaAttachmentWordPressTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Extensions/MediaAttachmentWordPressTests.swift
@@ -2,7 +2,7 @@ import Aztec
 import XCTest
 @testable import WordPressEditor
 
-class MediaAttachmentTests: XCTestCase {
+class MediaAttachmentWordPressTests: XCTestCase {
     
     func testUploadIDSetter() {
         let imageAttachment = MediaAttachment(identifier: "testing")

--- a/WordPressEditor/WordPressEditorTests/Extensions/MediaAttachmentWordPressTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Extensions/MediaAttachmentWordPressTests.swift
@@ -1,0 +1,32 @@
+import Aztec
+import XCTest
+@testable import WordPressEditor
+
+class MediaAttachmentTests: XCTestCase {
+    
+    func testUploadIDSetter() {
+        let imageAttachment = MediaAttachment(identifier: "testing")
+        let uploadID = "some-id"
+        
+        XCTAssertEqual(imageAttachment.extraAttributes[MediaAttachment.uploadKey], nil)
+        
+        imageAttachment.uploadID = uploadID
+        XCTAssertEqual(imageAttachment.extraAttributes[MediaAttachment.uploadKey], uploadID)
+        
+        imageAttachment.uploadID = nil
+        XCTAssertEqual(imageAttachment.extraAttributes[MediaAttachment.uploadKey], nil)
+    }
+    
+    func testUploadIDGetter() {
+        let imageAttachment = MediaAttachment(identifier: "testing")
+        let uploadID = "some-id"
+        
+        XCTAssertEqual(imageAttachment.uploadID, nil)
+        
+        imageAttachment.extraAttributes[MediaAttachment.uploadKey] = uploadID
+        XCTAssertEqual(imageAttachment.uploadID, uploadID)
+        
+        imageAttachment.extraAttributes[MediaAttachment.uploadKey] = nil
+        XCTAssertEqual(imageAttachment.uploadID, nil)
+    }
+}

--- a/WordPressEditor/WordPressEditorTests/Extensions/VideoAttachmentWordPressTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Extensions/VideoAttachmentWordPressTests.swift
@@ -1,0 +1,32 @@
+import Aztec
+import XCTest
+@testable import WordPressEditor
+
+class VideoAttachmentWordPressTests: XCTestCase {
+    
+    func testVideoPressIDSetter() {
+        let videoAttachment = VideoAttachment(identifier: "testing")
+        let videoPressID = "some-id"
+        
+        XCTAssertEqual(videoAttachment.extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute], nil)
+        
+        videoAttachment.videoPressID = videoPressID
+        XCTAssertEqual(videoAttachment.extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute], videoPressID)
+        
+        videoAttachment.videoPressID = nil
+        XCTAssertEqual(videoAttachment.extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute], nil)
+    }
+    
+    func testVideoPressIDGetter() {
+        let videoAttachment = VideoAttachment(identifier: "testing")
+        let videoPressID = "some-id"
+        
+        XCTAssertEqual(videoAttachment.videoPressID, nil)
+        
+        videoAttachment.extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute] = videoPressID
+        XCTAssertEqual(videoAttachment.videoPressID, videoPressID)
+        
+        videoAttachment.extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute] = nil
+        XCTAssertEqual(videoAttachment.videoPressID, nil)
+    }
+}

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/CaptionShortcode/CaptionShortcodeInputProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/CaptionShortcode/CaptionShortcodeInputProcessorTests.swift
@@ -4,8 +4,7 @@ import XCTest
 class CaptionShortcodeInputProcessorTests: XCTestCase {
 
     let processor = CaptionShortcodeInputProcessor()
-
-
+    
     /// Verifies that a Caption Shortcode wrapping an Image + Text is properly processed.
     ///
     func testCaptionShortcodeIsProperlyConvertedIntoFigureTag() {
@@ -19,8 +18,8 @@ class CaptionShortcodeInputProcessorTests: XCTestCase {
     /// Verifies that a caption shortcode wrapping [Image + Text + Multiple Line Breaks] is properly processed.
     ///
     func testCaptionShortcodeIsProperlyConvertedIntoFigureTagPreservingNestedTags() {
-        let input = "[caption]<img src=\".\"><b>Text</b><br><br><br>[/caption]"
-        let expected = "<figure><img src=\".\"><figcaption><b>Text</b><br><br><br></figcaption></figure>"
+        let input = "[caption someattribute]<img src=\".\"><b>Text</b><br><br><br>[/caption]"
+        let expected = "<figure someattribute><img src=\".\"><figcaption><b>Text</b><br><br><br></figcaption></figure>"
 
         XCTAssertEqual(processor.process(input), expected)
     }
@@ -40,6 +39,11 @@ class CaptionShortcodeInputProcessorTests: XCTestCase {
         XCTAssertEqual(processor.process(input), expected)
     }
 
+    func testBrokenCaptionIsNotProcessed() {
+        let input = "[caption]"
+        
+        XCTAssertEqual(processor.process(input), input)
+    }
 
     /// Verifies that a caption shortcode with no text doesn't get processed.
     ///

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/GalleryShortcode/GalleryAttachmentToElementConverterTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/GalleryShortcode/GalleryAttachmentToElementConverterTests.swift
@@ -1,0 +1,47 @@
+import Aztec
+import XCTest
+@testable import WordPressEditor
+
+class GalleryAttachmentToElementConverterTests: XCTestCase {
+    
+    let converter = GalleryAttachmentToElementConverter()
+    
+    func testGalleryElementConverterWithOnlyColumns() {
+        
+        let expectedIds = "4,5"
+        let expectedColumns = "2"
+        let expectedOrder = GalleryAttachment.Order.asc.rawValue
+        let expectedOrderBy = GalleryAttachment.OrderBy.menu.rawValue
+        
+        let attachment = GalleryAttachment(identifier: "testing")
+        let extraAttributeName = "extraAttribute"
+        let extraAttributeValue = "extraAttributeValue"
+        
+        attachment.ids = [4, 5]
+        attachment.columns = 2
+        attachment.order = .asc
+        attachment.orderBy = .menu
+        attachment.extraAttributes[extraAttributeName] = extraAttributeValue
+        
+        guard let element = converter.convert(attachment, attributes: [:]).first as? ElementNode else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(element.type, .gallery)
+        
+        let outputIds = element.attribute(named: GallerySupportedAttribute.ids.rawValue)?.value.toString()
+        XCTAssertEqual(outputIds, expectedIds)
+        
+        let outputColumns = element.attribute(named: GallerySupportedAttribute.columns.rawValue)?.value.toString()
+        XCTAssertEqual(outputColumns, expectedColumns)
+        
+        let outputOrder = element.attribute(named: GallerySupportedAttribute.order.rawValue)?.value.toString()
+        XCTAssertEqual(outputOrder, expectedOrder)
+        
+        let outputOrderBy = element.attribute(named: GallerySupportedAttribute.orderBy.rawValue)?.value.toString()
+        XCTAssertEqual(outputOrderBy, expectedOrderBy)
+        
+        let outputExtraAttribute = element.attribute(named: extraAttributeName)?.value.toString()
+        XCTAssertEqual(outputExtraAttribute, extraAttributeValue)
+    }
+}

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/GalleryShortcode/GalleryElementToTagConverterTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/GalleryShortcode/GalleryElementToTagConverterTests.swift
@@ -1,0 +1,20 @@
+import Aztec
+import XCTest
+@testable import WordPressEditor
+
+class GalleryElementToTagConverterTests: XCTestCase {
+    
+    let converter = GalleryElementToTagConverter()
+    
+    func testGalleryElementConverterWithOnlyColumns() {
+        let attributes = [
+            Attribute(name: "columns", value: .string("4")),
+            Attribute(name: "ids", value: .string("4, 5, 6, 7"))
+        ]
+        let element = ElementNode(type: .gallery, attributes: attributes)
+        
+        let (tag, _) = converter.convert(element)
+        
+        XCTAssertEqual(tag, "[gallery columns=\"4\" ids=\"4, 5, 6, 7\"]")
+    }
+}

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenblockTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenblockTests.swift
@@ -1,0 +1,21 @@
+import Aztec
+import XCTest
+@testable import WordPressEditor
+
+class GutenblockTests: XCTestCase {
+    
+    func testInitWithRepresentation() {
+        let gutenblockElement = ElementNode(type: .gutenblock)
+        let elementRepresentation = HTMLElementRepresentation(gutenblockElement)
+        let representation = HTMLRepresentation(for: .element(elementRepresentation))
+        let gutenblock = Gutenblock(storing: representation)
+        
+        XCTAssertEqual(gutenblock.representation, representation)
+    }
+    
+    func testInitWithCoder() {
+        let gutenblock = Gutenblock()
+        
+        XCTAssertEqual(gutenblock.representation, nil)
+    }
+}


### PR DESCRIPTION
### Description:

Adds more unit tests.

Fixes an issue in ImageAttachment+WordPress that was causing the `class` attribute to never be removed.

Moves forward #1032 

### Testing:

Just run the unit tests and make sure they don't fail.