### PR TITLE
Proposal to fix pasting from Notes App

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -118,6 +118,7 @@ extension Element {
     public static let ul = Element("ul")
     public static let video = Element("video")
     public static let wbr = Element("wbr")
+    public static let body = Element("body")
 
 }
 

--- a/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
@@ -98,6 +98,10 @@ public class HTMLConverter {
 
 private extension HTMLConverter {
     func hasBodyNode(_ nodes: [Node]) -> Bool {
+        return hasBodyNode(ArraySlice<Node>(nodes))
+    }
+
+    private func hasBodyNode(_ nodes: ArraySlice<Node>) -> Bool {
         if nodes.isEmpty {
             return false
         }
@@ -106,8 +110,7 @@ private extension HTMLConverter {
         case let element as ElementNode where element.name == Element.body.rawValue:
             return true
         default:
-            let remainingChildren = Array(nodes.dropFirst())
-            return hasBodyNode(remainingChildren)
+            return hasBodyNode(nodes.dropFirst())
         }
     }
 }

--- a/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
@@ -58,7 +58,22 @@ public class HTMLConverter {
         
         return attributedString
     }
-    
+
+
+    /// Check if the given html string is supported to be parsed into Attributed Strings.
+    ///
+    /// In some cases, like pasting from the Notes app, the generated HTML will have a `<body>` tag, and that
+    /// is not yet supported. In those cases is preferible to abort html parsing.
+    ///
+    /// - Parameter html: The html string to check.
+    /// - Returns: A bool value indicating if the given html string can be handled correctly.
+    ///
+    func isSupported(_ html: String) -> Bool {
+        let processedHTML = pluginManager.process(html: html)
+        let rootNode = htmlToTree.parse(processedHTML)
+        return hasBodyNode(rootNode.children) == false
+    }
+
     /// Converts an attributed string string into it's HTML string representation.
     ///
     /// - Parameters:
@@ -77,4 +92,22 @@ public class HTMLConverter {
         return pluginManager.process(outputHTML: html)
     }
     
+}
+
+// MARK: - Helpers
+
+private extension HTMLConverter {
+    func hasBodyNode(_ nodes: [Node]) -> Bool {
+        if nodes.isEmpty {
+            return false
+        }
+
+        switch nodes.first {
+        case let element as ElementNode where element.name == Element.body.rawValue:
+            return true
+        default:
+            let remainingChildren = Array(nodes.dropFirst())
+            return hasBodyNode(remainingChildren)
+        }
+    }
 }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -474,7 +474,7 @@ open class TextView: UITextView {
     /// - Returns: True if this method succeeds.
     ///
     func tryPastingHTML() -> Bool {
-        guard let html = UIPasteboard.general.html() else {
+        guard let html = UIPasteboard.general.html(), storage.htmlConverter.isSupported(html) else {
             return false
         }
 


### PR DESCRIPTION
Fixes #1066 

As @aerych mentioned, pasting from the Notes App was working correctly on WPv10.8.1.
The aztec changes for that release was from `1.0.0-beta.25.1` to `1.0.2` (I believe).

The important PR that seems to have broken pasting from Notes app is #1026 (Better support for pasting HTML).

The down side of that change is that now, pasting from Notes will be translated into HTML, and that HTML brings a series of tags that are not recognized by Aztec, like `<head>`, `<meta>`, `<style>` and `<body>`.

In particular, the `<body>` tag brings all the content, but since the tag is not recognized, the content is replaced with the `[BODY]` placeholder.

Ideally, we would add support for all those tags (I guess?), but it would be to handle rendering full page HTML code ready to be rendered in a browser.

As an example, this the HTML generated for a simple *bold* text pasted from Notes:
```html
<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">
<html>
	<head>   
		<meta name=\ "Generator\" content=\ "Cocoa HTML Writer\">
		<style type=\ "text/css\">
			p.p1 {margin: 0.0px 0.0px 0.0px 0.0px; font: 17.0px \'.SF UI Text\'; color: #454545}
			span.s1 {font-family: \'.SFUIText-Bold\'; font-weight: bold; font-style: normal; font-size: 17.00pt}
		</style>
	</head>

	<body>
		<p class=\ "p1\">
			<span class=\ "s1\">bold</span>
		</p>
	</body>
</html>
```
### The proposed solution:

Instead of adding support for the tags (for now), I opted to make a check if the HTML code present the `<body>` tag, in such case we would abort parsing the HTML code and fall back to the previous methods.

This seems to work properly:
[Video here](
https://cldup.com/V0iSL-hcku.mp4)

### To test:

- Copy paste from the Notes App as shown on the video.
- Test for possible regressions: (Test instructions from #1026)
  - Make sure pasting URLs work. Try to undo the operation.
  - Make sure pasting regular text works. Try to undo the operation.
  - Run the unit tests.
  - Test pasting HTML content:
  - Open Safari, and go to the Wikipedia page for WordPress.
  - Copy any chunk of text.
  - Paste it anywhere in the editor.
  - Switch to HTML and back, and make sure the content looks the same as when you pasted it.

cc @jkmassel @SiobhyB 

PD: There seems to be some tests failing, but they are also failing on the `develop` branch. 🤔