### PR TITLE
Fix blockquote cite's removal.

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/CiteFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/CiteFormatter.swift
@@ -8,6 +8,16 @@ class CiteFormatter: FontFormatter {
     init() {
         super.init(traits: .traitItalic, htmlRepresentationKey: .citeHtmlRepresentation)
     }
+    
+    override func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange {
+        var effectiveRange = NSRange()
+        
+        let location = min(range.location, max(text.length - 1, 0))
+        
+        text.attribute(.citeHtmlRepresentation, at: location, effectiveRange: &effectiveRange)
+        
+        return effectiveRange
+    }
 }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -982,6 +982,16 @@ open class TextView: UITextView {
 
         let formatter = BlockquoteFormatter(placeholderAttributes: typingAttributesSwifted)
         toggle(formatter: formatter, atRange: range)
+        
+        let citeFormatter = CiteFormatter()
+        
+        if citeFormatter.present(in: storage, at: selectedRange.location) {
+            let applicationRange = citeFormatter.applicationRange(for: selectedRange, in: attributedText)
+            
+            performUndoable(at: applicationRange) {
+                citeFormatter.removeAttributes(from: storage, at: applicationRange)
+            }
+        }
 
         forceRedrawCursorAfterDelay()
     }


### PR DESCRIPTION
### Description:

This moves forward #1090.  The issue is not completely solved as it's a complex combination of several issues.  This PR just fixes an initial part of it.

This PR makes sure `<cite>` elements are removed when the blockquote style is removed.

### Demo:

![blockquoteciteissue](https://user-images.githubusercontent.com/1836005/48919823-da8b1d80-ee73-11e8-9a41-2fd800459e76.gif)

### Testing:

1. Open the empty standard HTML demo.
2. Switch to HTML mode.
3. Paste:

```html
<blockquote>
   <p>Some quote</p>
   <cite>by Me</cite>
</blockquote>
```

4. Switch back to visual mode and toggle the blockquote in the cite line.
5. Switch back to HTML mode and make sure the `<cite>` tag is removed.
