### PR TITLE
Improves the HTML setter and getter for EditorView.

### DIFF
--- a/Aztec/Classes/EditorView/EditorView.swift
+++ b/Aztec/Classes/EditorView/EditorView.swift
@@ -132,11 +132,21 @@ public class EditorView: UIView {
     // MARK: - HTML
     
     public func getHTML() -> String {
-        return richTextView.getHTML()
+        switch editingMode {
+        case .html:
+            return htmlTextView.text
+        case .richText:
+            return richTextView.getHTML()
+        }
     }
     
     public func setHTML(_ html: String) {
-        richTextView.setHTML(html)
+        switch editingMode {
+        case .html:
+            htmlTextView.text = html
+        case .richText:
+            richTextView.setHTML(html)
+        }
     }
 
     public var activeView: UITextView {


### PR DESCRIPTION
### Description:

This is a very simple PR that fixes `setHTML()` and `getHTML` in `EditorView`.

This doesn't have an impact right now since the demo never starts in HTML mode, and it doesn't impact WPiOS either since it's not currently using `EditorView`, but the previous logic was flawed anyway.

While not a priority fix, I noticed the logic flaw while working in other issues and wanted to fix it quickly.

### Testing:

Run the unit tests and make sure all is fine.