### PR TITLE
Undo is no longer reset when switching editing modes.

### DIFF
--- a/Aztec/Classes/EditorView/EditorView.swift
+++ b/Aztec/Classes/EditorView/EditorView.swift
@@ -79,7 +79,7 @@ public class EditorView: UIView {
                 
                 htmlTextView.becomeFirstResponder()
             case .richText:
-                richTextView.setHTMLUndoable(htmlTextView.text)
+                richTextView.setHTMLUndoable(htmlTextView.text)                
                 richTextView.becomeFirstResponder()
             }
             
@@ -148,12 +148,8 @@ public class EditorView: UIView {
     }
     
     public func setHTML(_ html: String) {
-        switch editingMode {
-        case .html:
-            htmlTextView.text = html
-        case .richText:
-            richTextView.setHTML(html)
-        }
+        htmlTextView.text = html
+        richTextView.setHTML(html)
     }
 
     public var activeView: UITextView {

--- a/Aztec/Classes/EditorView/EditorView.swift
+++ b/Aztec/Classes/EditorView/EditorView.swift
@@ -69,10 +69,17 @@ public class EditorView: UIView {
             
             switch editingMode {
             case .html:
-                htmlTextView.text = richTextView.getHTML()
+                let newText = richTextView.getHTML()
+                
+                if newText != htmlTextView.text {
+                    let originalRange = htmlTextView.textRange(from: htmlTextView.beginningOfDocument, to: htmlTextView.endOfDocument)!
+                    
+                    htmlTextView.replace(originalRange, withText: newText)
+                }
+                
                 htmlTextView.becomeFirstResponder()
             case .richText:
-                richTextView.setHTML(htmlTextView.text)
+                richTextView.setHTMLUndoable(htmlTextView.text)
                 richTextView.becomeFirstResponder()
             }
             

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -683,6 +683,16 @@ open class TextView: UITextView {
     public func getHTML(prettify: Bool = true) -> String {
         return storage.getHTML(prettify: prettify)
     }
+    
+    /// Loads the specified HTML into the editor, and records a new undo step,
+    /// making sure the undo stack isn't reset
+    ///
+    /// - Parameters:
+    ///     - html: the HTML to load into the editor.
+    ///
+    public func setHTMLUndoable(_ html: String) {
+        replace(storage.rangeOfEntireString, withHTML: html)
+    }
 
     /// Loads the specified HTML into the editor.
     ///


### PR DESCRIPTION
### Description:

This PR fixes the undo stack being reset when switching editing modes.

![undoredo](https://user-images.githubusercontent.com/1836005/48787345-585df600-ecc7-11e8-9020-e5c1099b6cb4.gif)

### Additional Information:

By resolving this issue we will be able to properly record when the content has changes by asking the undo manager directly.

### Known limitations:

The undo stack is different in visual mode and HTML mode.  Atomic edits are only recorded in the mode you're in when they're registered.

The editing mode you're not in will only record a big change when switching.

### Testing:

**Test 1:**

- Open any of the editor demos with content.
- Undo

Make sure the initial content is never removed.

**Test 2:**

- Open an empty editor demo.
- Write whatever you want.
- Copy and paste content.
- Apply styles.
- Switch to HTML mode.
- Do some more edits.
- Switch back to visual.
- Undo as much as you want, and Redo.

Make sure it all works.