### PR TITLE
Blockquote + cite is now ended when pressing ENTER.

### DIFF
--- a/Aztec/Classes/Formatters/Base/FontFormatter.swift
+++ b/Aztec/Classes/Formatters/Base/FontFormatter.swift
@@ -39,15 +39,15 @@ class FontFormatter: AttributeFormatter {
 
     func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
         var resultingAttributes = attributes
+        
+        resultingAttributes.removeValue(forKey: htmlRepresentationKey)
+        
         guard let font = attributes[.font] as? UIFont else {
-            return attributes
+            return resultingAttributes
         }
 
         let newFont = font.modifyTraits(traits, enable: false)
         resultingAttributes[.font] = newFont
-        
-        resultingAttributes.removeValue(forKey: htmlRepresentationKey)
-
         return resultingAttributes
     }
 

--- a/Aztec/Classes/Formatters/Implementations/FigcaptionFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/FigcaptionFormatter.swift
@@ -37,10 +37,9 @@ open class FigcaptionFormatter: ParagraphAttributeFormatter {
 
     func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
         
-        let paragraphStyle = attributes.paragraphStyle()
-        
-        guard let figcaption = paragraphStyle.property(where: { $0 is Figcaption }) as? Figcaption else {
-            return attributes
+        guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle,
+            let figcaption = paragraphStyle.property(where: { $0 is Figcaption }) as? Figcaption else {
+                return attributes
         }
         
         paragraphStyle.removeProperty(ofType: Figcaption.self)

--- a/Aztec/Classes/Formatters/Implementations/FigureFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/FigureFormatter.swift
@@ -31,10 +31,9 @@ open class FigureFormatter: ParagraphAttributeFormatter {
 
     func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
         
-        let paragraphStyle = attributes.paragraphStyle()
-        
-        guard paragraphStyle.hasProperty(where: { $0 is Figure }) else {
-            return attributes
+        guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle,
+            paragraphStyle.hasProperty(where: { $0 is Figure }) else {
+                return attributes
         }
         
         paragraphStyle.removeProperty(ofType: Figure.self)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1864,25 +1864,7 @@ private extension TextView {
         }
         
         removeSingleLineParagraphAttributes()
-        
-        // Blockquote + cite removal
-        let formatter = BlockquoteFormatter(placeholderAttributes: typingAttributesSwifted)
-        let applicationRange = formatter.applicationRange(for: selectedRange, in: storage)
-        
-        performUndoable(at: applicationRange) {
-            formatter.removeAttributes(from: storage, at: selectedRange)
-            typingAttributesSwifted = formatter.remove(from: typingAttributesSwifted)
-        }
-        
-        let citeFormatter = CiteFormatter()
-        
-        if citeFormatter.present(in: storage, at: selectedRange.location) {
-            let applicationRange = citeFormatter.applicationRange(for: selectedRange, in: attributedText)
-            
-            performUndoable(at: applicationRange) {
-                citeFormatter.removeAttributes(from: storage, at: applicationRange)
-            }
-        }
+        removeBlockquoteAndCite()
     }
 
     /// Removes single-line paragraph attributes.
@@ -1893,6 +1875,30 @@ private extension TextView {
             
             removeAttributes(managedBy: formatter, from: range)
             removeTypingAttributes(managedBy: formatter)
+        }
+    }
+    
+    /// Removes blockquote + cite after pressing ENTER in a line that has both styles.
+    ///
+    private func removeBlockquoteAndCite() {
+        // Blockquote + cite removal
+        let formatter = BlockquoteFormatter(placeholderAttributes: typingAttributesSwifted)
+        let citeFormatter = CiteFormatter()
+        
+        if formatter.present(in: typingAttributesSwifted)
+            && citeFormatter.present(in: typingAttributesSwifted) {
+            
+            let applicationRange = formatter.applicationRange(for: selectedRange, in: storage)
+            
+            typingAttributesSwifted = formatter.remove(from: typingAttributesSwifted)
+            typingAttributesSwifted = citeFormatter.remove(from: typingAttributesSwifted)
+            
+            performUndoable(at: applicationRange) {
+                formatter.removeAttributes(from: storage, at: applicationRange)
+                citeFormatter.removeAttributes(from: storage, at: applicationRange)
+                
+                return applicationRange
+            }
         }
     }
     

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1864,6 +1864,25 @@ private extension TextView {
         }
         
         removeSingleLineParagraphAttributes()
+        
+        // Blockquote + cite removal
+        let formatter = BlockquoteFormatter(placeholderAttributes: typingAttributesSwifted)
+        let applicationRange = formatter.applicationRange(for: selectedRange, in: storage)
+        
+        performUndoable(at: applicationRange) {
+            formatter.removeAttributes(from: storage, at: selectedRange)
+            typingAttributesSwifted = formatter.remove(from: typingAttributesSwifted)
+        }
+        
+        let citeFormatter = CiteFormatter()
+        
+        if citeFormatter.present(in: storage, at: selectedRange.location) {
+            let applicationRange = citeFormatter.applicationRange(for: selectedRange, in: attributedText)
+            
+            performUndoable(at: applicationRange) {
+                citeFormatter.removeAttributes(from: storage, at: applicationRange)
+            }
+        }
     }
 
     /// Removes single-line paragraph attributes.


### PR DESCRIPTION
### Description:

Moves forward #1090.

Pressing enter while in visual-mode, in a line that has both `<blockquote>` and `<cite>`, will cause the blockquote to be closed and the styles removed.

If the user wants a multi-line citation, they can use the SHIFT + ENTER combo.

### Details:

The code changes are not as clean as I'd like, because our current way to access formatter causes a lot of code duplication, but this is a quick fix to keep the ball rolling.

### Demo:

![blockquoteandciteclosed](https://user-images.githubusercontent.com/1836005/49020375-0b6a9b80-f16f-11e8-9e38-5fe357da72e3.gif)

### Testing:

Follow the steps shown in the demo above.
Run the unit tests.