### PR TITLE
Fixes a bug that was causing certain HTML contents to be lost.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		F1C05B9D1E37FA77007510EA /* String+CharacterName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B9C1E37FA77007510EA /* String+CharacterName.swift */; };
 		F1C05B9F1E37FD2F007510EA /* NSAttributedString+CharacterName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B9E1E37FD2F007510EA /* NSAttributedString+CharacterName.swift */; };
 		F1CF7F9020E14E2200B24173 /* AttributedStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CF7F8F20E14E2200B24173 /* AttributedStringParser.swift */; };
+		F1DC21B42199D5D6007C189E /* GenericElementConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DC21B32199D5D6007C189E /* GenericElementConverterTests.swift */; };
 		F1DE83D51EF20493009269E6 /* UIColor+Parsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DE83D41EF20493009269E6 /* UIColor+Parsers.swift */; };
 		F1E1B7782062BE6B004642BB /* ParagraphStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E1B7772062BE6B004642BB /* ParagraphStyleTests.swift */; };
 		F1E1D5801FEC44B30086B339 /* AttachmentElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E1D57F1FEC44B30086B339 /* AttachmentElementConverter.swift */; };
@@ -441,6 +442,7 @@
 		F1C05B9C1E37FA77007510EA /* String+CharacterName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+CharacterName.swift"; sourceTree = "<group>"; };
 		F1C05B9E1E37FD2F007510EA /* NSAttributedString+CharacterName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+CharacterName.swift"; sourceTree = "<group>"; };
 		F1CF7F8F20E14E2200B24173 /* AttributedStringParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributedStringParser.swift; sourceTree = "<group>"; };
+		F1DC21B32199D5D6007C189E /* GenericElementConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericElementConverterTests.swift; sourceTree = "<group>"; };
 		F1DE83D41EF20493009269E6 /* UIColor+Parsers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Parsers.swift"; sourceTree = "<group>"; };
 		F1E1B7772062BE6B004642BB /* ParagraphStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParagraphStyleTests.swift; sourceTree = "<group>"; };
 		F1E1D57F1FEC44B30086B339 /* AttachmentElementConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentElementConverter.swift; sourceTree = "<group>"; };
@@ -901,6 +903,7 @@
 			isa = PBXGroup;
 			children = (
 				F126ADC521553E25008F7DD1 /* AttributesToStringAttributes */,
+				F1DC21B22199D58B007C189E /* ElementToAttributedString */,
 				F1E75630215B0C9E004BC254 /* StringAttributesToAttributes */,
 			);
 			name = Converters;
@@ -1230,6 +1233,14 @@
 				F1AFD65720B45E5700CB0279 /* HTMLAttachmentRenderer.swift */,
 			);
 			path = Renderers;
+			sourceTree = "<group>";
+		};
+		F1DC21B22199D58B007C189E /* ElementToAttributedString */ = {
+			isa = PBXGroup;
+			children = (
+				F1DC21B32199D5D6007C189E /* GenericElementConverterTests.swift */,
+			);
+			path = ElementToAttributedString;
 			sourceTree = "<group>";
 		};
 		F1E75630215B0C9E004BC254 /* StringAttributesToAttributes */ = {
@@ -1649,6 +1660,7 @@
 				F1E75632215B0CB7004BC254 /* BoldStringAttributeConverterTests.swift in Sources */,
 				F1953E251F4E544A00C717C9 /* HTMLParserTests.swift in Sources */,
 				F15415F6213446490096D18E /* CommentAttachmentRendererTests.swift in Sources */,
+				F1DC21B42199D5D6007C189E /* GenericElementConverterTests.swift in Sources */,
 				B5C16A631F4DF77300B113CF /* HeaderFormatterTests.swift in Sources */,
 				B5D575881F2288E2003A62F6 /* TextViewStubAttachmentDelegate.swift in Sources */,
 				F168DB861F6381A00009BD0E /* CSSParserTests.swift in Sources */,

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Base/AttachmentElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Base/AttachmentElementConverter.swift
@@ -9,7 +9,7 @@ public protocol AttachmentElementConverter: ElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> (attachment: AttachmentType, string: NSAttributedString)
+        contentSerializer serialize: ContentSerializer) -> (attachment: AttachmentType, string: NSAttributedString)
 }
 
 public extension AttachmentElementConverter {
@@ -19,9 +19,9 @@ public extension AttachmentElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> NSAttributedString {
+        contentSerializer serialize: ContentSerializer) -> NSAttributedString {
         
-        let (_, output) = convert(element, inheriting: attributes, childrenSerializer: serializeChildren)
+        let (_, output) = convert(element, inheriting: attributes, contentSerializer: serialize)
         
         return output
     }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Base/ElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Base/ElementConverter.swift
@@ -1,12 +1,11 @@
 import UIKit
 
-
 /// ElementConverters take an HTML Element that don't have a textual representation and return a special value to
 /// represent it (e.g. `<img>` or `<video>`). To apply a style to a piece of text, use `AttributeFormatter`.
 ///
 public protocol ElementConverter {
     
-    typealias ContentSerializer = (_ elementNode: ElementNode, _ inheriting: [NSAttributedStringKey:Any]) -> NSAttributedString
+    typealias ContentSerializer = (_ elementNode: ElementNode, _ intrinsicRepresentation: NSAttributedString?, _ inheriting: [NSAttributedStringKey:Any]) -> NSAttributedString
     
     /// Converts an instance of ElementNode into a NSAttributedString.
     ///

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Base/ElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Base/ElementConverter.swift
@@ -6,7 +6,7 @@ import UIKit
 ///
 public protocol ElementConverter {
     
-    typealias ChildrenSerializer = (_: [Node], _ inheriting: [NSAttributedStringKey:Any]) -> NSAttributedString
+    typealias ContentSerializer = (_ elementNode: ElementNode, _ inheriting: [NSAttributedStringKey:Any]) -> NSAttributedString
     
     /// Converts an instance of ElementNode into a NSAttributedString.
     ///
@@ -20,5 +20,5 @@ public protocol ElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting inheritedAttributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> NSAttributedString
+        contentSerializer serialize: ContentSerializer) -> NSAttributedString
 }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/BRElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/BRElementConverter.swift
@@ -10,10 +10,10 @@ class BRElementConverter: ElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> NSAttributedString {
+        contentSerializer serialize: ContentSerializer) -> NSAttributedString {
         
         precondition(element.type == .br)
         
-        return NSAttributedString(.lineSeparator, attributes: attributes)
+        return serialize(element, attributes)
     }
 }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/BRElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/BRElementConverter.swift
@@ -14,6 +14,8 @@ class BRElementConverter: ElementConverter {
         
         precondition(element.type == .br)
         
-        return serialize(element, attributes)
+        let intrinsicRepresentation = NSAttributedString(.lineSeparator, attributes: attributes)
+        
+        return serialize(element, intrinsicRepresentation, attributes)
     }
 }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/CiteElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/CiteElementConverter.swift
@@ -10,13 +10,13 @@ class CiteElementConverter: FormatterElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting inheritedAttributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> NSAttributedString {
+        contentSerializer serialize: ContentSerializer) -> NSAttributedString {
         
         precondition(element.type == .cite)
         
         let childrenAttributes = attributes(for: element, inheriting: inheritedAttributes)
         
-        return serializeChildren(element.children, childrenAttributes)
+        return serialize(element, childrenAttributes)
     }
     
     // MARK: - FormatterElementConverter

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/CiteElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/CiteElementConverter.swift
@@ -16,7 +16,7 @@ class CiteElementConverter: FormatterElementConverter {
         
         let childrenAttributes = attributes(for: element, inheriting: inheritedAttributes)
         
-        return serialize(element, childrenAttributes)
+        return serialize(element, nil, childrenAttributes)
     }
     
     // MARK: - FormatterElementConverter

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigcaptionElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigcaptionElementConverter.swift
@@ -12,13 +12,13 @@ class FigcaptionElementConverter: ElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> NSAttributedString {
+        contentSerializer serialize: ContentSerializer) -> NSAttributedString {
         
         precondition(element.type == .figcaption)
         
         let attributes = self.attributes(for: element, inheriting: attributes)
         
-        return serializeChildren(element.children, attributes)
+        return serialize(element, attributes)
     }
     
     private func attributes(for element: ElementNode, inheriting attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigcaptionElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigcaptionElementConverter.swift
@@ -18,7 +18,7 @@ class FigcaptionElementConverter: ElementConverter {
         
         let attributes = self.attributes(for: element, inheriting: attributes)
         
-        return serialize(element, attributes)
+        return serialize(element, nil, attributes)
     }
     
     private func attributes(for element: ElementNode, inheriting attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigureElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigureElementConverter.swift
@@ -16,7 +16,7 @@ class FigureElementConverter: ElementConverter {
        
         let attributes = self.attributes(for: element, inheriting: attributes)
         
-        return serialize(element, attributes)
+        return serialize(element, nil, attributes)
     }
     
     private func attributes(for element: ElementNode, inheriting attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigureElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigureElementConverter.swift
@@ -10,13 +10,13 @@ class FigureElementConverter: ElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> NSAttributedString {
+        contentSerializer serialize: ContentSerializer) -> NSAttributedString {
        
         precondition(element.type == .figure)
        
         let attributes = self.attributes(for: element, inheriting: attributes)
         
-        return serializeChildren(element.children, attributes)
+        return serialize(element, attributes)
     }
     
     private func attributes(for element: ElementNode, inheriting attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
@@ -64,13 +64,13 @@ class GenericElementConverter: ElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> NSAttributedString {
+        contentSerializer serialize: ContentSerializer) -> NSAttributedString {
         
         guard isSupportedByEditor(element) else {
             return convert(unsupported: element, inheriting: attributes)
         }
         
-        return convert(supported: element, inheriting: attributes, childrenSerializer: serializeChildren)
+        return convert(supported: element, inheriting: attributes, contentSerializer: serialize)
     }
     
     private func isSupportedByEditor(_ element: ElementNode) -> Bool {
@@ -100,11 +100,11 @@ class GenericElementConverter: ElementConverter {
     private func convert(
         supported element: ElementNode,
         inheriting inheritedAttributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> NSAttributedString {
+        contentSerializer serialize: ContentSerializer) -> NSAttributedString {
         
         let childrenAttributes = attributes(for: element, inheriting: inheritedAttributes)
         
-        return serializeChildren(element.children, childrenAttributes)
+        return serialize(element, childrenAttributes)
     }
 }
 

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
@@ -104,7 +104,7 @@ class GenericElementConverter: ElementConverter {
         
         let childrenAttributes = attributes(for: element, inheriting: inheritedAttributes)
         
-        return serialize(element, childrenAttributes)
+        return serialize(element, nil, childrenAttributes)
     }
 }
 

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
@@ -99,7 +99,7 @@ class GenericElementConverter: ElementConverter {
         
         let content = NSMutableAttributedString(attachment: attachment, attributes: attributes)
         
-        if element.needsClosingParagraphSeparator(ignoreChildren: true) {
+        if element.needsClosingParagraphSeparatorIncludingDescendants() {
             content.append(NSAttributedString(.paragraphSeparator, attributes: attributes))
         }
         

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
@@ -87,14 +87,23 @@ class GenericElementConverter: ElementConverter {
     ///
     /// - Returns: the converted node as an `NSAttributedString`.
     ///
-    private func convert(unsupported element: ElementNode, inheriting attributes: [NSAttributedStringKey: Any]) -> NSAttributedString {
+    private func convert(
+        unsupported element: ElementNode,
+        inheriting attributes: [NSAttributedStringKey: Any]) -> NSAttributedString {
+        
         let serializer = HTMLSerializer()
         let attachment = HTMLAttachment()
         
         attachment.rootTagName = element.name
         attachment.rawHTML = serializer.serialize(element)
         
-        return NSAttributedString(attachment: attachment, attributes: attributes)
+        let content = NSMutableAttributedString(attachment: attachment, attributes: attributes)
+        
+        if element.needsClosingParagraphSeparator(ignoreChildren: true) {
+            content.append(NSAttributedString(.paragraphSeparator, attributes: attributes))
+        }
+        
+        return content
     }
     
     private func convert(

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/HRElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/HRElementConverter.swift
@@ -12,7 +12,7 @@ class HRElementConverter: AttachmentElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> (attachment: NSTextAttachment, string: NSAttributedString) {
+        contentSerializer serialize: ContentSerializer) -> (attachment: NSTextAttachment, string: NSAttributedString) {
         
         precondition(element.type == .hr)
         

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/ImageElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/ImageElementConverter.swift
@@ -15,8 +15,10 @@ class ImageElementConverter: AttachmentElementConverter {
         contentSerializer serialize: ContentSerializer) -> (attachment: ImageAttachment, string: NSAttributedString) {
         
         let attachment = self.attachment(for: element)
+        let intrinsicRepresentation = NSAttributedString(attachment: attachment, attributes: attributes)
+        let serialization = serialize(element, intrinsicRepresentation, attributes)
         
-        return (attachment, NSAttributedString(attachment: attachment, attributes: attributes))
+        return (attachment, serialization)
     }
     
     // MARK: - Attachment Creation

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/ImageElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/ImageElementConverter.swift
@@ -12,7 +12,7 @@ class ImageElementConverter: AttachmentElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> (attachment: ImageAttachment, string: NSAttributedString) {
+        contentSerializer serialize: ContentSerializer) -> (attachment: ImageAttachment, string: NSAttributedString) {
         
         let attachment = self.attachment(for: element)
         

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
@@ -12,7 +12,7 @@ class VideoElementConverter: AttachmentElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> (attachment: VideoAttachment, string: NSAttributedString) {
+        contentSerializer serialize: ContentSerializer) -> (attachment: VideoAttachment, string: NSAttributedString) {
         
         let attachment = self.attachment(for: element)
         

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -136,12 +136,13 @@ public class ElementNode: Node {
 
     /// Checks if the specified node requires a closing paragraph separator.
     ///
+    /// Returns: true if the element has no children, needs an explicit representation (to avoid losing attributes),
+    ///     and if it either has a block level element to the right or is the last element in a block level separation.
+    ///
     override func needsClosingParagraphSeparator() -> Bool {
-        guard children.count == 0 else {
-            return false
-        }
-
-        return super.needsClosingParagraphSeparator()
+        return !hasChildren()
+            && (hasAttributes() || !isLastInTree())
+            && (hasRightBlockLevelSibling() || isLastInAncestorEndingInBlockLevelSeparation())
     }
 
     // MARK: - Node Queries
@@ -156,6 +157,10 @@ public class ElementNode: Node {
         return attributes.first { (attribute) -> Bool in
             return attribute.type == type
         }
+    }
+    
+    public func hasAttributes() -> Bool {
+        return attributes.count > 0
     }
 
     func stringValueForAttribute(named attributeName: String) -> String? {
@@ -268,6 +273,9 @@ public class ElementNode: Node {
         return type.equivalentNames.contains(name.lowercased())
     }
     
+    func hasChildren() -> Bool {
+        return children.count > 0
+    }
 
     /// Retrieves the last child matching a specific filtering closure.
     ///
@@ -320,7 +328,7 @@ public class ElementNode: Node {
         return elements.first { element in
             return element.isNodeType(type)
         }
-    }    
+    }
 
     // MARK: - DOM Queries
     

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -133,20 +133,20 @@ public class ElementNode: Node {
     }
     
     // MARK: - Node Overrides
+    
+    override func needsClosingParagraphSeparator() -> Bool {
+        return (!hasChildren())
+            && (hasAttributes() || !isLastInTree())
+            && (hasRightBlockLevelSibling() || isLastInAncestorEndingInBlockLevelSeparation())
+    }
 
-    /// Checks if the specified node requires a closing paragraph separator.
+    /// Checks if the specified node requires a closing paragraph separator in itself, or in the any of its descendants.
     ///
-    /// - Parameters:
-    ///     - ignoreChildren: Usually only the lowest node will have a paragraph separator, but this parameter
-    ///         allows the caller to check if this element requires a closing paragraph separator regardless of
-    ///         if it has children or not.
-    ///
-    /// - Returns: true if the element has no children, needs an explicit representation (to avoid losing attributes),
+    /// - Returns: true if the element needs an explicit representation (to avoid losing attributes),
     ///     and if it either has a block level element to the right or is the last element in a block level separation.
     ///
-    func needsClosingParagraphSeparator(ignoreChildren: Bool = false) -> Bool {
-        return (ignoreChildren || !hasChildren())
-            && (hasAttributes() || !isLastInTree())
+    func needsClosingParagraphSeparatorIncludingDescendants() -> Bool {
+        return (hasAttributes() || !isLastInTree())
             && (hasRightBlockLevelSibling() || isLastInAncestorEndingInBlockLevelSeparation())
     }
 

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -139,8 +139,8 @@ public class ElementNode: Node {
     /// Returns: true if the element has no children, needs an explicit representation (to avoid losing attributes),
     ///     and if it either has a block level element to the right or is the last element in a block level separation.
     ///
-    override func needsClosingParagraphSeparator() -> Bool {
-        return !hasChildren()
+    func needsClosingParagraphSeparator(ignoreChildren: Bool = false) -> Bool {
+        return (ignoreChildren || !hasChildren())
             && (hasAttributes() || !isLastInTree())
             && (hasRightBlockLevelSibling() || isLastInAncestorEndingInBlockLevelSeparation())
     }

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -136,7 +136,12 @@ public class ElementNode: Node {
 
     /// Checks if the specified node requires a closing paragraph separator.
     ///
-    /// Returns: true if the element has no children, needs an explicit representation (to avoid losing attributes),
+    /// - Parameters:
+    ///     - ignoreChildren: Usually only the lowest node will have a paragraph separator, but this parameter
+    ///         allows the caller to check if this element requires a closing paragraph separator regardless of
+    ///         if it has children or not.
+    ///
+    /// - Returns: true if the element has no children, needs an explicit representation (to avoid losing attributes),
     ///     and if it either has a block level element to the right or is the last element in a block level separation.
     ///
     func needsClosingParagraphSeparator(ignoreChildren: Bool = false) -> Bool {

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -965,8 +965,9 @@ private extension AttributedStringParser {
         var output = [Node]()
 
         for (index, substring) in substrings.enumerated() {
-
-            output.append(TextNode(text: substring))
+            
+            let cleanString = substring.replacingOccurrences(of: String(.zeroWidthSpace), with: "")
+            output.append(TextNode(text: cleanString))
 
             if index < substrings.count - 1 {
                 output.append(ElementNode(type: .br))

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -174,6 +174,13 @@ class AttributedStringSerializer {
             content.append(nodeString)
         }
         
+        guard content.length > 0 else {
+            // We need to make sure something is returned even if there's nothing to serialize
+            // Otherwise the attributes are lost.
+            //
+            return NSAttributedString(string: String(.zeroWidthSpace), attributes: attributes)
+        }
+        
         return content
     }
 

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -136,11 +136,6 @@ class AttributedStringSerializer {
         let convertedString = converter.convert(element, inheriting: attributes, contentSerializer: contentSerializer)
         
         content.append(convertedString)
-        /*
-        guard !element.needsClosingParagraphSeparator() else {
-            return appendParagraphSeparator(to: content, inheriting: attributes)
-        }
- */
 
         return content
     }
@@ -163,7 +158,7 @@ class AttributedStringSerializer {
     //
     private(set) lazy var genericElementConverter = GenericElementConverter()
     
-    lazy var contentSerializer: ElementConverter.ContentSerializer = { [unowned self] (elementNode, attributes) in
+    lazy var contentSerializer: ElementConverter.ContentSerializer = { [unowned self] (elementNode, intrinsicRepresentation, attributes) in
         let content = NSMutableAttributedString()
         
         for child in elementNode.children {
@@ -171,8 +166,8 @@ class AttributedStringSerializer {
             content.append(nodeString)
         }
         
-        if elementNode.type == .br {
-            content.append(NSAttributedString(.lineSeparator, attributes: attributes))
+        if let intrinsicRepresentation = intrinsicRepresentation {
+            content.append(intrinsicRepresentation)
         }
         
         guard !elementNode.needsClosingParagraphSeparator() else {

--- a/AztecTests/New Group/ElementToAttributedString/GenericElementConverterTests.swift
+++ b/AztecTests/New Group/ElementToAttributedString/GenericElementConverterTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import Aztec
+
+class GenericElementConverterTests: XCTestCase {
+
+    let converter = GenericElementConverter()
+    let contentSerializer: ElementConverter.ContentSerializer = { elementNode, implicitRepresentation, attributes in
+        return NSAttributedString()
+    }
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        
+        continueAfterFailure = false
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testNewlineAfterUnsupportedElementInBlockLevelParent() {
+        let childElementNode = ElementNode(type: .br)
+        let attribute = Attribute(name: "someAttribute", value: .none)
+        let elementNode = ElementNode(name: "unsupported", attributes: [attribute], children: [childElementNode])
+        
+        // The reason for having a parent element node, even if unused, is that it should force the unsupported element node
+        // to have a newline after it when converted, since it's the last node in a block-level parent element.
+        let parent = ElementNode(type: .p, attributes: [], children: [elementNode])
+        
+        // This is just to silence the warning that says `parent` is unused.
+        let _ = parent
+        
+        let output = converter.convert(elementNode, inheriting: [:], contentSerializer: contentSerializer)
+    
+        XCTAssertEqual(output.length, 2)
+        XCTAssertEqual(output.string.last, Character(.paragraphSeparator))
+    }
+}

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -465,7 +465,7 @@ class TextStorageTests: XCTestCase {
         XCTAssertEqual(html, outputHTML)
     }
 
-    func testListElemeAttributes() {
+    func testListElementAttributes() {
         let html = """
 <ul class="wp-block-gallery alignnone columns-1 is-cropped">
   <li class="blocks-gallery-item">

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -832,7 +832,6 @@ class TextViewTests: XCTestCase {
     /// Ref. Scenario Mark III on Issue https://github.com/wordpress-mobile/AztecEditor-iOS/pull/425
     ///
     func testNewLinesAreInsertedAfterEmptyList() {
-        let newline = String(.lineFeed)
         let textView = TextViewStub(withHTML: "")
 
         // Toggle List + Move the selection to the EOD
@@ -841,8 +840,8 @@ class TextViewTests: XCTestCase {
 
         // Insert Newline
         var expectedLength = textView.text.count
-        textView.insertText(newline)
-        expectedLength += newline.count
+        textView.insertText(String(.lineFeed))
+        expectedLength += String(.lineFeed).count
 
         XCTAssertEqual(textView.text.count, expectedLength)
     }

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/GalleryShortcode/GalleryElementConverter.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/GalleryShortcode/GalleryElementConverter.swift
@@ -16,7 +16,7 @@ class GalleryElementConverter: AttachmentElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> (attachment: GalleryAttachment, string: NSAttributedString) {
+        contentSerializer serialize: ContentSerializer) -> (attachment: GalleryAttachment, string: NSAttributedString) {
         
         precondition(element.type == .gallery)
         

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenblockConverter.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenblockConverter.swift
@@ -18,7 +18,7 @@ class GutenblockConverter: ElementConverter {
         
         let attributes = self.attributes(for: element, inheriting: attributes)
     
-        return serialize(element, attributes)
+        return serialize(element, nil, attributes)
     }
     
     private func attributes(for element: ElementNode, inheriting attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenblockConverter.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenblockConverter.swift
@@ -12,13 +12,13 @@ class GutenblockConverter: ElementConverter {
     func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> NSAttributedString {
+        contentSerializer serialize: ContentSerializer) -> NSAttributedString {
         
         precondition(element.type == .gutenblock)
         
         let attributes = self.attributes(for: element, inheriting: attributes)
     
-        return serializeChildren(element.children, attributes)
+        return serialize(element, attributes)
     }
     
     private func attributes(for element: ElementNode, inheriting attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenpackConverter.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenpackConverter.swift
@@ -12,7 +12,7 @@ public class GutenpackConverter: ElementConverter {
     public func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
-        childrenSerializer serializeChildren: ChildrenSerializer) -> NSAttributedString {
+        contentSerializer serialize: ContentSerializer) -> NSAttributedString {
         
         precondition(element.type == .gutenpack)
 

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/GalleryShortcode/GalleryElementConverterTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/GalleryShortcode/GalleryElementConverterTests.swift
@@ -10,7 +10,7 @@ class GalleryElementConverterTests: XCTestCase {
         let attributes = [Attribute(name: "columns", value: .string("4"))]
         let element = ElementNode(type: .gallery, attributes: attributes)
         
-        let (gallery, _) = converter.convert(element, inheriting: [:]) { (node, attributes) -> NSAttributedString in
+        let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes) -> NSAttributedString in
             return NSAttributedString()
         }
         
@@ -24,7 +24,7 @@ class GalleryElementConverterTests: XCTestCase {
         let attributes = [Attribute(name: "iDs", value: .string("4, 2, 6,8"))]
         let element = ElementNode(type: .gallery, attributes: attributes)
         
-        let (gallery, _) = converter.convert(element, inheriting: [:]) { (node, attributes) -> NSAttributedString in
+        let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes) -> NSAttributedString in
             return NSAttributedString()
         }
         
@@ -43,7 +43,7 @@ class GalleryElementConverterTests: XCTestCase {
             let attributes = [Attribute(name: "orderby", value: .string(orderValue))]
             let element = ElementNode(type: .gallery, attributes: attributes)
             
-            let (gallery, _) = converter.convert(element, inheriting: [:]) { (node, attributes) -> NSAttributedString in
+            let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes) -> NSAttributedString in
                 return NSAttributedString()
             }
             
@@ -63,7 +63,7 @@ class GalleryElementConverterTests: XCTestCase {
             let attributes = [Attribute(name: "orderby", value: .string(orderByValue))]
             let element = ElementNode(type: .gallery, attributes: attributes)
             
-            let (gallery, _) = converter.convert(element, inheriting: [:]) { (node, attributes) -> NSAttributedString in
+            let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes) -> NSAttributedString in
                 return NSAttributedString()
             }
             
@@ -92,7 +92,7 @@ class GalleryElementConverterTests: XCTestCase {
                 let attributes = [columnsAttribute, idsAttribute, orderAttribute, orderByAttribute]
                 let element = ElementNode(type: .gallery, attributes: attributes)
                 
-                let (gallery, _) = converter.convert(element, inheriting: [:]) { (node, attributes) -> NSAttributedString in
+                let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes) -> NSAttributedString in
                     return NSAttributedString()
                 }
                 

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
@@ -193,5 +193,21 @@ class WordpressPluginTests: XCTestCase {
 
         XCTAssertEqual(finalHTML, expected)
     }
+    
+    //  MARK: - Spacer Block
+    
+    /// This test was spawned off this issue:
+    /// https://github.com/wordpress-mobile/AztecEditor-iOS/issues/1078
+    ///
+    /// Spacer blocks are not being properly parsed and are being stripped from posts.
+    ///
+    func testSpacerBlockNotRemoved() {
+        let spacerBlock = "<!-- wp:spacer --><div style=\"height: 100px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div><!-- /wp:spacer -->"
+        
+        let attributedString = htmlConverter.attributedString(from: spacerBlock)
+        let finalHTML = htmlConverter.html(from: attributedString)
+        
+        XCTAssertEqual(finalHTML, spacerBlock)
+    }
 }
 


### PR DESCRIPTION
### Description:

Fixes #1078 

This issue provides a mechanism for making sure data isn't lost on HTML elements without actual contents.

### Testing:

**Test 1:**
Run the newly added unit test.

**Test 2:**

As reported [here](https://github.com/wordpress-mobile/AztecEditor-iOS/issues/1078).

1. Open the empty Gutenberg demo.
2. Paste the following HTML content:
```html
<!-- wp:spacer -->
<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->
```
3. Switch to visual and back.

Make sure the content is still there.