### PR TITLE
Issue/1060 fix url pasting

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -527,8 +527,11 @@ open class TextView: UITextView {
             let url = UIPasteboard.general.url else {
                 return false
         }
-        
-        setLink(url, inRange: selectedRange)
+        if selectedRange.length == 0 {
+            setLink(url, title:url.absoluteString, inRange: selectedRange)
+        } else {
+            setLink(url, inRange: selectedRange)
+        }
         return true
     }
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -527,11 +527,13 @@ open class TextView: UITextView {
             let url = UIPasteboard.general.url else {
                 return false
         }
+
         if selectedRange.length == 0 {
             setLink(url, title:url.absoluteString, inRange: selectedRange)
         } else {
             setLink(url, inRange: selectedRange)
         }
+
         return true
     }
 

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import Aztec
+import MobileCoreServices
 
 class TextViewTests: XCTestCase {
 
@@ -1926,5 +1927,29 @@ class TextViewTests: XCTestCase {
         let textView = TextViewStub(withHTML: originalHTML)
 
         XCTAssertEqual(textView.getHTML(prettify: false), originalHTML)
+    }
+
+    func testPasteOfURLsWithoutSelectedRange() {
+        let textView = TextViewStub(withHTML: "")
+        let pasteboard = UIPasteboard.general
+        let url = URL(string: "http://wordpress.com")!
+        pasteboard.setValue(url, forPasteboardType: String(kUTTypeURL))
+
+        textView.paste(nil)
+
+        let html = "<p><a href=\"http://wordpress.com\">http://wordpress.com</a></p>"
+        XCTAssertEqual(textView.getHTML(prettify: false), html)
+    }
+
+    func testPasteOfURLsWithSelectedRange() {
+        let textView = TextViewStub(withHTML: "WordPress")
+        let pasteboard = UIPasteboard.general
+        let url = URL(string: "http://wordpress.com")!
+        pasteboard.setValue(url, forPasteboardType: String(kUTTypeURL))
+        textView.selectedRange = NSRange(location: 0, length: 9)
+        textView.paste(nil)
+
+        let html = "<p><a href=\"http://wordpress.com\">WordPress</a></p>"
+        XCTAssertEqual(textView.getHTML(prettify: false), html)
     }
 }


### PR DESCRIPTION
Fixes #1060 

To test:
- Start the demo app
- Open the empty demo
- Switch to Safari and copy an URL from there
- Paste on the empty demo.
- Check that a link is created using the link and the text where the link is applied is the URL absolute path.