### PR TITLE
Resolves some issues with more gutenberg blocks.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/Node.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Node.swift
@@ -137,7 +137,9 @@ public class Node: Equatable, CustomReflectable, Hashable {
             if node is ElementNode {
                 return true
             } else if let textNode = node as? TextNode {
-                return textNode.length() > 0
+                let text = textNode.sanitizedText()
+                
+                return text.count > 0
             } else if node is CommentNode {
                 return true
             }

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -66,3 +66,55 @@ public class TextNode: Node {
         return self.name == textNode.name && self.contents == textNode.contents
     }    
 }
+
+// MARK: - Text Sanitization
+
+extension TextNode {
+    
+    func sanitizedText() -> String {
+        guard shouldSanitizeText() else {
+            return text()
+        }
+        
+        return sanitize(text())
+    }
+    
+    private func sanitize(_ text: String) -> String {
+        guard text != String(.space) else {
+            return text
+        }
+        
+        let hasAnEndingSpace = text.hasSuffix(String(.space))
+        let hasAStartingSpace = text.hasPrefix(String(.space))
+        
+        // We cannot use CharacterSet.whitespacesAndNewlines directly, because it includes
+        // U+000A, which is non-breaking space.  We need to maintain it.
+        //
+        let whitespace = CharacterSet.whitespacesAndNewlines
+        let whitespaceToKeep = CharacterSet(charactersIn: String(.nonBreakingSpace))
+        let whitespaceToRemove = whitespace.subtracting(whitespaceToKeep)
+        
+        let trimmedText = text.trimmingCharacters(in: whitespaceToRemove)
+        var singleSpaceText = trimmedText
+        let doubleSpace = "  "
+        let singleSpace = " "
+        
+        while singleSpaceText.range(of: doubleSpace) != nil {
+            singleSpaceText = singleSpaceText.replacingOccurrences(of: doubleSpace, with: singleSpace)
+        }
+        
+        let noBreaksText = singleSpaceText.replacingOccurrences(of: String(.lineFeed), with: "")
+        let endingSpace = !noBreaksText.isEmpty && hasAnEndingSpace ? String(.space) : ""
+        let startingSpace = !noBreaksText.isEmpty && hasAStartingSpace ? String(.space) : ""
+        return "\(startingSpace)\(noBreaksText)\(endingSpace)"
+    }
+    
+    /// This method check that in the current context it makes sense to clean up newlines and double spaces from text.
+    /// For example if you are inside a pre element you shoulnd't clean up the nodes.
+    ///
+    /// - Returns: true if sanitization should happen, false otherwise
+    ///
+    private func shouldSanitizeText() -> Bool {
+        return !hasAncestor(ofType: .pre)
+    }
+}

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenpackAttachmentRenderer.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenpackAttachmentRenderer.swift
@@ -3,8 +3,7 @@ import Foundation
 import UIKit
 
 
-// MARK: - SpecialTagAttachmentRenderer. This render aims rendering WordPress specific tags.
-//
+/// Renders self-closing Gutenberg blocks.
 final public class GutenpackAttachmentRenderer {
     
     /// Text Color
@@ -14,9 +13,6 @@ final public class GutenpackAttachmentRenderer {
     public init() {}
 }
 
-
-// MARK: - TextViewCommentsDelegate Methods
-//
 extension GutenpackAttachmentRenderer: TextViewAttachmentImageProvider {
     
     public func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {


### PR DESCRIPTION
### Description:

Resolves some issues with the MORE Gutenberg block.

Moves forward: https://github.com/wordpress-mobile/WordPress-iOS/issues/10371

This PR also sneaks in some unrelated changes here: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1077/files#diff-b8006fa672b42a2ab3040720285a175dL6

They're just documentation updates and should be harmless.  Apologies for the mix up.

### Testing:

In the Gutenberg empty editor, pasting the following HTML:

```html
<!-- wp:paragraph -->
<p>This is text</p>
<!-- /wp:paragraph -->

<!-- wp:more -->
<!--more-->
<!-- /wp:more -->

<!-- wp:paragraph -->
<p>This is more text</p>
<!-- /wp:paragraph -->
```

Then switching to visual and back to HTML, would generate this output.

```html
<!-- wp:paragraph -->
<p>This is text</p>
<!-- /wp:paragraph -->
<!-- wp:more --><!--more-->This is more text<!-- /wp:more -->
```

This PR solves this specific issue.