### PR TITLE
Fixes a data loss issue.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -83,7 +83,7 @@ public class ElementNode: Node {
     private func updateParentForChildren() {
         for child in children where child.parent !== self {
             if let oldParent = child.parent,
-                let childIndex = oldParent.children.index(of: child) {
+                let childIndex = oldParent.children.index(where: { child === $0 }) {
                 
                 oldParent.children.remove(at: childIndex)
             }
@@ -285,7 +285,7 @@ public class ElementNode: Node {
     /// - Returns: the index of the specified child node.
     ///
     func indexOf(childNode: Node) -> Int {
-        guard let index = children.index(of: childNode) else {
+        guard let index = children.index(where: { childNode === $0 } ) else {
             fatalError("Broken parent-child relationship found.")
         }
         

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
@@ -180,4 +180,13 @@ class GutenbergInputHTMLTreeProcessorTests: XCTestCase {
                 && attribute.value.toString() == selfClosingComment
         }))
     }
+    
+    func testLostText() {
+        let input = "<!-- wp:paragraph -->a<!-- /wp:paragraph -->\n<!-- wp:image -->\n<figure class=\"wp-block-image alignright\"><img src=\"https://wordpress.org/gutenberg/files/2017/12/Dropcap.png\" height=234 alt=\"\" width=312></figure>\nThis text will be lost<!-- /wp:image -->"
+        
+        let rootNode = parser.parse(input)
+        processor.process(rootNode)
+        
+        XCTAssertTrue(rootNode.rawText().contains("This text will be lost"))
+    }
 }

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
@@ -185,6 +185,8 @@ class GutenbergInputHTMLTreeProcessorTests: XCTestCase {
         let input = "<!-- wp:paragraph -->a<!-- /wp:paragraph -->\n<!-- wp:image -->\n<figure class=\"wp-block-image alignright\"><img src=\"https://wordpress.org/gutenberg/files/2017/12/Dropcap.png\" height=234 alt=\"\" width=312></figure>\nThis text will be lost<!-- /wp:image -->"
         
         let rootNode = parser.parse(input)
+        XCTAssertTrue(rootNode.rawText().contains("This text will be lost"))
+        
         processor.process(rootNode)
         
         XCTAssertTrue(rootNode.rawText().contains("This text will be lost"))

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
@@ -181,7 +181,11 @@ class GutenbergInputHTMLTreeProcessorTests: XCTestCase {
         }))
     }
     
-    func testLostText() {
+    /// There was an issue with Gutenberg posts losing edits.  This automated test makes sure the issues we found don't regress.
+    ///
+    /// https://github.com/wordpress-mobile/AztecEditor-iOS/issues/1052
+    ///
+    func testDataLossWhenProcessing() {
         let input = "<!-- wp:paragraph -->a<!-- /wp:paragraph -->\n<!-- wp:image -->\n<figure class=\"wp-block-image alignright\"><img src=\"https://wordpress.org/gutenberg/files/2017/12/Dropcap.png\" height=234 alt=\"\" width=312></figure>\nThis text will be lost<!-- /wp:image -->"
         
         let rootNode = parser.parse(input)


### PR DESCRIPTION
### Description:

Fixes #1052.

### Testing:

1. Run the unit tests.
2. Paste this in HTML mode and switch to visual.  Make sure the test at the bottom is not lost:

```html
<!-- wp:paragraph -->a<!-- /wp:paragraph -->
<!-- wp:image -->
<figure class="wp-block-image alignright"><img src="https://wordpress.org/gutenberg/files/2017/12/Dropcap.png" height="234" alt="" width="312"></figure>
This text will be lost<!-- /wp:image -->
```