### PR TITLE
Better compatibility with gutenberg gallery

### DIFF
--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -456,17 +456,14 @@ private extension AttributedStringParser {
             guard newProperties.count > index else {
                 break
             }
-            
-            let previousProperty = conversion.property
-            let newProperty = newProperties[index]
-            
-            guard newProperty.isEqual(previousProperty) else {
+
+            guard isMergable(at: index, conversion: conversion, newProperties: newProperties) else {
                 break
             }
             
             lastMergeableIndex = index
         }
-        
+
         guard lastMergeableIndex >= 0 else {
             return nil
         }
@@ -495,6 +492,20 @@ private extension AttributedStringParser {
         }
         
         return previousConversions.prefix(through: lastMergeableIndex)
+    }
+
+    private func isMergable(at index: Int, conversion: ParagraphPropertyConversion, newProperties: [ParagraphProperty]) -> Bool {
+
+        let previousProperty = conversion.property
+        let newProperty = newProperties[index]
+
+        // `li` tags as a rule will never merge, unless it has a `figure` as child. We want to keep all
+        // `figure` children merged inside a single `li` tag.
+        if newProperty is HTMLLi, newProperties.indices.contains(index + 1), newProperties[index + 1] is Figure {
+            return newProperty === previousProperty
+        } else {
+            return newProperty.isEqual(previousProperty)
+        }
     }
 }
 

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -457,7 +457,7 @@ private extension AttributedStringParser {
                 break
             }
 
-            guard isMergable(at: index, conversion: conversion, newProperties: newProperties) else {
+            guard isMergable(conversion, with: newProperties, at: index) else {
                 break
             }
             
@@ -494,8 +494,7 @@ private extension AttributedStringParser {
         return previousConversions.prefix(through: lastMergeableIndex)
     }
 
-    private func isMergable(at index: Int, conversion: ParagraphPropertyConversion, newProperties: [ParagraphProperty]) -> Bool {
-
+    private func isMergable(_ conversion: ParagraphPropertyConversion, with newProperties: [ParagraphProperty], at index: Int) -> Bool {
         let previousProperty = conversion.property
         let newProperty = newProperties[index]
 

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
+		7E45CBBF2187A54200C0B2AB /* gallery.html in Resources */ = {isa = PBXBuildFile; fileRef = 7E45CBBE2187A54200C0B2AB /* gallery.html */; };
 		B5DB1C371EC630E10005E623 /* UnknownEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */; };
 		B5FB212A1FEC38470067D597 /* captions.html in Resources */ = {isa = PBXBuildFile; fileRef = B5FB21271FEC37DB0067D597 /* captions.html */; };
 		BE2672F31FC6E5A80026107E /* EditorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2672F21FC6E5A80026107E /* EditorPage.swift */; };
@@ -133,6 +134,7 @@
 		607FACDA1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		607FACDC1AFB9204008FA782 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		7E45CBBE2187A54200C0B2AB /* gallery.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = gallery.html; sourceTree = "<group>"; };
 		B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnknownEditorViewController.swift; sourceTree = "<group>"; };
 		B5FB21271FEC37DB0067D597 /* captions.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = captions.html; sourceTree = "<group>"; };
 		BE2672F21FC6E5A80026107E /* EditorPage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorPage.swift; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 			isa = PBXGroup;
 			children = (
 				59280F281D47CAF40083FB59 /* content.html */,
+				7E45CBBE2187A54200C0B2AB /* gallery.html */,
 				B5FB21271FEC37DB0067D597 /* captions.html */,
 				FF149F4920E3C49A0070FECB /* imagesOverlays.html */,
 				59280F291D47CAF40083FB59 /* SampleText.rtf */,
@@ -435,6 +438,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7E45CBBF2187A54200C0B2AB /* gallery.html in Resources */,
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
 				59280F2A1D47CAF40083FB59 /* content.html in Resources */,

--- a/Example/Example/SampleContent/gallery.html
+++ b/Example/Example/SampleContent/gallery.html
@@ -1,0 +1,16 @@
+<!-- wp:gallery -->
+<ul class="wp-block-gallery columns-3 is-cropped">
+    <li class="blocks-gallery-item">
+        <figure>
+            <img src="https://etoledomatomicsite01.blog/wp-content/uploads/2018/05/giphy.gif" alt="" data-id="56" data-link="https://etoledomatomicsite01.blog/giphy/" class="wp-image-56" />
+            <figcaption>caption</figcaption>
+        </figure>
+    </li>
+    <li class="blocks-gallery-item">
+        <figure>
+            <img src="https://etoledomatomicsite01.blog/wp-content/uploads/2018/04/kitty-cat-kitten-pet-45201.jpg" alt="" data-id="49" data-link="https://etoledomatomicsite01.blog/kitty-cat-kitten-pet-45201/" class="wp-image-49" />
+            <figcaption>caption</figcaption>
+        </figure>
+    </li>
+</ul>
+<!-- /wp:gallery -->

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -24,6 +24,7 @@ class ViewController: UITableViewController
             DemoSection(title: "WordPressEditor (Calypso & Gutenberg)", rows: [
                 DemoRow(title: "Gutenberg Demo", action: { self.showEditorDemo(filename: "gutenberg", wordPressMode: true) }),
                 DemoRow(title: "Video Shortcode Demo", action: { self.showEditorDemo(filename: "video", wordPressMode: true) }),
+                DemoRow(title: "Gutenberg Gallery", action: { self.showEditorDemo(filename: "gallery", wordPressMode: true) }),
                 DemoRow(title: "Empty Demo", action: { self.showEditorDemo(wordPressMode: true) })
                 ]
             ),


### PR DESCRIPTION
Fixes [WPiOS: 10355](https://github.com/wordpress-mobile/WordPress-iOS/issues/10355)

The issue happens when parsing NSAttributedStrings back to HTML:

Having this kind of input:
```html
<li class="blocks-gallery-item">
    <figure>
        <img src="https://etoledomatomicsite01.blog/wp-content/uploads/2018/05/giphy.gif" alt="" data-id="56" data-link="https://etoledomatomicsite01.blog/giphy/" class="wp-image-56" />
        <figcaption>caption</figcaption>
    </figure>
</li>
```

we were having back this HTML code:
```html
<ul class="wp-block-gallery columns-3 is-cropped">
    <li class="blocks-gallery-item">
        <figure>
            <img src="https://etoledomatomicsite01.blog/wp-content/uploads/2018/05/giphy.gif" data-id="56" data-link="https://etoledomatomicsite01.blog/giphy/" class="wp-image-56" alt="">
        </figure>
    </li>
    <li class="blocks-gallery-item">
        <figure>
            <figcaption>caption</figcaption>
        </figure>
    </li>
</ul>
```
The `li` tag was splitting the content of `figure ` tag.
This kind of `figure` tags inside a list is the way `Gutenberg-gallery` is constructed, so we are having troubles displaying and saving them on the mobile app.

The common behavior of Aztec is to not merge `li` tags, but in this case in particular, we do want to merge all it's content, to keep the `img` and `figcaption` together as children of `figure` tag.

This PR adds an exception to the `li do not merge` "rule", by inspecting if its child is a `figure` tag.
While not ideal, it solves this particular case without modifying the previous behavior.

- This PR also adds a `Gutenberg-gallery` example, to easily inspect and test this behavior.

**To test:**
- All tests regarding `li` tags must pass, including the new one checking the Gutenberg-gallery composition.
- Run the example app, 
- Check that `li` tags works properly.
- Check that the new `Gutenberg Gallery` row in the (Calypso & Gutenberg) section behaves properly.
