### PR TITLE
Fix persistence of custom string attributes.

### DIFF
--- a/Aztec/Classes/Extensions/NSAttributedString+Analyzers.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Analyzers.swift
@@ -6,22 +6,6 @@ import UIKit
 //
 extension NSAttributedString {
 
-    /// Returns true if the text preceding a given location contains the specified attribute key.
-    ///
-    /// - Parameters:
-    ///   - location: location to check
-    ///   - key: the attributed to check
-    /// - Returns: True if the attribute is there
-    ///
-    func isLocation(_ location: Int, preceededBy key: NSAttributedStringKey) -> Bool {
-        guard location != 0 else {
-            return false
-        }
-        let beforeRange = NSRange(location: location - 1, length: 1)
-
-        return attribute(key, at: beforeRange.location, effectiveRange: nil) != nil
-    }
-
     /// Returns true if the text preceding a given location contains the NSLinkAttribute.
     ///
     func isLocationPreceededByLink(_ location: Int) -> Bool {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1161,32 +1161,6 @@ open class TextView: UITextView {
         typingAttributesSwifted.removeValue(forKey: .link)
     }
 
-    /// This method makes sure that the Custom Code HTML attribute is copy across to the next character that is typed on the textview.
-    ///
-    /// - Parameter range: the range where the new text will be inserted
-    ///
-    private func ensureCopyOfCodeCustomTypingAttributes(at range: NSRange) {
-        guard typingAttributesSwifted[.codeHtmlRepresentation] == nil,
-            storage.isLocation(range.location, preceededBy: .codeHtmlRepresentation) else {
-            return
-        }
-
-        typingAttributesSwifted[.codeHtmlRepresentation] = HTMLRepresentation(for: .element(HTMLElementRepresentation.init(name: "code", attributes: [])))
-    }
-
-    /// This method makes sure that the Custom Code HTML attribute is copy across to the next character that is typed on the textview.
-    ///
-    /// - Parameter range: the range where the new text will be inserted
-    ///
-    private func ensureCopyOfCiteCustomTypingAttributes(at range: NSRange) {
-        guard typingAttributesSwifted[.citeHtmlRepresentation] == nil,
-            storage.isLocation(range.location, preceededBy: .citeHtmlRepresentation) else {
-                return
-        }
-
-        typingAttributesSwifted[.citeHtmlRepresentation] = HTMLRepresentation(for: .element(HTMLElementRepresentation.init(name: "cite", attributes: [])))
-    }
-
 
     /// Force the SDK to Redraw the cursor, asynchronously, if the edited text (inserted / deleted) requires it.
     /// This method was meant as a workaround for Issue #144.

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1257,13 +1257,19 @@ open class TextView: UITextView {
     /// by the user to turn a style off).
     ///
     private func recalculateTypingAttributes() {
-        guard storage.length > 1 else {
+        
+        let mustRecalculate = storage.length > 1
+            && !storage.string.isEmptyLineAtEndOfFile(at: selectedRange.location)
+        
+        guard mustRecalculate else {
             return
         }
         
-        let location = min(selectedRange.location, attributedText.length - 1)
+        let location = min(selectedRange.location, storage.length - 1)
         
         typingAttributesSwifted = attributedText.attributes(at: location, effectiveRange: nil)
+        
+        
     }
     
     // MARK: - iOS 11 Workarounds


### PR DESCRIPTION
### Description:

Moves forward #1090.

This PR fixes part of the logic that takes care of persisting custom attributes while typing.  Previously we were forcing the typing attributes to be maintained while typing, which means there was no way to turn some styles off (such as `<cite>` and `<code>`).

### Demo:

![styleremoved](https://user-images.githubusercontent.com/1836005/48950187-175d2000-ef19-11e8-85e6-fb97d86efd3f.gif)

### Known limitations:

While this improves how those styles are maintained as we type and move through the document, there are still issues with how blockquotes are expanded in visual mode:

- Gutenberg blockquotes are still breaking.
- Multi-line cites still need fixing.
- While cite is currently being removed, the italic styling it enables is not.

### Testing:

1. Open the empty standard HTML editor.
2. Switch to HTML mode.
3. Paste:

```html
<blockquote>
   <p>Some quote</p>
   <cite>by Me</cite>
</blockquote>
```

4. Switch to visual mode.
5. Place the caret in the extra-line (the last whiteline without styling).
6. Type and make sure the blockquote and cite styling is removed.