### PR TITLE
Proposal to fix pasting embeds

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		F1FF7D9D201A147B007B0B32 /* Figure.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FF7D9C201A147B007B0B32 /* Figure.swift */; };
 		F1FF7D9F201A1D24007B0B32 /* Figcaption.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FF7D9E201A1D24007B0B32 /* Figcaption.swift */; };
 		F1FF7DA1201A1D3E007B0B32 /* FigcaptionElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FF7DA0201A1D3E007B0B32 /* FigcaptionElementConverter.swift */; };
+		F9982CF621877663001E606B /* TextViewPasteboardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9982CF521877663001E606B /* TextViewPasteboardDelegate.swift */; };
 		FF0714021EFD78AF00E50713 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FF0714001EFD78AF00E50713 /* Media.xcassets */; };
 		FF20D6401EDC389A00294B78 /* ShortcodeAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF20D63D1EDC389A00294B78 /* ShortcodeAttribute.swift */; };
 		FF20D6411EDC389A00294B78 /* HTMLProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF20D63E1EDC389A00294B78 /* HTMLProcessor.swift */; };
@@ -466,6 +467,7 @@
 		F1FF7D9C201A147B007B0B32 /* Figure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Figure.swift; sourceTree = "<group>"; };
 		F1FF7D9E201A1D24007B0B32 /* Figcaption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Figcaption.swift; sourceTree = "<group>"; };
 		F1FF7DA0201A1D3E007B0B32 /* FigcaptionElementConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigcaptionElementConverter.swift; sourceTree = "<group>"; };
+		F9982CF521877663001E606B /* TextViewPasteboardDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewPasteboardDelegate.swift; sourceTree = "<group>"; };
 		FF0714001EFD78AF00E50713 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		FF20D63D1EDC389A00294B78 /* ShortcodeAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcodeAttribute.swift; sourceTree = "<group>"; };
 		FF20D63E1EDC389A00294B78 /* HTMLProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLProcessor.swift; sourceTree = "<group>"; };
@@ -765,6 +767,7 @@
 				E109B51B1DC33F2C0099605E /* LayoutManager.swift */,
 				FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */,
 				B5A99D831EBA073D00DED081 /* HTMLStorage.swift */,
+				F9982CF521877663001E606B /* TextViewPasteboardDelegate.swift */,
 			);
 			path = TextKit;
 			sourceTree = "<group>";
@@ -1544,6 +1547,7 @@
 				B5E94D101FE01335000E7C20 /* FigureElementConverter.swift in Sources */,
 				40A2986D1FD61B0C00AEDF3B /* ElementConverter.swift in Sources */,
 				F1FF7DA1201A1D3E007B0B32 /* FigcaptionElementConverter.swift in Sources */,
+				F9982CF621877663001E606B /* TextViewPasteboardDelegate.swift in Sources */,
 				F1289FB72155244A001E07C5 /* AttributeType.swift in Sources */,
 				F1FA0E821E6EF514009D98EE /* CommentNode.swift in Sources */,
 				F1656FE42152AB54009C7E3A /* ConditionalItalicStringAttributeConverter.swift in Sources */,

--- a/Aztec/Classes/Extensions/String+CharacterName.swift
+++ b/Aztec/Classes/Extensions/String+CharacterName.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension String {
+public extension String {
     
     /// Initializes this instance with the specified character.
     ///

--- a/Aztec/Classes/Plugin/Plugin.swift
+++ b/Aztec/Classes/Plugin/Plugin.swift
@@ -63,7 +63,7 @@ open class Plugin {
     
     /// Method plugins can use to execute extra code when loaded.
     ///
-    public func loaded() {}
+    open func loaded(textView: TextView) {}
 
     // MARK: - Equatable
     

--- a/Aztec/Classes/Plugin/PluginManager.swift
+++ b/Aztec/Classes/Plugin/PluginManager.swift
@@ -11,14 +11,14 @@ class PluginManager {
     
     /// Loads a plugins.
     ///
-    func load(_ plugin: Plugin) {
+    func load(_ plugin: Plugin, in textView: TextView) {
         guard !plugins.contains(where: { $0 == plugin }) else {
             assertionFailure()
             return
         }
         
         plugins.append(plugin)
-        plugin.loaded()
+        plugin.loaded(textView: textView)
     }
     
     // MARK: - Input Processing

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -226,7 +226,7 @@ open class TextView: UITextView {
     }
     
     public func load(_ plugin: Plugin) {
-        pluginManager.load(plugin)
+        pluginManager.load(plugin, in: self)
     }
 
     // MARK: - TextKit Aztec Subclasses

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -123,6 +123,11 @@ public protocol TextViewFormattingDelegate: class {
 //
 public protocol TextViewPasteboardDelegate: class {
 
+    /// Called by the TextView when it's attempting to paste the contents of the pasteboard.
+    ///
+    /// - Returns: True if the paste succeeded, false if it did not.
+    func tryPasting(in textView: TextView) -> Bool
+
     /// Called by the TextView when it's attempting to paste a URL.
     ///
     /// - Returns: True when the paste succeeded, false if it did not.
@@ -457,13 +462,7 @@ open class TextView: UITextView {
     }
 
     open override func paste(_ sender: Any?) {
-
-        let pasteHandled = pasteboardDelegate.tryPastingURL(in: self)
-            || pasteboardDelegate.tryPastingHTML(in: self)
-            || pasteboardDelegate.tryPastingAttributedString(in: self)
-            || pasteboardDelegate.tryPastingString(in: self)
-
-        guard pasteHandled else {
+        guard pasteboardDelegate.tryPasting(in: self) else {
             super.paste(sender)
             return
         }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -119,6 +119,30 @@ public protocol TextViewFormattingDelegate: class {
     func textViewCommandToggledAStyle()
 }
 
+// MARK: - TextViewPasteboardDelegate
+//
+public protocol TextViewPasteboardDelegate: class {
+
+    /// Called by the TextView when it's attempting to paste a URL.
+    ///
+    /// - Returns: True when the paste succeeded, false if it did not.
+    func tryPastingURL(in textView: TextView) -> Bool
+
+    /// Called by the TextView when it's attempting to paste HTML content.
+    ///
+    /// - Returns: True when the paste succeeded, false if it did not.
+    func tryPastingHTML(in textView: TextView) -> Bool
+
+    /// Called by the TextView when it's attempting to paste an attributed string.
+    ///
+    /// - Returns: True when the paste succeeded, false if it did not.
+    func tryPastingAttributedString(in textView: TextView) -> Bool
+
+    /// Called by the TextView when it's attempting to paste a string.
+    ///
+    /// - Returns: True when the paste succeeded, false if it did not.
+    func tryPastingString(in textView: TextView) -> Bool
+}
 
 // MARK: - TextView
 //
@@ -138,7 +162,12 @@ open class TextView: UITextView {
     /// Formatting Delegate: to be used by the Edition's Format Bar.
     ///
     open weak var formattingDelegate: TextViewFormattingDelegate?
-    
+
+    /// Pasteboard Delegate: Handles Cut, Copy, and Paste commands. Can be overridden
+    /// by a subclass to customize behaviour.
+    ///
+    open var pasteboardDelegate: TextViewPasteboardDelegate = AztecTextViewPasteboardDelegate()
+
     // MARK: - Behavior configuration
     
     private static let singleLineParagraphFormatters: [AttributeFormatter] = [
@@ -428,8 +457,12 @@ open class TextView: UITextView {
     }
 
     open override func paste(_ sender: Any?) {
-        let pasteHandled = tryPastingURL() || tryPastingHTML() || tryPastingAttributedString() || tryPastingString()
-        
+
+        let pasteHandled = pasteboardDelegate.tryPastingURL(in: self)
+            || pasteboardDelegate.tryPastingHTML(in: self)
+            || pasteboardDelegate.tryPastingAttributedString(in: self)
+            || pasteboardDelegate.tryPastingString(in: self)
+
         guard pasteHandled else {
             super.paste(sender)
             return
@@ -437,106 +470,12 @@ open class TextView: UITextView {
     }
 
     @objc open func pasteWithoutFormatting(_ sender: Any?) {
-        guard tryPastingString() else {
+        guard pasteboardDelegate.tryPastingString(in: self) else {
             super.paste(sender)
             return
         }
     }
     
-    // MARK: - Try Pasting
-    
-    /// Tries to paste an attributed string from the clipboard as source, replacing the selected range.
-    ///
-    /// - Returns: True if this method succeeds.
-    ///
-    private func tryPastingAttributedString() -> Bool {
-        guard let string = UIPasteboard.general.attributedString() else {
-            return false
-        }
-        
-        let finalRange = NSRange(location: selectedRange.location, length: string.length)
-        let originalText = attributedText.attributedSubstring(from: selectedRange)
-        
-        undoManager?.registerUndo(withTarget: self, handler: { [weak self] target in
-            self?.undoTextReplacement(of: originalText, finalRange: finalRange)
-        })
-        
-        string.loadLazyAttachments()
-        
-        storage.replaceCharacters(in: selectedRange, with: string)
-        notifyTextViewDidChange()
-        selectedRange = NSRange(location: selectedRange.location + string.length, length: 0)
-        return true
-    }
-
-    /// Tries to paste HTML from the clipboard as source, replacing the selected range.
-    ///
-    /// - Returns: True if this method succeeds.
-    ///
-    func tryPastingHTML() -> Bool {
-        guard let html = UIPasteboard.general.html(), storage.htmlConverter.isSupported(html) else {
-            return false
-        }
-
-        replace(selectedRange, withHTML: html)
-        return true
-    }
-
-    /// Tries to paste raw text from the clipboard, replacing the selected range.
-    ///
-    /// - Returns: True if this method succeeds.
-    ///
-    private func tryPastingString() -> Bool {
-        guard let string = UIPasteboard.general.attributedString() else {
-            return false
-        }
-
-        let finalRange = NSRange(location: selectedRange.location, length: string.length)
-        let originalText = attributedText.attributedSubstring(from: selectedRange)
-
-        undoManager?.registerUndo(withTarget: self, handler: { [weak self] target in
-            self?.undoTextReplacement(of: originalText, finalRange: finalRange)
-        })
-        
-        let newString = NSMutableAttributedString(attributedString: string)
-        
-        string.enumerateAttributes(in: string.rangeOfEntireString, options: []) { (attributes, range, stop) in
-            let newAttributes = attributes.filter({ (key, value) -> Bool in
-                return value is NSTextAttachment
-            })
-            
-            newString.setAttributes(newAttributes, range: range)
-        }
-        
-        newString.addAttributes(typingAttributesSwifted, range: string.rangeOfEntireString)
-        newString.loadLazyAttachments()
-
-        storage.replaceCharacters(in: selectedRange, with: newString)
-        notifyTextViewDidChange()
-        selectedRange = NSRange(location: selectedRange.location + newString.length, length: 0)
-        return true
-    }
-
-    /// Tries to paste a URL from the clipboard as a link applied to the selected range.
-    ///
-    /// - Returns: True if this method succeeds.
-    ///
-    private func tryPastingURL() -> Bool {
-        
-        guard UIPasteboard.general.hasURLs,
-            let url = UIPasteboard.general.url else {
-                return false
-        }
-
-        if selectedRange.length == 0 {
-            setLink(url, title:url.absoluteString, inRange: selectedRange)
-        } else {
-            setLink(url, inRange: selectedRange)
-        }
-
-        return true
-    }
-
     // MARK: - Intercept Keystrokes
 
     override open var keyCommands: [UIKeyCommand]? {
@@ -600,7 +539,7 @@ open class TextView: UITextView {
         pasteboard.items[0][NSAttributedString.pastesboardUTI] = data
     }
 
-    fileprivate func notifyTextViewDidChange() {
+    final func notifyTextViewDidChange() {
         delegate?.textViewDidChange?(self)
         NotificationCenter.default.post(name: .UITextViewTextDidChange, object: self)
     }
@@ -2168,7 +2107,7 @@ extension TextView: TextStorageAttachmentsDelegate {
 
 // MARK: - Undo implementation
 //
-private extension TextView {
+public extension TextView {
 
     /// Undoable Operation. Returns the Final Text Range, resulting from applying the undoable Operation
     /// Note that for Styling Operations, the Final Range will most likely match the Initial Range.
@@ -2184,7 +2123,7 @@ private extension TextView {
     ///     - initialRange: Initial Storage Range upon which we'll apply a transformation.
     ///     - block: Undoable Operation. Should return the resulting Substring's Range.
     ///
-    func performUndoable(at initialRange: NSRange, block: Undoable) {
+    private func performUndoable(at initialRange: NSRange, block: Undoable) {
         let originalString = storage.attributedSubstring(from: initialRange)
 
         let finalRange = block()
@@ -2196,7 +2135,7 @@ private extension TextView {
         notifyTextViewDidChange()
     }
 
-    func undoTextReplacement(of originalText: NSAttributedString, finalRange: NSRange) {
+    public func undoTextReplacement(of originalText: NSAttributedString, finalRange: NSRange) {
 
         let redoFinalRange = NSRange(location: finalRange.location, length: originalText.length)
         let redoOriginalText = storage.attributedSubstring(from: finalRange)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -130,22 +130,22 @@ public protocol TextViewPasteboardDelegate: class {
 
     /// Called by the TextView when it's attempting to paste a URL.
     ///
-    /// - Returns: True when the paste succeeded, false if it did not.
+    /// - Returns: True if the paste succeeded, false if it did not.
     func tryPastingURL(in textView: TextView) -> Bool
 
     /// Called by the TextView when it's attempting to paste HTML content.
     ///
-    /// - Returns: True when the paste succeeded, false if it did not.
+    /// - Returns: True if the paste succeeded, false if it did not.
     func tryPastingHTML(in textView: TextView) -> Bool
 
     /// Called by the TextView when it's attempting to paste an attributed string.
     ///
-    /// - Returns: True when the paste succeeded, false if it did not.
+    /// - Returns: True if the paste succeeded, false if it did not.
     func tryPastingAttributedString(in textView: TextView) -> Bool
 
     /// Called by the TextView when it's attempting to paste a string.
     ///
-    /// - Returns: True when the paste succeeded, false if it did not.
+    /// - Returns: True if the paste succeeded, false if it did not.
     func tryPastingString(in textView: TextView) -> Bool
 }
 

--- a/Aztec/Classes/TextKit/TextViewPasteboardDelegate.swift
+++ b/Aztec/Classes/TextKit/TextViewPasteboardDelegate.swift
@@ -4,6 +4,17 @@ open class AztecTextViewPasteboardDelegate: TextViewPasteboardDelegate {
 
     public init() {}
 
+    /// Tries to paste whatever is on the pasteboard into the editor.
+    ///
+    /// - Returns: True if the paste succeeds, false if it does not.
+    ///
+    open func tryPasting(in textView: TextView) -> Bool {
+        return tryPastingURL(in: textView)
+            || tryPastingHTML(in: textView)
+            || tryPastingAttributedString(in: textView)
+            || tryPastingString(in: textView)
+    }
+
     /// Tries to paste a URL from the clipboard as a link applied to the selected range.
     ///
     /// - Returns: True if this method succeeds.

--- a/Aztec/Classes/TextKit/TextViewPasteboardDelegate.swift
+++ b/Aztec/Classes/TextKit/TextViewPasteboardDelegate.swift
@@ -17,7 +17,7 @@ open class AztecTextViewPasteboardDelegate: TextViewPasteboardDelegate {
 
     /// Tries to paste a URL from the clipboard as a link applied to the selected range.
     ///
-    /// - Returns: True if this method succeeds.
+    /// - Returns: True if the paste succeeds, false if it does not.
     ///
     open func tryPastingURL(in textView: TextView) -> Bool {
         guard UIPasteboard.general.hasURLs,
@@ -38,7 +38,7 @@ open class AztecTextViewPasteboardDelegate: TextViewPasteboardDelegate {
     
     /// Tries to paste HTML from the clipboard as source, replacing the selected range.
     ///
-    /// - Returns: True if this method succeeds.
+    /// - Returns: True if the paste succeeds, false if it does not.
     ///
     open func tryPastingHTML(in textView: TextView) -> Bool {
         guard let html = UIPasteboard.general.html(),
@@ -52,7 +52,7 @@ open class AztecTextViewPasteboardDelegate: TextViewPasteboardDelegate {
 
     /// Tries to paste an attributed string from the clipboard as source, replacing the selected range.
     ///
-    /// - Returns: True if this method succeeds.
+    /// - Returns: True if the paste succeeds, false if it does not.
     ///
     open func tryPastingAttributedString(in textView: TextView) -> Bool {
         guard let string = UIPasteboard.general.attributedString() else {
@@ -82,7 +82,7 @@ open class AztecTextViewPasteboardDelegate: TextViewPasteboardDelegate {
 
     /// Tries to paste raw text from the clipboard, replacing the selected range.
     ///
-    /// - Returns: True if this method succeeds.
+    /// - Returns: True if the paste succeeds, false if it does not.
     ///
     open func tryPastingString(in textView: TextView) -> Bool {
         guard let string = UIPasteboard.general.attributedString() else {

--- a/Aztec/Classes/TextKit/TextViewPasteboardDelegate.swift
+++ b/Aztec/Classes/TextKit/TextViewPasteboardDelegate.swift
@@ -30,8 +30,9 @@ open class AztecTextViewPasteboardDelegate: TextViewPasteboardDelegate {
     /// - Returns: True if this method succeeds.
     ///
     open func tryPastingHTML(in textView: TextView) -> Bool {
-        guard let html = UIPasteboard.general.html() else {
-            return false
+        guard let html = UIPasteboard.general.html(),
+            textView.storage.htmlConverter.isSupported(html) else {
+                return false
         }
 
         textView.replace(textView.selectedRange, withHTML: html)

--- a/Aztec/Classes/TextKit/TextViewPasteboardDelegate.swift
+++ b/Aztec/Classes/TextKit/TextViewPasteboardDelegate.swift
@@ -1,0 +1,110 @@
+import UIKit
+
+open class AztecTextViewPasteboardDelegate: TextViewPasteboardDelegate {
+
+    public init() {}
+
+    /// Tries to paste a URL from the clipboard as a link applied to the selected range.
+    ///
+    /// - Returns: True if this method succeeds.
+    ///
+    open func tryPastingURL(in textView: TextView) -> Bool {
+        guard UIPasteboard.general.hasURLs,
+            let url = UIPasteboard.general.url else {
+                return false
+        }
+
+        let selectedRange = textView.selectedRange
+
+        if selectedRange.length == 0 {
+            textView.setLink(url, title:url.absoluteString, inRange: selectedRange)
+        } else {
+            textView.setLink(url, inRange: selectedRange)
+        }
+
+        return true
+    }
+    
+    /// Tries to paste HTML from the clipboard as source, replacing the selected range.
+    ///
+    /// - Returns: True if this method succeeds.
+    ///
+    open func tryPastingHTML(in textView: TextView) -> Bool {
+        guard let html = UIPasteboard.general.html() else {
+            return false
+        }
+
+        textView.replace(textView.selectedRange, withHTML: html)
+        return true
+    }
+
+    /// Tries to paste an attributed string from the clipboard as source, replacing the selected range.
+    ///
+    /// - Returns: True if this method succeeds.
+    ///
+    open func tryPastingAttributedString(in textView: TextView) -> Bool {
+        guard let string = UIPasteboard.general.attributedString() else {
+            return false
+        }
+
+        let selectedRange = textView.selectedRange
+        let storage = textView.storage
+
+        let finalRange = NSRange(location: selectedRange.location, length: string.length)
+        let originalText = textView.attributedText.attributedSubstring(from: selectedRange)
+
+        textView.undoManager?.registerUndo(withTarget: textView, handler: { [weak textView] target in
+            textView?.undoTextReplacement(of: originalText, finalRange: finalRange)
+        })
+
+        string.loadLazyAttachments()
+
+        storage.replaceCharacters(in: selectedRange, with: string)
+        textView.notifyTextViewDidChange()
+
+        let newSelectedRange = NSRange(location: selectedRange.location + string.length, length: 0)
+        textView.selectedRange = newSelectedRange
+
+        return true
+    }
+
+    /// Tries to paste raw text from the clipboard, replacing the selected range.
+    ///
+    /// - Returns: True if this method succeeds.
+    ///
+    open func tryPastingString(in textView: TextView) -> Bool {
+        guard let string = UIPasteboard.general.attributedString() else {
+            return false
+        }
+
+        let selectedRange = textView.selectedRange
+        let finalRange = NSRange(location: selectedRange.location, length: string.length)
+        let originalText = textView.attributedText.attributedSubstring(from: selectedRange)
+
+        textView.undoManager?.registerUndo(withTarget: textView, handler: { [weak textView] target in
+            textView?.undoTextReplacement(of: originalText, finalRange: finalRange)
+        })
+
+        let newString = NSMutableAttributedString(attributedString: string)
+
+        string.enumerateAttributes(in: string.rangeOfEntireString, options: []) { (attributes, range, stop) in
+            let newAttributes = attributes.filter({ (key, value) -> Bool in
+                return value is NSTextAttachment
+            })
+
+            newString.setAttributes(newAttributes, range: range)
+        }
+
+        let typingAttributesSwifted = textView.typingAttributesSwifted
+        newString.addAttributes(typingAttributesSwifted, range: string.rangeOfEntireString)
+        newString.loadLazyAttachments()
+
+        textView.storage.replaceCharacters(in: selectedRange, with: newString)
+        textView.notifyTextViewDidChange()
+
+        let newSelectedRange = NSRange(location: selectedRange.location + newString.length, length: 0)
+        textView.selectedRange = newSelectedRange
+
+        return true
+    }
+}

--- a/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
+++ b/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		F1FC70862139A998007AAFB3 /* GutenpackAttachmentRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC70852139A998007AAFB3 /* GutenpackAttachmentRendererTests.swift */; };
 		F1FC70932139B70A007AAFB3 /* GutenpackAttachmentRender_3x.png.dat in Resources */ = {isa = PBXBuildFile; fileRef = F1FC70922139B70A007AAFB3 /* GutenpackAttachmentRender_3x.png.dat */; };
 		F1FC70972139C778007AAFB3 /* GutenpackAttachmentRender_2x.png.dat in Resources */ = {isa = PBXBuildFile; fileRef = F1FC70952139C57D007AAFB3 /* GutenpackAttachmentRender_2x.png.dat */; };
+		F9982CFB218786E8001E606B /* WordPressPasteboardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9982CFA218786E8001E606B /* WordPressPasteboardDelegate.swift */; };
 		F9982CFD21878789001E606B /* EmbedURLProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9982CFC21878788001E606B /* EmbedURLProcessor.swift */; };
 		F9982CFF2187879E001E606B /* EmbedURLProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9982CFE2187879E001E606B /* EmbedURLProcessorTests.swift */; };
 		FF72508C20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */; };
@@ -152,6 +153,7 @@
 		F1FC70922139B70A007AAFB3 /* GutenpackAttachmentRender_3x.png.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = GutenpackAttachmentRender_3x.png.dat; sourceTree = "<group>"; };
 		F1FC70952139C57D007AAFB3 /* GutenpackAttachmentRender_2x.png.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = GutenpackAttachmentRender_2x.png.dat; sourceTree = "<group>"; };
 		F1FC70962139C58F007AAFB3 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		F9982CFA218786E8001E606B /* WordPressPasteboardDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressPasteboardDelegate.swift; sourceTree = "<group>"; };
 		F9982CFC21878788001E606B /* EmbedURLProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedURLProcessor.swift; sourceTree = "<group>"; };
 		F9982CFE2187879E001E606B /* EmbedURLProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedURLProcessorTests.swift; sourceTree = "<group>"; };
 		FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergAttributeDecoder.swift; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 			children = (
 				F16A2AEA20CDA19500BF3A0A /* AutopRemovep */,
 				F16A2AE820CDA16D00BF3A0A /* CaptionShortcode */,
+				F9982CF9218786D2001E606B /* Embeds */,
 				F16A2AE720CDA15700BF3A0A /* GalleryShortcode */,
 				F16A2AE920CDA18100BF3A0A /* VideoShortcode */,
 			);
@@ -463,6 +466,14 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		F9982CF9218786D2001E606B /* Embeds */ = {
+			isa = PBXGroup;
+			children = (
+				F9982CFA218786E8001E606B /* WordPressPasteboardDelegate.swift */,
+			);
+			path = Embeds;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -613,6 +624,7 @@
 				F105937520B2FEF1005A836E /* Gutenblock.swift in Sources */,
 				F1065DBE20ADEECD008C72CC /* WordPressPlugin.swift in Sources */,
 				F1065DC220ADEEF4008C72CC /* CaptionShortcodeOutputProcessor.swift in Sources */,
+				F9982CFB218786E8001E606B /* WordPressPasteboardDelegate.swift in Sources */,
 				F16A2ADF20CD9F1300BF3A0A /* GalleryAttachmentToElementConverter.swift in Sources */,
 				F11C5DB220EFA49100EDBABC /* GutenbergAttributeEncoder.swift in Sources */,
 				F13E8ADA20B71DFF007C9F8A /* GutenpackAttachment.swift in Sources */,

--- a/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
+++ b/WordPressEditor/WordPressEditor.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		F1FC70862139A998007AAFB3 /* GutenpackAttachmentRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1FC70852139A998007AAFB3 /* GutenpackAttachmentRendererTests.swift */; };
 		F1FC70932139B70A007AAFB3 /* GutenpackAttachmentRender_3x.png.dat in Resources */ = {isa = PBXBuildFile; fileRef = F1FC70922139B70A007AAFB3 /* GutenpackAttachmentRender_3x.png.dat */; };
 		F1FC70972139C778007AAFB3 /* GutenpackAttachmentRender_2x.png.dat in Resources */ = {isa = PBXBuildFile; fileRef = F1FC70952139C57D007AAFB3 /* GutenpackAttachmentRender_2x.png.dat */; };
+		F9982CFD21878789001E606B /* EmbedURLProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9982CFC21878788001E606B /* EmbedURLProcessor.swift */; };
+		F9982CFF2187879E001E606B /* EmbedURLProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9982CFE2187879E001E606B /* EmbedURLProcessorTests.swift */; };
 		FF72508C20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */; };
 		FFC41BEA20DD04A8004DFB4D /* GutenpackConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */; };
 		FFC41BF620DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */; };
@@ -150,6 +152,8 @@
 		F1FC70922139B70A007AAFB3 /* GutenpackAttachmentRender_3x.png.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = GutenpackAttachmentRender_3x.png.dat; sourceTree = "<group>"; };
 		F1FC70952139C57D007AAFB3 /* GutenpackAttachmentRender_2x.png.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = GutenpackAttachmentRender_2x.png.dat; sourceTree = "<group>"; };
 		F1FC70962139C58F007AAFB3 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		F9982CFC21878788001E606B /* EmbedURLProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedURLProcessor.swift; sourceTree = "<group>"; };
+		F9982CFE2187879E001E606B /* EmbedURLProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbedURLProcessorTests.swift; sourceTree = "<group>"; };
 		FF72508B20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergAttributeDecoder.swift; sourceTree = "<group>"; };
 		FFC41BE920DD04A8004DFB4D /* GutenpackConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackConverter.swift; sourceTree = "<group>"; };
 		FFC41BF520DD5EEB004DFB4D /* GutenpackAttachmentToElementConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenpackAttachmentToElementConverter.swift; sourceTree = "<group>"; };
@@ -299,6 +303,7 @@
 			isa = PBXGroup;
 			children = (
 				F1D36127209352AA00B4E7A5 /* ShortcodeProcessorTests.swift */,
+				F9982CFE2187879E001E606B /* EmbedURLProcessorTests.swift */,
 			);
 			path = Processors;
 			sourceTree = "<group>";
@@ -431,6 +436,7 @@
 		F1D3610C20929F3A00B4E7A5 /* Processors */ = {
 			isa = PBXGroup;
 			children = (
+				F9982CFC21878788001E606B /* EmbedURLProcessor.swift */,
 				F1D3610F20929F7900B4E7A5 /* ShortcodeProcessor.swift */,
 			);
 			path = Processors;
@@ -596,6 +602,7 @@
 				F1065DD220AE3D98008C72CC /* VideoShortcodeProcessor.swift in Sources */,
 				F15A8B5F20BDB9E800C57ED2 /* GutenbergAttributeNames.swift in Sources */,
 				FF72508C20E14E7D00A4C9D0 /* GutenbergAttributeDecoder.swift in Sources */,
+				F9982CFD21878789001E606B /* EmbedURLProcessor.swift in Sources */,
 				F1C9F40920AF62E900205227 /* GutenbergOutputHTMLTreeProcessor.swift in Sources */,
 				F1065DCF20ADF5D3008C72CC /* RemovePProcessor.swift in Sources */,
 				F1B1FDD220D14B6D0090A0A5 /* WordPressOutputCustomizer.swift in Sources */,
@@ -629,6 +636,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F9982CFF2187879E001E606B /* EmbedURLProcessorTests.swift in Sources */,
 				F1FC70782139952C007AAFB3 /* VideoAttachmentWordPressTests.swift in Sources */,
 				F1FC708021399A3B007AAFB3 /* GutenblockTests.swift in Sources */,
 				F118745320BC41BF0079C631 /* WordPressPluginTests.swift in Sources */,

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/Embeds/WordPressPasteboardDelegate.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/Embeds/WordPressPasteboardDelegate.swift
@@ -1,0 +1,27 @@
+import UIKit
+import Aztec
+
+class WordPressTextViewPasteboardDelegate: AztecTextViewPasteboardDelegate {
+
+    override func tryPastingURL(in textView: TextView) -> Bool {
+
+        let selectedRange = textView.selectedRange
+
+        /// TODO: support pasting multiple URLs
+        guard UIPasteboard.general.hasURLs,             // There are URLs on the pasteboard
+            let url = UIPasteboard.general.url,         // We can get the first one
+            selectedRange.length == 0,                  // No text is selected in the TextView
+            EmbedURLProcessor(url: url).isValidEmbed    // The pasteboard contains an embeddable URL
+            else {
+                return super.tryPastingURL(in: textView)
+        }
+
+        let result = super.tryPastingString(in: textView)
+
+        // Bump the input to the next line – we need the embed link to be the only
+        // text on this line – otherwise it can't be autoconverted.
+        textView.insertText(String(.lineSeparator))
+
+        return result
+    }
+}

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/WordPressPlugin.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/WordPressPlugin.swift
@@ -16,4 +16,8 @@ open class WordPressPlugin: Plugin {
             inputCustomizer: WordPressInputCustomizer(gutenbergContentVerifier: isGutenbergContent),
             outputCustomizer: WordPressOutputCustomizer(gutenbergContentVerifier: isGutenbergContent))
     }
+
+    open override func loaded(textView: TextView) {
+        textView.pasteboardDelegate = WordPressTextViewPasteboardDelegate()
+    }
 }

--- a/WordPressEditor/WordPressEditor/Classes/Processors/EmbedURLProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Processors/EmbedURLProcessor.swift
@@ -20,10 +20,10 @@ public struct EmbedURLProcessor{
     ///  - Short URL
     ///
     public var isYouTubeEmbed: Bool {
-        let longPattern = "^https?://(www.)?youtube.com/(watch\\?v=|embed/)[0-9|a-z|A-Z]+$"
+        let longPattern = "^https?://(www.)?youtube.com/(watch\\?v=|embed/)[0-9|a-z|A-Z|_]+$"
         let long = try! NSRegularExpression(pattern: longPattern, options: [.caseInsensitive])
 
-        let shortPattern = "^https?://youtu.be/[0-9|a-z|A-Z]+$"
+        let shortPattern = "^https?://youtu.be/[0-9|a-z|A-Z|_]+$"
         let short = try! NSRegularExpression(pattern: shortPattern, options: [.caseInsensitive])
 
         return matches(long) || matches(short)

--- a/WordPressEditor/WordPressEditor/Classes/Processors/EmbedURLProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Processors/EmbedURLProcessor.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public struct EmbedURLProcessor{
+
+    let url: URL
+
+    init(url: URL){
+        self.url = url
+    }
+
+    public var isValidEmbed: Bool{
+        return isYouTubeEmbed || isVimeoEmbed
+    }
+
+    /// Tests the url to see if it's a valid YouTube URL.
+    ///
+    /// Supports these formats:
+    ///  - Watch URL
+    ///  - Embed URL
+    ///  - Short URL
+    ///
+    public var isYouTubeEmbed: Bool {
+        let longPattern = "^https?://(www.)?youtube.com/(watch\\?v=|embed/)[0-9|a-z|A-Z]+$"
+        let long = try! NSRegularExpression(pattern: longPattern, options: [.caseInsensitive])
+
+        let shortPattern = "^https?://youtu.be/[0-9|a-z|A-Z]+$"
+        let short = try! NSRegularExpression(pattern: shortPattern, options: [.caseInsensitive])
+
+        return matches(long) || matches(short)
+    }
+
+    /// Tests the url to see if it's a valid Vimeo URL.
+    ///
+    /// Supports these formats:
+    ///  - Watch URL
+    ///  - Channel URL
+    ///  - Embedded Player URL
+    ///
+    public var isVimeoEmbed: Bool {
+        let pattern = "^https?://vimeo.com/[0-9]+$"
+        let regex = try! NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+
+        let channelPattern = "^https?://vimeo.com/channels/[0-9|a-z|A-Z]+/[0-9]+$"
+        let channel = try! NSRegularExpression(pattern: channelPattern, options: [.caseInsensitive])
+
+        let playerPattern = "^https://player.vimeo.com/video/[0-9]+$"
+        let player = try! NSRegularExpression(pattern: playerPattern, options: [.caseInsensitive])
+
+        return matches(regex) || matches(channel) || matches(player)
+    }
+
+    private func matches(_ regex: NSRegularExpression) -> Bool {
+        let urlRange = NSMakeRange(0, url.absoluteString.lengthOfBytes(using: .utf8))
+        let urlString = url.absoluteString
+
+        return !regex.matches(in: urlString, options: [], range: urlRange).isEmpty
+    }
+}

--- a/WordPressEditor/WordPressEditorTests/Processors/EmbedURLProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Processors/EmbedURLProcessorTests.swift
@@ -18,6 +18,9 @@ class EmbedURLProcessorTests: XCTestCase {
         assert(EmbedURLProcessor(url: url("https://youtube.com/watch?v=Z1BCujX3pw8")).isYouTubeEmbed)
         //HTTP, WWW
         assert(EmbedURLProcessor(url: url("http://www.youtube.com/watch?v=Z1BCujX3pw8")).isYouTubeEmbed)
+        //With underscores!
+        assert(EmbedURLProcessor(url: url("https://www.youtube.com/watch?v=Ms5mi_xADJw")).isYouTubeEmbed)
+        assert(EmbedURLProcessor(url: url("https://youtu.be/Ms5mi_xADJw")).isYouTubeEmbed)
     }
 
     func testThatValidYouTubeEmbedURLsWork() {

--- a/WordPressEditor/WordPressEditorTests/Processors/EmbedURLProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Processors/EmbedURLProcessorTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import WordPressEditor
+
+class EmbedURLProcessorTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testThatValidYouTubeWatchURLsWork() {
+        //HTTPS, WWW
+        assert(EmbedURLProcessor(url: url("https://www.youtube.com/watch?v=Z1BCujX3pw8")).isYouTubeEmbed)
+        //HTTPS, no WWW
+        assert(EmbedURLProcessor(url: url("https://youtube.com/watch?v=Z1BCujX3pw8")).isYouTubeEmbed)
+        //HTTP, WWW
+        assert(EmbedURLProcessor(url: url("http://www.youtube.com/watch?v=Z1BCujX3pw8")).isYouTubeEmbed)
+    }
+
+    func testThatValidYouTubeEmbedURLsWork() {
+        //HTTPS, WWW
+        assert(EmbedURLProcessor(url: url("https://www.youtube.com/embed/Z1BCujX3pw8")).isYouTubeEmbed)
+        //HTTPS, no WWW
+        assert(EmbedURLProcessor(url: url("https://youtube.com/embed/Z1BCujX3pw8")).isYouTubeEmbed)
+        //HTTP, WWW
+        assert(EmbedURLProcessor(url: url("http://www.youtube.com/embed/Z1BCujX3pw8")).isYouTubeEmbed)
+    }
+
+    func testThatValidYouTubeShortURLsWork() {
+        //HTTPS
+        assert(EmbedURLProcessor(url: url("https://youtu.be/Z1BCujX3pw8")).isYouTubeEmbed)
+        //HTTP
+        assert(EmbedURLProcessor(url: url("http://youtu.be/Z1BCujX3pw8")).isYouTubeEmbed)
+    }
+
+    func testThatValidVimeoURLsWork() {
+        //HTTPS
+        assert(EmbedURLProcessor(url: url("https://vimeo.com/295040990")).isVimeoEmbed)
+        //HTTP
+        assert(EmbedURLProcessor(url: url("http://vimeo.com/295040990")).isVimeoEmbed)
+
+        //HTTPS – Channel
+        assert(EmbedURLProcessor(url: url("https://vimeo.com/channels/staffpicks/290322470")).isVimeoEmbed)
+        //HTTP – Channel
+        assert(EmbedURLProcessor(url: url("http://vimeo.com/channels/staffpicks/290322470")).isVimeoEmbed)
+
+        //HTTPS – Player
+        assert(EmbedURLProcessor(url: url("https://player.vimeo.com/video/291598893")).isVimeoEmbed)
+        //HTTP – Player
+        assert(EmbedURLProcessor(url: url("https://player.vimeo.com/video/291598893")).isVimeoEmbed)
+    }
+
+    private func url(_ string: String) -> URL{
+        return URL(string: string)!
+    }
+}

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
@@ -4,13 +4,17 @@
 import Foundation
 import XCTest
 
+fileprivate let emptyImage = UIImage(data: Data(base64Encoded: "R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==")!)!
+
 class WordpressPluginTests: XCTestCase {
     
     let pluginManager: PluginManager = {
         let pluginManager = PluginManager()
+        let systemFont = UIFont.systemFont(ofSize: UIFont.systemFontSize)
+        let textView = TextView(defaultFont: systemFont, defaultMissingImage: emptyImage)
         
-        pluginManager.load(WordPressPlugin())
-        
+        pluginManager.load(WordPressPlugin(), in: textView)
+
         return pluginManager
     }()
     


### PR DESCRIPTION
Currently, when pasting a URL that could be transformed into an embed (such as a YouTube link), it’ll be turned into an `<a>` tag instead, which is frustrating for several users we're talking to. This solves the issue in the simplest possible way, which may not be the best long-term, so this should probably be treated as a proof-of-concept for a fix, rather than the fix itself (unless everyone likes the direction). 

This pull request pre-empts the URL transformation of links if there’s no text selected (for instance, the user might actually want to make some text like “click here” be the link to the YouTube video, and we want the link transformation to work in that case). This allows a pasteboard that contains only a URL to be evaluated for whether it can be embedded, and if it can, it does. If not, it'll paste it as a regular link.

This PR implements support for YouTube and Vimeo embeds. The full list is a lot longer (https://codex.wordpress.org/Embeds), but it shouldn’t be difficult to implement each – it’ll just take time to write all the detection logic. 

Fixes #589 (partially)

**To test:**

Open "Empty Demo"
Paste in a YouTube or Vimeo link

**Before**
Turns into an `<a>` tag.

**After**
Just pastes the url on its own line – this'll allow WordPress to turn the link into an embed.
