### PR TITLE
Fix bugs with m.youtube URLs and IDs with dashes

### DIFF
--- a/WordPressEditor/WordPressEditor/Classes/Processors/EmbedURLProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Processors/EmbedURLProcessor.swift
@@ -20,10 +20,10 @@ public struct EmbedURLProcessor{
     ///  - Short URL
     ///
     public var isYouTubeEmbed: Bool {
-        let longPattern = "^https?://(www.)?youtube.com/(watch\\?v=|embed/)[0-9|a-z|A-Z|_]+$"
+        let longPattern = "^https?://(www.|m.)?youtube.com/(watch\\?v=|embed/)[0-9|a-z|A-Z|_|-]+$"
         let long = try! NSRegularExpression(pattern: longPattern, options: [.caseInsensitive])
 
-        let shortPattern = "^https?://youtu.be/[0-9|a-z|A-Z|_]+$"
+        let shortPattern = "^https?://youtu.be/[0-9|a-z|A-Z|_|-]+$"
         let short = try! NSRegularExpression(pattern: shortPattern, options: [.caseInsensitive])
 
         return matches(long) || matches(short)

--- a/WordPressEditor/WordPressEditorTests/Processors/EmbedURLProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Processors/EmbedURLProcessorTests.swift
@@ -21,6 +21,11 @@ class EmbedURLProcessorTests: XCTestCase {
         //With underscores!
         assert(EmbedURLProcessor(url: url("https://www.youtube.com/watch?v=Ms5mi_xADJw")).isYouTubeEmbed)
         assert(EmbedURLProcessor(url: url("https://youtu.be/Ms5mi_xADJw")).isYouTubeEmbed)
+        //With dashes!
+        assert(EmbedURLProcessor(url: url("https://www.youtube.com/watch?v=WVbQ-oro7FQ")).isYouTubeEmbed)
+        assert(EmbedURLProcessor(url: url("https://youtu.be/WVbQ-oro7FQ")).isYouTubeEmbed)
+        //The mobile version!
+        assert(EmbedURLProcessor(url: url("https://m.youtube.com/watch?v=gqEtq34dSUo")).isYouTubeEmbed)
     }
 
     func testThatValidYouTubeEmbedURLsWork() {


### PR DESCRIPTION
Adds test cases to ensure this continues to work

**To test:**
- The added unit tests have examples of links that weren't working before – ensuring the unit tests pass should be sufficient testing
