### PR TITLE
Adds an ENTER-key optional-override-callback to Aztec.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -139,6 +139,17 @@ open class TextView: UITextView {
     ///
     open weak var formattingDelegate: TextViewFormattingDelegate?
     
+    // MARK: - Other callbacks
+    
+    let enterKey = "\n"
+    
+    /// Callback that's executed when enter is pressed.
+    ///
+    /// - Returns: `true` if the callback handled the keypress completely.  This means the default
+    ///     handler will be skipped.  `false` is the default handler still needs to be executed.
+    ///
+    var onEnter: (() -> Bool)? = nil
+    
     // MARK: - Behavior configuration
     
     private static let singleLineParagraphFormatters: [AttributeFormatter] = [
@@ -603,6 +614,13 @@ open class TextView: UITextView {
     // MARK: - Intercept keyboard operations
 
     open override func insertText(_ text: String) {
+        if text == enterKey {
+            let enterHandled = onEnter?() ?? false
+            
+            guard !enterHandled else {
+                return
+            }
+        }
         
         // For some reason the text view is allowing the attachment style to be set in
         // typingAttributes.  That's simply not acceptable.

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1927,4 +1927,50 @@ class TextViewTests: XCTestCase {
 
         XCTAssertEqual(textView.getHTML(prettify: false), originalHTML)
     }
+    
+    // MARK: - Enter Override
+    
+    /// Tests that the enter override is properly called, and that returning `true` when
+    /// it's executed results in the default handler being skipped.
+    ///
+    func testEnterOverrideWorks() {
+        let inputText = "<p>Hello 🌎!</p>"
+        let expectedText = inputText
+        
+        let textView = TextViewStub(withHTML: inputText)
+        var didExecuteOverride = false
+        
+        textView.onEnter = { () -> Bool in
+            didExecuteOverride = true
+            return true
+        }
+        
+        textView.selectedRange = NSRange(location: 5, length: 0)
+        textView.insertText(textView.enterKey)
+
+        XCTAssertTrue(didExecuteOverride)
+        XCTAssertEqual(textView.getHTML(), expectedText)
+    }
+    
+    /// Tests that the enter override is properly called, and that returning `false` when
+    /// it's executed results in the default handler being executed.
+    ///
+    func testEnterOverrideWorks2() {
+        let inputText = "<p>Hello 🌎!</p>"
+        let expectedText = "<p>Hello</p><p> 🌎!</p>"
+        
+        let textView = TextViewStub(withHTML: inputText)
+        var didExecuteOverride = false
+        
+        textView.onEnter = { () -> Bool in
+            didExecuteOverride = true
+            return false
+        }
+        
+        textView.selectedRange = NSRange(location: 5, length: 0)
+        textView.insertText(textView.enterKey)
+        
+        XCTAssertTrue(didExecuteOverride)
+        XCTAssertEqual(textView.getHTML(prettify: false), expectedText)
+    }
 }


### PR DESCRIPTION
### Description:

Adds an ENTER-key optional-override-callback to Aztec, so that consuming Apps can override what happens when ENTER is pressed in the editor.

Also added some unit tests to make sure the override works as expected.

### Testing:

Simply run the unit tests.
Optionally define an override that just returns `true` and make sure newlines are not added to the editor.