### PR TITLE
589 basic embed paste support

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -208,6 +208,8 @@
 		F1FF7D9D201A147B007B0B32 /* Figure.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FF7D9C201A147B007B0B32 /* Figure.swift */; };
 		F1FF7D9F201A1D24007B0B32 /* Figcaption.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FF7D9E201A1D24007B0B32 /* Figcaption.swift */; };
 		F1FF7DA1201A1D3E007B0B32 /* FigcaptionElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FF7DA0201A1D3E007B0B32 /* FigcaptionElementConverter.swift */; };
+		F9B609552174F2E1006779D7 /* EmbedURLProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B609542174F2E1006779D7 /* EmbedURLProcessor.swift */; };
+		F9B609572174F791006779D7 /* EmbedURLProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B609562174F791006779D7 /* EmbedURLProcessorTests.swift */; };
 		FF0714021EFD78AF00E50713 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FF0714001EFD78AF00E50713 /* Media.xcassets */; };
 		FF20D6401EDC389A00294B78 /* ShortcodeAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF20D63D1EDC389A00294B78 /* ShortcodeAttribute.swift */; };
 		FF20D6411EDC389A00294B78 /* HTMLProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF20D63E1EDC389A00294B78 /* HTMLProcessor.swift */; };
@@ -466,6 +468,8 @@
 		F1FF7D9C201A147B007B0B32 /* Figure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Figure.swift; sourceTree = "<group>"; };
 		F1FF7D9E201A1D24007B0B32 /* Figcaption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Figcaption.swift; sourceTree = "<group>"; };
 		F1FF7DA0201A1D3E007B0B32 /* FigcaptionElementConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigcaptionElementConverter.swift; sourceTree = "<group>"; };
+		F9B609542174F2E1006779D7 /* EmbedURLProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedURLProcessor.swift; sourceTree = "<group>"; };
+		F9B609562174F791006779D7 /* EmbedURLProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedURLProcessorTests.swift; sourceTree = "<group>"; };
 		FF0714001EFD78AF00E50713 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		FF20D63D1EDC389A00294B78 /* ShortcodeAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcodeAttribute.swift; sourceTree = "<group>"; };
 		FF20D63E1EDC389A00294B78 /* HTMLProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLProcessor.swift; sourceTree = "<group>"; };
@@ -1282,6 +1286,7 @@
 				FF20D63D1EDC389A00294B78 /* ShortcodeAttribute.swift */,
 				F193AD6620C5A40A00BBA8F4 /* ShortcodeAttributeParser.swift */,
 				F165D92320C72C1000EAA6B0 /* ShortcodeAttributeSerializer.swift */,
+				F9B609542174F2E1006779D7 /* EmbedURLProcessor.swift */,
 			);
 			path = Processor;
 			sourceTree = "<group>";
@@ -1292,6 +1297,7 @@
 				B5B988D71FF4185400C0280D /* ShortcodeAttributeSerializerTests.swift */,
 				FF20D6461EDC3B3900294B78 /* HTMLProcessorTests.swift */,
 				F15415F2213440650096D18E /* HTMLTreeProcessorTests.swift */,
+				F9B609562174F791006779D7 /* EmbedURLProcessorTests.swift */,
 			);
 			path = Processor;
 			sourceTree = "<group>";
@@ -1583,6 +1589,7 @@
 				F16A2ADB20CC4DC500BF3A0A /* ImageAttachmentToElementConverter.swift in Sources */,
 				F17BC8941F4E4BA500398E2B /* UnsupportedHTML.swift in Sources */,
 				F12F586F1EF20394008AE298 /* PreFormatter.swift in Sources */,
+				F9B609552174F2E1006779D7 /* EmbedURLProcessor.swift in Sources */,
 				B5B86D371DA3EC250083DB3F /* NSRange+Helpers.swift in Sources */,
 				F15BA6172151693F00424120 /* BoldCSSAttributeMatcher.swift in Sources */,
 				F1E2323420C18055008DA49F /* FormatterElementConverter.swift in Sources */,
@@ -1632,6 +1639,7 @@
 				F1E1B7782062BE6B004642BB /* ParagraphStyleTests.swift in Sources */,
 				E11B77601DBA14B40024E455 /* BlockquoteFormatterTests.swift in Sources */,
 				F185A5BD2123C0DA00DDFAB1 /* ArrayHelperTests.swift in Sources */,
+				F9B609572174F791006779D7 /* EmbedURLProcessorTests.swift in Sources */,
 				F1E75634215B0FC7004BC254 /* ItalicStringAttributeConverterTests.swift in Sources */,
 				F185A5B22123C0DA00DDFAB1 /* NSMutableAttributedStringParagraphProperty.swift in Sources */,
 				F17BC8A21F4E4F5A00398E2B /* DefaultHTMLSerializerTests.swift in Sources */,

--- a/Aztec/Classes/Processor/EmbedURLProcessor.swift
+++ b/Aztec/Classes/Processor/EmbedURLProcessor.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public struct EmbedURLProcessor{
+
+    let url: URL
+
+    init(url: URL){
+        self.url = url
+    }
+
+    public var isValidEmbed: Bool{
+        return isYouTubeEmbed || isVimeoEmbed
+    }
+
+    /// Tests the url to see if it's a valid YouTube URL.
+    ///
+    /// Supports these formats:
+    ///  - Watch URL
+    ///  - Embed URL
+    ///  - Short URL
+    ///
+    public var isYouTubeEmbed: Bool {
+        let longPattern = "^https?://(www.)?youtube.com/(watch\\?v=|embed/)[0-9|a-z|A-Z]+$"
+        let long = try! NSRegularExpression(pattern: longPattern, options: [.caseInsensitive])
+
+        let shortPattern = "^https?://youtu.be/[0-9|a-z|A-Z]+$"
+        let short = try! NSRegularExpression(pattern: shortPattern, options: [.caseInsensitive])
+
+        return matches(long) || matches(short)
+    }
+
+    /// Tests the url to see if it's a valid Vimeo URL.
+    ///
+    /// Supports these formats:
+    ///  - Watch URL
+    ///  - Channel URL
+    ///  - Embedded Player URL
+    ///
+    public var isVimeoEmbed: Bool {
+        let pattern = "^https?://vimeo.com/[0-9]+$"
+        let regex = try! NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+
+        let channelPattern = "^https?://vimeo.com/channels/[0-9|a-z|A-Z]+/[0-9]+$"
+        let channel = try! NSRegularExpression(pattern: channelPattern, options: [.caseInsensitive])
+
+        let playerPattern = "^https://player.vimeo.com/video/[0-9]+$"
+        let player = try! NSRegularExpression(pattern: playerPattern, options: [.caseInsensitive])
+
+        return matches(regex) || matches(channel) || matches(player)
+    }
+
+    private func matches(_ regex: NSRegularExpression) -> Bool {
+        let urlRange = NSMakeRange(0, url.absoluteString.lengthOfBytes(using: .utf8))
+        let urlString = url.absoluteString
+
+        return !regex.matches(in: urlString, options: [], range: urlRange).isEmpty
+    }
+}

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -529,6 +529,12 @@ open class TextView: UITextView {
         }
 
         if selectedRange.length == 0 {
+            
+            //If this is a valid embed URL, don't turn it into an <a> tag
+            guard !EmbedURLProcessor(url: url).isValidEmbed else {
+                return false
+            }
+
             setLink(url, title:url.absoluteString, inRange: selectedRange)
         } else {
             setLink(url, inRange: selectedRange)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -531,8 +531,14 @@ open class TextView: UITextView {
         if selectedRange.length == 0 {
             
             //If this is a valid embed URL, don't turn it into an <a> tag
-            guard !EmbedURLProcessor(url: url).isValidEmbed else {
-                return false
+            if EmbedURLProcessor(url: url).isValidEmbed {
+                let result = self.tryPastingString()
+
+                // Bump the input to the next line – we need the embed link to be the only
+                // text on this line – otherwise it can't be autoconverted.
+                insertText(String(.lineSeparator)
+
+                return result
             }
 
             setLink(url, title:url.absoluteString, inRange: selectedRange)

--- a/AztecTests/Processor/EmbedURLProcessorTests.swift
+++ b/AztecTests/Processor/EmbedURLProcessorTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import Aztec
+
+class EmbedURLProcessorTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testThatValidYouTubeWatchURLsWork() {
+        //HTTPS, WWW
+        assert(EmbedURLProcessor(url: url("https://www.youtube.com/watch?v=Z1BCujX3pw8")).isYouTubeEmbed)
+        //HTTPS, no WWW
+        assert(EmbedURLProcessor(url: url("https://youtube.com/watch?v=Z1BCujX3pw8")).isYouTubeEmbed)
+        //HTTP, WWW
+        assert(EmbedURLProcessor(url: url("http://www.youtube.com/watch?v=Z1BCujX3pw8")).isYouTubeEmbed)
+    }
+
+    func testThatValidYouTubeEmbedURLsWork() {
+        //HTTPS, WWW
+        assert(EmbedURLProcessor(url: url("https://www.youtube.com/embed/Z1BCujX3pw8")).isYouTubeEmbed)
+        //HTTPS, no WWW
+        assert(EmbedURLProcessor(url: url("https://youtube.com/embed/Z1BCujX3pw8")).isYouTubeEmbed)
+        //HTTP, WWW
+        assert(EmbedURLProcessor(url: url("http://www.youtube.com/embed/Z1BCujX3pw8")).isYouTubeEmbed)
+    }
+
+    func testThatValidYouTubeShortURLsWork() {
+        //HTTPS
+        assert(EmbedURLProcessor(url: url("https://youtu.be/Z1BCujX3pw8")).isYouTubeEmbed)
+        //HTTP
+        assert(EmbedURLProcessor(url: url("http://youtu.be/Z1BCujX3pw8")).isYouTubeEmbed)
+    }
+
+    func testThatValidVimeoURLsWork() {
+        //HTTPS
+        assert(EmbedURLProcessor(url: url("https://vimeo.com/295040990")).isVimeoEmbed)
+        //HTTP
+        assert(EmbedURLProcessor(url: url("http://vimeo.com/295040990")).isVimeoEmbed)
+
+        //HTTPS – Channel
+        assert(EmbedURLProcessor(url: url("https://vimeo.com/channels/staffpicks/290322470")).isVimeoEmbed)
+        //HTTP – Channel
+        assert(EmbedURLProcessor(url: url("http://vimeo.com/channels/staffpicks/290322470")).isVimeoEmbed)
+
+        //HTTPS – Player
+        assert(EmbedURLProcessor(url: url("https://player.vimeo.com/video/291598893")).isVimeoEmbed)
+        //HTTP – Player
+        assert(EmbedURLProcessor(url: url("https://player.vimeo.com/video/291598893")).isVimeoEmbed)
+    }
+
+    private func url(_ string: String) -> URL{
+        return URL(string: string)!
+    }
+}


### PR DESCRIPTION
Currently, when pasting a URL that could be transformed into an embed (such as a YouTube link), it’ll be turned into an <a> tag instead, which is frustrating for several users we're talking to.  This solves the issue in the simplest possible way, which may not be the best long-term, so this should probably be treated as a proof-of-concept for a fix.

This pull request pre-empts the URL transformation of links if there’s no text selected (for instance, the user might actually want to make some text like “click here” be the link to the YouTube video, and we want the link transformation to work in that case). This allows a pasteboard that contains only a URL to be evaluated for whether it can be embedded, and if it can, it does. If not, it'll paste it as a regular link.

This PR implements support for YouTube and Vimeo embeds. The full list is a lot longer (https://codex.wordpress.org/Embeds), but shouldn’t difficult to implement each – it’ll just take a little time.

Fixes #589 (partially)

**To test:** 

Open "Empty Demo"
Paste in a YouTube or Vimeo link

**Before**
Turns into an `<a>` tag.

**After**
Just pastes the url on its own line – this'll allow WordPress to turn the link into an embed.