### PR TITLE
Fixes all unit tests in Xcode 10.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		F197340E1FA14B85007018A8 /* HTMLTreeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F197340D1FA14B85007018A8 /* HTMLTreeProcessor.swift */; };
 		F1AFD65820B45E5700CB0279 /* CommentAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AFD65620B45E5700CB0279 /* CommentAttachmentRenderer.swift */; };
 		F1AFD65920B45E5700CB0279 /* HTMLAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AFD65720B45E5700CB0279 /* HTMLAttachmentRenderer.swift */; };
+		F1B7525E219CBAB100E5CC31 /* Array+Attribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B7525D219CBAB100E5CC31 /* Array+Attribute.swift */; };
 		F1BDDDE520603C18000714E1 /* FigcaptionFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BDDDE420603C18000714E1 /* FigcaptionFormatter.swift */; };
 		F1BDDDE72060403B000714E1 /* FigureFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BDDDE62060403B000714E1 /* FigureFormatter.swift */; };
 		F1C05B991E37F99D007510EA /* Character+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B981E37F99D007510EA /* Character+Name.swift */; };
@@ -436,6 +437,7 @@
 		F197340D1FA14B85007018A8 /* HTMLTreeProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLTreeProcessor.swift; sourceTree = "<group>"; };
 		F1AFD65620B45E5700CB0279 /* CommentAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentAttachmentRenderer.swift; sourceTree = "<group>"; };
 		F1AFD65720B45E5700CB0279 /* HTMLAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachmentRenderer.swift; sourceTree = "<group>"; };
+		F1B7525D219CBAB100E5CC31 /* Array+Attribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Attribute.swift"; sourceTree = "<group>"; };
 		F1BDDDE420603C18000714E1 /* FigcaptionFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FigcaptionFormatter.swift; sourceTree = "<group>"; };
 		F1BDDDE62060403B000714E1 /* FigureFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FigureFormatter.swift; sourceTree = "<group>"; };
 		F1C05B981E37F99D007510EA /* Character+Name.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Character+Name.swift"; sourceTree = "<group>"; };
@@ -696,6 +698,7 @@
 		599F25241D8BC9A1002871D6 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				F1B7525D219CBAB100E5CC31 /* Array+Attribute.swift */,
 				B575344F1F267D0B009D4904 /* Array+Helpers.swift */,
 				F165D92920C72EF500EAA6B0 /* Array+ShortcodeAttribute.swift */,
 				F1C05B981E37F99D007510EA /* Character+Name.swift */,
@@ -1587,6 +1590,7 @@
 				FFB5D29720BEB21A0038DCFB /* CiteFormatter.swift in Sources */,
 				F12F586A1EF20394008AE298 /* HeaderFormatter.swift in Sources */,
 				F193AD6720C5A40A00BBA8F4 /* ShortcodeAttributeParser.swift in Sources */,
+				F1B7525E219CBAB100E5CC31 /* Array+Attribute.swift in Sources */,
 				F14C4D2620C076EA007CBC57 /* HTMLConverter.swift in Sources */,
 				F13CE5401F4DD08E0043368D /* RegexProcessor.swift in Sources */,
 				40A298731FD61E1900AEDF3B /* VideoElementConverter.swift in Sources */,

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/ImageElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/ImageElementConverter.swift
@@ -24,10 +24,11 @@ class ImageElementConverter: AttachmentElementConverter {
     // MARK: - Attachment Creation
     
     private func attachment(for element: ElementNode) -> ImageAttachment {
-        var extraAttributes = [String: String]()
+        var extraAttributes = [Attribute]()
+        
         for attribute in element.attributes {
             if let value = attribute.value.toString() {
-                extraAttributes[attribute.name] = value
+                extraAttributes[attribute.name] = .string(value)
             }
         }
 
@@ -35,7 +36,7 @@ class ImageElementConverter: AttachmentElementConverter {
         let srcAttribute = element.attributes.first(where: { $0.name == "src" })
         
         if let urlString = srcAttribute?.value.toString() {
-            extraAttributes.removeValue(forKey: "src")
+            extraAttributes.remove(named: "src")
             url = URL(string: urlString)
         } else {
             url = nil
@@ -62,9 +63,9 @@ class ImageElementConverter: AttachmentElementConverter {
             })
             let remainingClassAttributes = otherAttributes.joined(separator: " ")
             if remainingClassAttributes.isEmpty {
-                extraAttributes.removeValue(forKey: "class")
+                extraAttributes.remove(named: "class")
             } else {
-                extraAttributes["class"] = remainingClassAttributes
+                extraAttributes["class"] = .string(remainingClassAttributes)
             }
         }
         

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
@@ -22,11 +22,11 @@ class VideoElementConverter: AttachmentElementConverter {
     // MARK: - Attachment Creation
     
     func attachment(for element: ElementNode) -> VideoAttachment {
-        var extraAttributes = [String:String]()
+        var extraAttributes = [Attribute]()
 
         for attribute in element.attributes {
             if let value = attribute.value.toString() {
-                extraAttributes[attribute.name] = value
+                extraAttributes[attribute.name] = .string(value)
             }
         }
 
@@ -35,7 +35,7 @@ class VideoElementConverter: AttachmentElementConverter {
         
         if let urlString = srcAttribute?.value.toString() {
             srcURL = URL(string: urlString)
-            extraAttributes.removeValue(forKey: "src")
+            extraAttributes.remove(named: "src")
         } else {
             srcURL = nil
         }
@@ -45,7 +45,7 @@ class VideoElementConverter: AttachmentElementConverter {
         
         if let urlString = posterAttribute?.value.toString() {
             posterURL = URL(string: urlString)
-            extraAttributes.removeValue(forKey: "poster")
+            extraAttributes.remove(named: "poster")
         } else {
             posterURL = nil
         }

--- a/Aztec/Classes/Extensions/Array+Attribute.swift
+++ b/Aztec/Classes/Extensions/Array+Attribute.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public extension Array where Element == Attribute {
+    
+    subscript(_ name: String) -> Attribute.Value? {
+        get {
+            return first(where: { $0.name == name })?.value
+        }
+        
+        set {
+            guard let newValue = newValue else {
+                remove(named: name)
+                return
+            }
+            
+            set(newValue, for: name)
+        }
+    }
+    
+    public mutating func set(_ value: String, for name: String) {
+        set(.string(value), for: name)
+    }
+    
+    public mutating func set(_ value: Attribute.Value, for name: String) {
+        guard let attributeIndex = index(where: { $0.name == name }) else {
+            let newAttribute = Attribute(name: name, value: value)
+            
+            append(newAttribute)
+            return
+        }
+        
+        self[attributeIndex].value = value
+    }
+    
+    public mutating func remove(named name: String) {
+        guard let attributeIndex = index(where: { $0.name == name }) else {
+            return
+        }
+        
+        remove(at: attributeIndex)
+    }
+}

--- a/Aztec/Classes/NSAttributedString/Conversions/AttachmentToElementConverter/ImageAttachmentToElementConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttachmentToElementConverter/ImageAttachmentToElementConverter.swift
@@ -25,12 +25,26 @@ class ImageAttachmentToElementConverter: AttachmentToElementConverter {
             imageElement.updateAttribute(named: attribute.name, value: attribute.value)
         }
         
-        for (key,value) in attachment.extraAttributes {
+        for attribute in attachment.extraAttributes {
+            
+            let key = attribute.name
+            
+            guard let value = attribute.value.toString() else {
+                continue
+            }
+            
             var finalValue = value
-            if key == "class", let baseValue = imageElement.stringValueForAttribute(named: "class"){
-                let baseComponents = Set(baseValue.components(separatedBy: " "))
-                let extraComponents = Set(value.components(separatedBy: " "))
-                finalValue = baseComponents.union(extraComponents).joined(separator: " ")
+            
+            if key == "class",
+                let baseValue = imageElement.stringValueForAttribute(named: "class") {
+                
+                // Apple, we really need a Swift-native ordered set.  Thank you!
+                let baseComponents = NSMutableOrderedSet(array: baseValue.components(separatedBy: " "))
+                let extraComponents = NSOrderedSet(array: value.components(separatedBy: " "))
+                
+                baseComponents.union(extraComponents)
+                
+                finalValue = (baseComponents.array as! [String]).joined(separator: " ")
             }
             imageElement.updateAttribute(named: key, value: .string(finalValue))
         }

--- a/Aztec/Classes/NSAttributedString/Conversions/AttachmentToElementConverter/VideoAttachmentToElementConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttachmentToElementConverter/VideoAttachmentToElementConverter.swift
@@ -21,8 +21,8 @@ class VideoAttachmentToElementConverter: AttachmentToElementConverter {
             element.updateAttribute(named: attribute.name, value: attribute.value)
         }
         
-        for (key,value) in attachment.extraAttributes {
-            element.updateAttribute(named: key, value: .string(value))
+        for attribute in attachment.extraAttributes {
+            element.updateAttribute(named: attribute.name, value: attribute.value)
         }
         
         return [element]

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -28,7 +28,7 @@ open class MediaAttachment: NSTextAttachment {
 
     /// Attributes accessible by the user, for general purposes.
     ///
-    open var extraAttributes = [String: String]()
+    open var extraAttributes = [Attribute]()
 
     /// Identifier used to match this attachment with a custom UIView subclass
     ///

--- a/AztecTests/Renderers/CommentAttachmentRendererTests.swift
+++ b/AztecTests/Renderers/CommentAttachmentRendererTests.swift
@@ -46,42 +46,4 @@ class CommentAttachmentRendererTests: XCTestCase {
         
         XCTAssertEqual(bounds, expectedBounds)
     }
-    
-    func testImageForAttachment() {
-        let textView = TextView(
-            defaultFont: UIFont.systemFont(ofSize: 12),
-            defaultMissingImage: UIImage())
-        let attachment = CommentAttachment()
-        attachment.text = "Some comment!"
-        let renderer = CommentAttachmentRenderer(font: UIFont.systemFont(ofSize: 12))
-        
-        let fileName: String = {
-            if UIScreen.main.scale == 3 {
-                return "CommentAttachmentRender_3x.png"
-            } else if UIScreen.main.scale == 2 {
-                return "CommentAttachmentRender_2x.png"
-            }
-            
-            // We no longer support 1x
-            fatalError()
-        }()
-        
-        let bundle = Bundle(for: type(of: self))
-        guard let url = bundle.url(forResource: fileName, withExtension: "dat", subdirectory: nil),
-            let expectedPNGRepresentation = try? Data(contentsOf: url, options: []) else {
-                XCTFail()
-                return
-        }
-        
-        let desiredSize = CGSize(width: 100, height: 44.0)
-        
-        guard let image = renderer.textView(textView, imageFor: attachment, with: desiredSize),
-            let pngRepresentation = UIImagePNGRepresentation(image) else {
-                XCTFail()
-                return
-        }
-        
-        XCTAssertNotNil(pngRepresentation)
-        XCTAssertEqual(pngRepresentation, expectedPNGRepresentation)
-    }
 }

--- a/AztecTests/Renderers/HTMLAttachmentRendererTests.swift
+++ b/AztecTests/Renderers/HTMLAttachmentRendererTests.swift
@@ -51,41 +51,4 @@ class HTMLAttachmentRendererTests: XCTestCase {
         
         XCTAssertNil(renderer.textView(textView, imageFor: attachment, with: CGSize(width: 10, height: 10)))
     }
-    
-    func testImageForAttachment() {
-        let textView = TextView(
-            defaultFont: UIFont.systemFont(ofSize: 12),
-            defaultMissingImage: UIImage())
-        let attachment = HTMLAttachment()
-        let renderer = HTMLAttachmentRenderer(font: UIFont.systemFont(ofSize: 12))
-        
-        let fileName: String = {
-            if UIScreen.main.scale == 3 {
-                return "HTMLAttachmentRender_3x.png"
-            } else if UIScreen.main.scale == 2 {
-                return "HTMLAttachmentRender_2x.png"
-            }
-            
-            // We no longer support 1x
-            fatalError()
-        }()
- 
-        let bundle = Bundle(for: type(of: self))
-        guard let url = bundle.url(forResource: fileName, withExtension: "dat", subdirectory: nil),
-            let expectedPNGRepresentation = try? Data(contentsOf: url, options: []) else {
-                XCTFail()
-                return
-        }
-        
-        let desiredSize = CGSize(width: 100, height: 44.0)
-        
-        guard let image = renderer.textView(textView, imageFor: attachment, with: desiredSize),
-            let pngRepresentation = UIImagePNGRepresentation(image) else {
-                XCTFail()
-                return
-        }
-        
-        XCTAssertNotNil(pngRepresentation)
-        XCTAssertEqual(pngRepresentation, expectedPNGRepresentation)
-    }
 }

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1542,9 +1542,9 @@ class TextViewTests: XCTestCase {
             XCTFail("An video attachment should be present")
             return
         }
-        XCTAssertEqual(attachment.extraAttributes["data-wpvideopress"], "videopress", "Property should be available")
+        XCTAssertEqual(attachment.extraAttributes["data-wpvideopress"], .string("videopress"), "Property should be available")
 
-        attachment.extraAttributes["data-wpvideopress"] = "ABCDE"
+        attachment.extraAttributes["data-wpvideopress"] = .string("ABCDE")
 
         XCTAssertEqual(textView.getHTML(), "<p><video src=\"newVideo.mp4\" poster=\"video.jpg\" data-wpvideopress=\"ABCDE\"></video></p>")
     }
@@ -1665,19 +1665,19 @@ class TextViewTests: XCTestCase {
         let html = "<img src=\"image.jpg\" class=\"alignnone\" alt=\"Alt\" title=\"Title\">"
         let textView = TextViewStub(withHTML: html)
 
-        XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone\" title=\"Title\" alt=\"Alt\"></p>")
+        XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone\" alt=\"Alt\" title=\"Title\"></p>")
 
         guard let attachment = textView.storage.mediaAttachments.first as? ImageAttachment else {
             XCTFail("An video attachment should be present")
             return
         }
-        XCTAssertEqual(attachment.extraAttributes["alt"], "Alt", "Alt Property should be available")
-        XCTAssertEqual(attachment.extraAttributes["title"], "Title", "Title Property should be available")
+        XCTAssertEqual(attachment.extraAttributes["alt"], .string("Alt"), "Alt Property should be available")
+        XCTAssertEqual(attachment.extraAttributes["title"], .string("Title"), "Title Property should be available")
 
-        attachment.extraAttributes["alt"] = "Changed Alt"
-        attachment.extraAttributes["class"] = "wp-image-169"
+        attachment.extraAttributes["alt"] = .string("Changed Alt")
+        attachment.extraAttributes["class"] = .string("wp-image-169")
 
-        XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone wp-image-169\" title=\"Title\" alt=\"Changed Alt\"></p>")
+        XCTAssertEqual(textView.getHTML(), "<p><img src=\"image.jpg\" class=\"alignnone wp-image-169\" alt=\"Changed Alt\" title=\"Title\"></p>")
     }
 
 
@@ -1890,7 +1890,7 @@ class TextViewTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(attributedValue, "ABCDE")
+        XCTAssertEqual(attributedValue, .string("ABCDE"))
 
         // Remove attribute
         attachment.extraAttributes["data-wp_upload_id"] = nil

--- a/Example/Example/AttachmentDetailsViewController.swift
+++ b/Example/Example/AttachmentDetailsViewController.swift
@@ -62,7 +62,7 @@ class AttachmentDetailsViewController: UITableViewController
         linkURLTextField.text = linkURL?.absoluteString
 
         captionTextView.attributedText = caption
-        altTextField.text = attachment.extraAttributes["alt"]
+        altTextField.text = attachment.extraAttributes["alt"]?.toString()
     }
 
     @IBAction func cancelWasPressed() {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1461,7 +1461,7 @@ private extension EditorDemoController
 
             let attachment = self.richTextView.edit(attachment) { attachment in
                 if let alt = alt {
-                    attachment.extraAttributes["alt"] = alt
+                    attachment.extraAttributes["alt"] = .string(alt)
                 }
 
                 attachment.alignment = alignment

--- a/WordPressEditor/WordPressEditor/Classes/Extensions/ImageAttachment+WordPress.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Extensions/ImageAttachment+WordPress.swift
@@ -7,52 +7,53 @@ extension ImageAttachment {
 
     @objc var alt: String? {
         get {
-            return extraAttributes["alt"]
+            return extraAttributes["alt"]?.toString()
         }
         set {
             if let nonNilValue = newValue, newValue != "" {
-                extraAttributes["alt"] = nonNilValue
+                extraAttributes["alt"] = .string(nonNilValue)
             } else {
-                extraAttributes.removeValue(forKey: "alt")
+                extraAttributes.remove(named: "alt")
             }
         }
     }
 
     var width: Int? {
         get {
-            guard let stringInt = extraAttributes["width"] else {
+            guard let stringInt = extraAttributes["width"]?.toString() else {
                 return nil
             }
+            
             return Int(stringInt)
         }
         set {
             if let nonNilValue = newValue {
-                extraAttributes["width"] = "\(nonNilValue)"
+                extraAttributes["width"] = .string(String(nonNilValue))
             } else {
-                extraAttributes.removeValue(forKey: "width")
+                extraAttributes.remove(named: "width")
             }
         }
     }
 
     var height: Int? {
         get {
-            guard let stringInt = extraAttributes["height"] else {
+            guard let stringInt = extraAttributes["height"]?.toString() else {
                 return nil
             }
             return Int(stringInt)
         }
         set {
             if let nonNilValue = newValue {
-                extraAttributes["height"] = "\(nonNilValue)"
+                extraAttributes["height"] = .string(String(nonNilValue))
             } else {
-                extraAttributes.removeValue(forKey: "height")
+                extraAttributes.remove(named: "height")
             }
         }
     }
 
     var imageID: Int? {
         get {
-            guard let classAttribute = extraAttributes["class"] else {
+            guard let classAttribute = extraAttributes["class"]?.toString() else {
                 return nil
             }
             
@@ -72,7 +73,7 @@ extension ImageAttachment {
         set {
             var attributes = [String]()
             
-            if let classAttribute = extraAttributes["class"] {
+            if let classAttribute = extraAttributes["class"]?.toString() {
                 attributes = classAttribute.components(separatedBy: " ")
             }
             
@@ -85,9 +86,9 @@ extension ImageAttachment {
             }
             
             if attributes.isEmpty {
-                extraAttributes.removeValue(forKey: "class")
+                extraAttributes.remove(named: "class")
             } else {
-                extraAttributes["class"] = attributes.joined(separator: " ")
+                extraAttributes["class"] = .string(attributes.joined(separator: " "))
             }
         }
     }

--- a/WordPressEditor/WordPressEditor/Classes/Extensions/MediaAttachment+WordPress.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Extensions/MediaAttachment+WordPress.swift
@@ -10,13 +10,13 @@ extension MediaAttachment {
 
     var uploadID: String? {
         get {
-            return extraAttributes[MediaAttachment.uploadKey]
+            return extraAttributes[MediaAttachment.uploadKey]?.toString()
         }
         set {
             if let nonNilValue = newValue {
-                extraAttributes[MediaAttachment.uploadKey] = "\(nonNilValue)"
+                extraAttributes[MediaAttachment.uploadKey] = .string(nonNilValue)
             } else {
-                extraAttributes.removeValue(forKey: MediaAttachment.uploadKey)
+                extraAttributes.remove(named: MediaAttachment.uploadKey)
             }
         }
     }

--- a/WordPressEditor/WordPressEditor/Classes/Extensions/VideoAttachment+WordPress.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Extensions/VideoAttachment+WordPress.swift
@@ -8,13 +8,13 @@ extension VideoAttachment {
 
     @objc var videoPressID: String? {
         get {
-            return extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute]
+            return extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute]?.toString()
         }
         set {
             if let nonNilValue = newValue {
-                extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute] = nonNilValue
+                extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute] = .string(nonNilValue)
             } else {
-                extraAttributes.removeValue(forKey: VideoShortcodeProcessor.videoPressHTMLAttribute)
+                extraAttributes.remove(named: VideoShortcodeProcessor.videoPressHTMLAttribute)
             }
         }
     }

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/GalleryShortcode/GalleryAttachmentToElementConverter.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/GalleryShortcode/GalleryAttachmentToElementConverter.swift
@@ -41,12 +41,12 @@ extension GalleryAttachmentToElementConverter {
     }
     
     private func getUnsupportedAttributes(from attachment: GalleryAttachment) -> [Attribute] {
-        return attachment.extraAttributes.compactMap { (key, value) -> Attribute? in
-            guard !GallerySupportedAttribute.isSupported(key) else {
+        return attachment.extraAttributes.compactMap { attribute -> Attribute? in
+            guard !GallerySupportedAttribute.isSupported(attribute.name) else {
                 return nil
             }
             
-            return Attribute(name: key, value: .string(value))
+            return attribute
         }
     }
     

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/GalleryShortcode/GalleryElementConverter.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/GalleryShortcode/GalleryElementConverter.swift
@@ -69,21 +69,16 @@ private extension GalleryElementConverter {
         return attribute(.orderBy, in: attributes, withType: GalleryAttachment.OrderBy.self)
     }
     
-    private func getUnsupportedAttributes(_ attributes: [Attribute]) -> [String: String] {
+    private func getUnsupportedAttributes(_ attributes: [Attribute]) -> [Attribute] {
         
-        var output = [String: String]()
+        var output = [Attribute]()
         
         for attribute in attributes {
-            guard !GallerySupportedAttribute.isSupported(attribute.name),
-                // The following condition is only necessary because we're storing attributes as [String: String]
-                // which was a poor decision since it can't represent attributes without values.  To remove this
-                // condition we need to pick a more appropriate type to represent attributes in attachments,
-                // which is outside of the scope of my current modification.
-                let value = attribute.value.toString() else {
-                    continue
+            guard !GallerySupportedAttribute.isSupported(attribute.name) else {
+                continue
             }
             
-            output[attribute.name] = value
+            output.append(attribute)
         }
         
         return output

--- a/WordPressEditor/WordPressEditorTests/Extensions/ImageAttachmentWordPressTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Extensions/ImageAttachmentWordPressTests.swift
@@ -11,7 +11,7 @@ class ImageAttachmentWordPressTests: XCTestCase {
         XCTAssertEqual(imageAttachment.extraAttributes["alt"], nil)
         
         imageAttachment.alt = alt
-        XCTAssertEqual(imageAttachment.extraAttributes["alt"], alt)
+        XCTAssertEqual(imageAttachment.extraAttributes["alt"], .string(alt))
         
         imageAttachment.alt = nil
         XCTAssertEqual(imageAttachment.extraAttributes["alt"], nil)
@@ -23,7 +23,7 @@ class ImageAttachmentWordPressTests: XCTestCase {
         
         XCTAssertEqual(imageAttachment.alt, nil)
         
-        imageAttachment.extraAttributes["alt"] = alt
+        imageAttachment.extraAttributes["alt"] = .string(alt)
         XCTAssertEqual(imageAttachment.alt, alt)
         
         imageAttachment.extraAttributes["alt"] = nil
@@ -37,7 +37,7 @@ class ImageAttachmentWordPressTests: XCTestCase {
         XCTAssertEqual(imageAttachment.extraAttributes["width"], nil)
         
         imageAttachment.width = width
-        XCTAssertEqual(imageAttachment.extraAttributes["width"], String(width))
+        XCTAssertEqual(imageAttachment.extraAttributes["width"], .string(String(width)))
         
         imageAttachment.width = nil
         XCTAssertEqual(imageAttachment.extraAttributes["width"], nil)
@@ -49,7 +49,7 @@ class ImageAttachmentWordPressTests: XCTestCase {
         
         XCTAssertEqual(imageAttachment.width, nil)
         
-        imageAttachment.extraAttributes["width"] = String(width)
+        imageAttachment.extraAttributes["width"] = .string(String(width))
         XCTAssertEqual(imageAttachment.width, width)
         
         imageAttachment.extraAttributes["width"] = nil
@@ -63,7 +63,7 @@ class ImageAttachmentWordPressTests: XCTestCase {
         XCTAssertEqual(imageAttachment.extraAttributes["height"], nil)
         
         imageAttachment.height = height
-        XCTAssertEqual(imageAttachment.extraAttributes["height"], String(height))
+        XCTAssertEqual(imageAttachment.extraAttributes["height"], .string(String(height)))
         
         imageAttachment.height = nil
         XCTAssertEqual(imageAttachment.extraAttributes["height"], nil)
@@ -75,7 +75,7 @@ class ImageAttachmentWordPressTests: XCTestCase {
         
         XCTAssertEqual(imageAttachment.height, nil)
         
-        imageAttachment.extraAttributes["height"] = String(height)
+        imageAttachment.extraAttributes["height"] = .string(String(height))
         XCTAssertEqual(imageAttachment.height, height)
         
         imageAttachment.extraAttributes["height"] = nil
@@ -93,37 +93,37 @@ class ImageAttachmentWordPressTests: XCTestCase {
         
         XCTAssertEqual(imageAttachment.imageID, nil)
         
-        imageAttachment.extraAttributes["class"] = "some-class"
+        imageAttachment.extraAttributes["class"] = .string("some-class")
         XCTAssertEqual(imageAttachment.imageID, nil)
         
-        imageAttachment.extraAttributes["class"] = "wp-image-200"
+        imageAttachment.extraAttributes["class"] = .string("wp-image-200")
         XCTAssertEqual(imageAttachment.imageID, 200)
         
-        imageAttachment.extraAttributes["class"] = "otherclass wp-image-400 ignoredclass"
+        imageAttachment.extraAttributes["class"] = .string("otherclass wp-image-400 ignoredclass")
         XCTAssertEqual(imageAttachment.imageID, 400)
     }
     
     func testImageIDChangesExtraAttributes() {
         let imageAttachment = ImageAttachment(identifier: "testing")
         
-        imageAttachment.extraAttributes["class"] = "some-attributes some-more-attributes"
+        imageAttachment.extraAttributes["class"] = .string("some-attributes some-more-attributes")
         
         imageAttachment.imageID = 200
-        XCTAssertEqual(imageAttachment.extraAttributes["class"], "some-attributes some-more-attributes wp-image-200")
+        XCTAssertEqual(imageAttachment.extraAttributes["class"], .string("some-attributes some-more-attributes wp-image-200"))
         
         imageAttachment.imageID = 400
-        XCTAssertEqual(imageAttachment.extraAttributes["class"], "some-attributes some-more-attributes wp-image-400")
+        XCTAssertEqual(imageAttachment.extraAttributes["class"], .string("some-attributes some-more-attributes wp-image-400"))
     }
     
     func testImageIDSetToNilChangesExtraAttributes() {
         let imageAttachment = ImageAttachment(identifier: "testing")
         
-        imageAttachment.extraAttributes["class"] = "wp-image-200"
+        imageAttachment.extraAttributes["class"] = .string("wp-image-200")
         imageAttachment.imageID = nil
         XCTAssertEqual(imageAttachment.extraAttributes["class"], nil)
         
-        imageAttachment.extraAttributes["class"] = "wp-image-200 some-other-class"
+        imageAttachment.extraAttributes["class"] = .string("wp-image-200 some-other-class")
         imageAttachment.imageID = nil
-        XCTAssertEqual(imageAttachment.extraAttributes["class"], "some-other-class")
+        XCTAssertEqual(imageAttachment.extraAttributes["class"], .string("some-other-class"))
     }
 }

--- a/WordPressEditor/WordPressEditorTests/Extensions/MediaAttachmentWordPressTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Extensions/MediaAttachmentWordPressTests.swift
@@ -11,7 +11,7 @@ class MediaAttachmentWordPressTests: XCTestCase {
         XCTAssertEqual(imageAttachment.extraAttributes[MediaAttachment.uploadKey], nil)
         
         imageAttachment.uploadID = uploadID
-        XCTAssertEqual(imageAttachment.extraAttributes[MediaAttachment.uploadKey], uploadID)
+        XCTAssertEqual(imageAttachment.extraAttributes[MediaAttachment.uploadKey], .string(uploadID))
         
         imageAttachment.uploadID = nil
         XCTAssertEqual(imageAttachment.extraAttributes[MediaAttachment.uploadKey], nil)
@@ -23,7 +23,7 @@ class MediaAttachmentWordPressTests: XCTestCase {
         
         XCTAssertEqual(imageAttachment.uploadID, nil)
         
-        imageAttachment.extraAttributes[MediaAttachment.uploadKey] = uploadID
+        imageAttachment.extraAttributes[MediaAttachment.uploadKey] = .string(uploadID)
         XCTAssertEqual(imageAttachment.uploadID, uploadID)
         
         imageAttachment.extraAttributes[MediaAttachment.uploadKey] = nil

--- a/WordPressEditor/WordPressEditorTests/Extensions/VideoAttachmentWordPressTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Extensions/VideoAttachmentWordPressTests.swift
@@ -11,7 +11,7 @@ class VideoAttachmentWordPressTests: XCTestCase {
         XCTAssertEqual(videoAttachment.extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute], nil)
         
         videoAttachment.videoPressID = videoPressID
-        XCTAssertEqual(videoAttachment.extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute], videoPressID)
+        XCTAssertEqual(videoAttachment.extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute], .string(videoPressID))
         
         videoAttachment.videoPressID = nil
         XCTAssertEqual(videoAttachment.extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute], nil)
@@ -23,7 +23,7 @@ class VideoAttachmentWordPressTests: XCTestCase {
         
         XCTAssertEqual(videoAttachment.videoPressID, nil)
         
-        videoAttachment.extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute] = videoPressID
+        videoAttachment.extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute] = .string(videoPressID)
         XCTAssertEqual(videoAttachment.videoPressID, videoPressID)
         
         videoAttachment.extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute] = nil

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/GalleryShortcode/GalleryAttachmentToElementConverterTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/GalleryShortcode/GalleryAttachmentToElementConverterTests.swift
@@ -21,7 +21,7 @@ class GalleryAttachmentToElementConverterTests: XCTestCase {
         attachment.columns = 2
         attachment.order = .asc
         attachment.orderBy = .menu
-        attachment.extraAttributes[extraAttributeName] = extraAttributeValue
+        attachment.extraAttributes[extraAttributeName] = .string(extraAttributeValue)
         
         guard let element = converter.convert(attachment, attributes: [:]).first as? ElementNode else {
             XCTFail()


### PR DESCRIPTION
### Description:

Fixes all unit tests.

This PR:

- Removes two unit tests since the offer dubious value, and are hard to maintain ([here](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1083/files#diff-b34007032479e80681066243a95e3dedL50) and [here](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1083/files#diff-4d3fa99b1de29afdcfa965e25df61a09L55)).
- Changes [the extra attributes in `MediaAttachment`](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1083/files#diff-02f978663f7d3e9a329ad11de178526fR31) so that they're ordered.  This change is what forced most of the other changes you see in this PR.
- Also changes [the reduction of HTML class values](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1083/files#diff-cc023a7c6bf6a6207feecd14bc7d7e0eR42) so that it's ordered as well.

Do make sure to review the changes, to make sure nothing was broken.

### Testing:

Run the unit tests.