### PR TITLE
Non breaking spaces are no longer removed by WordPressEditor.

### DIFF
--- a/Aztec/Classes/Extensions/String+HTML.swift
+++ b/Aztec/Classes/Extensions/String+HTML.swift
@@ -33,8 +33,9 @@ extension String {
     ///
     private var entities: [Entity] {
         return [
-            ("&", "&amp;"),
+            ("&", "&amp;"), // IMPORTANT: keep this first to avoid replacing the ampersand from other escaped entities.
             ("<", "&lt;"),
+            (String(.nonBreakingSpace), "&nbsp;"),
             (">", "&gt;")
         ]
     }

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1951,4 +1951,18 @@ class TextViewTests: XCTestCase {
         let html = "<p><a href=\"http://wordpress.com\">WordPress</a></p>"
         XCTAssertEqual(textView.getHTML(prettify: false), html)
     }
+    
+    // MARK: - Non-breaking spaces.
+    
+    func testNonBreakingSpacesAreProperlyEncoded() {
+        let textView = TextViewStub(withHTML: "WordPress")
+        
+        let html = "<p>&nbsp;&nbsp;</p><p>&nbsp;<br>&nbsp;</p>"
+        let expected = "<p>&nbsp;&nbsp;</p><p>&nbsp;<br>&nbsp;</p>"
+        
+        textView.setHTML(html)
+        let output = textView.getHTML(prettify: false)
+        
+        XCTAssertEqual(output, expected)
+    }
 }

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
@@ -209,5 +209,17 @@ class WordpressPluginTests: XCTestCase {
         
         XCTAssertEqual(finalHTML, spacerBlock)
     }
+    
+    // MARK: - Non-breaking spaces.
+    
+    func testNonBreakingSpacesAreProperlyEncoded() {
+        let html = "<p>&nbsp;&nbsp;</p><p>&nbsp;<br>&nbsp;</p>"
+        let expected = "&nbsp;&nbsp;\n\n&nbsp;\n&nbsp;"
+        
+        let attributedString = htmlConverter.attributedString(from: html)
+        let finalHTML = htmlConverter.html(from: attributedString)
+        
+        XCTAssertEqual(finalHTML, expected)
+    }
 }
 


### PR DESCRIPTION
### Description:

Non breaking spaces were being removed by `WordPressEditor` and were not being properly encoded when switching back to HTML mode in Aztec.

### Testing:

1. Open either the Aztec or WordPressEditor empty demo.
2. Switch to HTML mode.
3. Write several `&nbsp;`s, in multiple lines, or one after the other.
4. Switch to visual mode and back to HTML mode.

Make sure the `&nbsp;`s are still there and properly encoded for HTML.

Props to @charliescheer for finding this issue and reporting it.