### PR TITLE
Formatter identifiers are now extensible

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormattingIdentifier.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormattingIdentifier.swift
@@ -1,25 +1,39 @@
 import Foundation
 
-public enum FormattingIdentifier: String {
+public struct FormattingIdentifier: RawRepresentable, Hashable {
     
-    case bold = "bold"
-    case italic = "italic"
-    case underline = "underline"
-    case strikethrough = "strikethrough"
-    case orderedlist = "orderedlist"
-    case unorderedlist = "unorderedlist"
-    case blockquote = "blockquote"
-    case link = "link"
-    case media = "media"
-    case more = "more"
-    case sourcecode = "sourcecode"
-    case header1 = "header1"
-    case header2 = "header2"
-    case header3 = "header3"
-    case header4 = "header4"
-    case header5 = "header5"
-    case header6 = "header6"
-    case horizontalruler = "horizontalruler"
-    case p = "p"
-    case code = "code"
+    public typealias RawValue = String
+    
+    public var rawValue: String
+    
+    public init?(rawValue: String) {
+        self.rawValue = rawValue
+    }
+    
+    public init(_ rawValue: RawValue) {
+        self.rawValue = rawValue
+    }
+}
+
+extension FormattingIdentifier {
+    public static let blockquote = FormattingIdentifier("blockquote")
+    public static let bold = FormattingIdentifier("bold")
+    public static let code = FormattingIdentifier("code")
+    public static let italic = FormattingIdentifier("italic")
+    public static let media = FormattingIdentifier("media")
+    public static let more = FormattingIdentifier("more")
+    public static let header1 = FormattingIdentifier("header1")
+    public static let header2 = FormattingIdentifier("header2")
+    public static let header3 = FormattingIdentifier("header3")
+    public static let header4 = FormattingIdentifier("header4")
+    public static let header5 = FormattingIdentifier("header5")
+    public static let header6 = FormattingIdentifier("header6")
+    public static let horizontalruler = FormattingIdentifier("horizontalruler")
+    public static let link = FormattingIdentifier("link")
+    public static let orderedlist = FormattingIdentifier("orderedlist")
+    public static let p = FormattingIdentifier("p")
+    public static let sourcecode = FormattingIdentifier("sourcecode")
+    public static let strikethrough = FormattingIdentifier("strikethrough")
+    public static let underline = FormattingIdentifier("underline")
+    public static let unorderedlist = FormattingIdentifier("unorderedlist")
 }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -760,7 +760,7 @@ open class TextView: UITextView {
     ///
     /// - Returns: A list of identifiers.
     ///
-    open func formatIdentifiersSpanningRange(_ range: NSRange) -> Set<FormattingIdentifier> {
+    open func formattingIdentifiersSpanningRange(_ range: NSRange) -> Set<FormattingIdentifier> {
         guard storage.length != 0 else {
             return formattingIdentifiersForTypingAttributes()
         }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -735,7 +735,7 @@ open class TextView: UITextView {
 
     // MARK: - Getting format identifiers
 
-    private static let formatterIdentifiersMap: [FormattingIdentifier: AttributeFormatter] = [
+    private static let formatterMap: [FormattingIdentifier: AttributeFormatter] = [
         .bold: BoldFormatter(),
         .italic: ItalicFormatter(),
         .underline: UnderlineFormatter(),
@@ -762,16 +762,16 @@ open class TextView: UITextView {
     ///
     open func formatIdentifiersSpanningRange(_ range: NSRange) -> Set<FormattingIdentifier> {
         guard storage.length != 0 else {
-            return formatIdentifiersForTypingAttributes()
+            return formattingIdentifiersForTypingAttributes()
         }
 
         if range.length == 0 {
-            return formatIdentifiersAtIndex(range.location)
+            return formattingIdentifiersAtIndex(range.location)
         }
 
         var identifiers = Set<FormattingIdentifier>()
 
-        for (key, formatter) in type(of: self).formatterIdentifiersMap {
+        for (key, formatter) in type(of: self).formatterMap {
             if formatter.present(in: storage, at: range) {
                 identifiers.insert(key)
             }
@@ -787,7 +787,7 @@ open class TextView: UITextView {
     ///
     /// - Returns: A list of identifiers.
     ///
-    open func formatIdentifiersAtIndex(_ index: Int) -> Set<FormattingIdentifier> {
+    open func formattingIdentifiersAtIndex(_ index: Int) -> Set<FormattingIdentifier> {
         guard storage.length != 0 else {
             return []
         }
@@ -795,7 +795,7 @@ open class TextView: UITextView {
         let index = adjustedIndex(index)
         var identifiers = Set<FormattingIdentifier>()
 
-        for (key, formatter) in type(of: self).formatterIdentifiersMap {
+        for (key, formatter) in type(of: self).formatterMap {
             if formatter.present(in: storage, at: index) {
                 identifiers.insert(key)
             }
@@ -809,11 +809,11 @@ open class TextView: UITextView {
     ///
     /// - Returns: A list of Formatting Identifiers.
     ///
-    open func formatIdentifiersForTypingAttributes() -> Set<FormattingIdentifier> {
+    open func formattingIdentifiersForTypingAttributes() -> Set<FormattingIdentifier> {
         let activeAttributes = typingAttributesSwifted
         var identifiers = Set<FormattingIdentifier>()
 
-        for (key, formatter) in type(of: self).formatterIdentifiersMap where formatter.present(in: activeAttributes) {
+        for (key, formatter) in type(of: self).formatterMap where formatter.present(in: activeAttributes) {
             identifiers.insert(key)
         }
 

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -96,39 +96,39 @@ class TextViewTests: XCTestCase {
 
     // MARK: - Retrieve Format Identifiers
 
-    func testFormatIdentifiersSpanningRange() {
+    func testFormattingIdentifiersSpanningRange() {
         let textView = TextViewStub(withHTML: "foo<b>bar</b>baz")
 
         let range = NSRange(location: 3, length: 3)
-        let identifiers = textView.formatIdentifiersSpanningRange(range)
+        let identifiers = textView.formattingIdentifiersSpanningRange(range)
 
         XCTAssert(identifiers.count == 1)
         XCTAssert(identifiers.contains(.bold))
     }
 
-    func testFormatIdentifiersAtIndex() {
+    func testFormattingIdentifiersAtIndex() {
         let textView = TextViewStub(withHTML: "foo<b>bar</b>baz")
 
-        var identifiers = textView.formatIdentifiersAtIndex(4)
+        var identifiers = textView.formattingIdentifiersAtIndex(4)
         XCTAssert(identifiers.count == 1)
         XCTAssert(identifiers.contains(.bold))
 
-        identifiers = textView.formatIdentifiersAtIndex(5)
+        identifiers = textView.formattingIdentifiersAtIndex(5)
         XCTAssert(identifiers.count == 1)
         XCTAssert(identifiers.contains(.bold))
 
-        identifiers = textView.formatIdentifiersAtIndex(6)
+        identifiers = textView.formattingIdentifiersAtIndex(6)
         XCTAssert(identifiers.count == 1)
         XCTAssert(identifiers.contains(.bold))
 
 
-        identifiers = textView.formatIdentifiersAtIndex(0)
+        identifiers = textView.formattingIdentifiersAtIndex(0)
         XCTAssert(identifiers.count == 0)
 
-        identifiers = textView.formatIdentifiersAtIndex(3)
+        identifiers = textView.formattingIdentifiersAtIndex(3)
         XCTAssert(identifiers.count == 0)
 
-        identifiers = textView.formatIdentifiersAtIndex(7)
+        identifiers = textView.formattingIdentifiersAtIndex(7)
         XCTAssert(identifiers.count == 0)
     }
 
@@ -139,60 +139,60 @@ class TextViewTests: XCTestCase {
         let textView = TextViewStub(withHTML: "foo<b>bar</b>baz")
         let range = NSRange(location: 3, length: 3)
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(range).contains(.bold))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(range).contains(.bold))
 
         textView.toggleBold(range: range)
 
-        XCTAssert(!textView.formatIdentifiersSpanningRange(range).contains(.bold))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(range).contains(.bold))
 
         textView.toggleBold(range: range)
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(range).contains(.bold))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(range).contains(.bold))
     }
 
     func testToggleItalic() {
         let textView = TextViewStub(withHTML: "foo<i>bar</i>baz")
         let range = NSRange(location: 3, length: 3)
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(range).contains(.italic))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(range).contains(.italic))
 
         textView.toggleItalic(range: range)
 
-        XCTAssert(!textView.formatIdentifiersSpanningRange(range).contains(.italic))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(range).contains(.italic))
 
         textView.toggleItalic(range: range)
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(range).contains(.italic))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(range).contains(.italic))
     }
 
     func testToggleUnderline() {
         let textView = TextViewStub(withHTML: "foo<u>bar</u>baz")
         let range = NSRange(location: 3, length: 3)
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(range).contains(.underline))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(range).contains(.underline))
 
         textView.toggleUnderline(range: range)
 
-        XCTAssert(!textView.formatIdentifiersSpanningRange(range).contains(.underline))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(range).contains(.underline))
 
         textView.toggleUnderline(range: range)
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(range).contains(.underline))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(range).contains(.underline))
     }
 
     func testToggleStrike() {
         let textView = TextViewStub(withHTML: "foo<strike>bar</strike>baz")
         let range = NSRange(location: 3, length: 3)
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(range).contains(.strikethrough))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(range).contains(.strikethrough))
 
         textView.toggleStrikethrough(range: range)
 
-        XCTAssert(!textView.formatIdentifiersSpanningRange(range).contains(.strikethrough))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(range).contains(.strikethrough))
 
         textView.toggleStrikethrough(range: range)
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(range).contains(.strikethrough))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(range).contains(.strikethrough))
     }
 
     func testToggleBlockquote() {
@@ -202,13 +202,13 @@ class TextViewTests: XCTestCase {
 
         textView.toggleBlockquote(range: range)
 
-        XCTAssert(textView.formatIdentifiersAtIndex(1).contains(.blockquote))
-        XCTAssert(textView.formatIdentifiersSpanningRange(range).contains(.blockquote))
+        XCTAssert(textView.formattingIdentifiersAtIndex(1).contains(.blockquote))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(range).contains(.blockquote))
 
         textView.toggleBlockquote(range: range)
 
-        XCTAssert(!textView.formatIdentifiersAtIndex(1).contains(.blockquote))
-        XCTAssert(!textView.formatIdentifiersSpanningRange(range).contains(.blockquote))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(1).contains(.blockquote))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(range).contains(.blockquote))
     }
 
     func testToggleOrderedList() {
@@ -218,13 +218,13 @@ class TextViewTests: XCTestCase {
 
         textView.toggleOrderedList(range: range)
 
-        XCTAssert(textView.formatIdentifiersAtIndex(0).contains(.orderedlist))
-        XCTAssert(textView.formatIdentifiersSpanningRange(range).contains(.orderedlist))
+        XCTAssert(textView.formattingIdentifiersAtIndex(0).contains(.orderedlist))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(range).contains(.orderedlist))
 
         textView.toggleOrderedList(range: range)
 
-        XCTAssert(!textView.formatIdentifiersAtIndex(0).contains(.orderedlist))
-        XCTAssert(!textView.formatIdentifiersSpanningRange(range).contains(.orderedlist))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(0).contains(.orderedlist))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(range).contains(.orderedlist))
     }
 
     func testToggleUnorderedList() {
@@ -234,13 +234,13 @@ class TextViewTests: XCTestCase {
 
         textView.toggleUnorderedList(range: range)
 
-        XCTAssert(textView.formatIdentifiersAtIndex(0).contains(.unorderedlist))
-        XCTAssert(textView.formatIdentifiersSpanningRange(range).contains(.unorderedlist))
+        XCTAssert(textView.formattingIdentifiersAtIndex(0).contains(.unorderedlist))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(range).contains(.unorderedlist))
 
         textView.toggleOrderedList(range: range)
 
-        XCTAssert(!textView.formatIdentifiersAtIndex(0).contains(.unorderedlist))
-        XCTAssert(!textView.formatIdentifiersSpanningRange(range).contains(.unorderedlist))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(0).contains(.unorderedlist))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(range).contains(.unorderedlist))
     }
 
     /// This test was created to prevent regressions related to this issue:
@@ -259,51 +259,51 @@ class TextViewTests: XCTestCase {
     // MARK: - Test Attributes Exist
 
     func check(textView: TextView, range:NSRange, forIndentifier identifier: FormattingIdentifier) -> Bool {
-        return textView.formatIdentifiersSpanningRange(range).contains(identifier)
+        return textView.formattingIdentifiersSpanningRange(range).contains(identifier)
     }
 
     func testBoldSpansRange() {
         let textView = TextViewStub(withHTML: "foo<b>bar</b>baz")
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 3, length: 3)).contains(.bold))
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 3, length: 2)).contains(.bold))
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 3, length: 1)).contains(.bold))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 3, length: 3)).contains(.bold))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 3, length: 2)).contains(.bold))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 3, length: 1)).contains(.bold))
 
-        XCTAssert(!textView.formatIdentifiersSpanningRange(NSRange(location: 2, length: 3)).contains(.bold))
-        XCTAssert(!textView.formatIdentifiersSpanningRange(NSRange(location: 4, length: 3)).contains(.bold))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(NSRange(location: 2, length: 3)).contains(.bold))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(NSRange(location: 4, length: 3)).contains(.bold))
     }
 
     func testItalicSpansRange() {
         let textView = TextViewStub(withHTML: "foo<i>bar</i>baz")
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 3, length: 3)).contains(.italic))
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 3, length: 2)).contains(.italic))
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 3, length: 1)).contains(.italic))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 3, length: 3)).contains(.italic))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 3, length: 2)).contains(.italic))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 3, length: 1)).contains(.italic))
 
-        XCTAssert(!textView.formatIdentifiersSpanningRange(NSRange(location: 2, length: 3)).contains(.italic))
-        XCTAssert(!textView.formatIdentifiersSpanningRange(NSRange(location: 4, length: 3)).contains(.italic))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(NSRange(location: 2, length: 3)).contains(.italic))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(NSRange(location: 4, length: 3)).contains(.italic))
     }
 
     func testUnderlineSpansRange() {
         let textView = TextViewStub(withHTML: "foo<u>bar</u>baz")
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 3, length: 3)).contains(.underline))
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 3, length: 2)).contains(.underline))
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 3, length: 1)).contains(.underline))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 3, length: 3)).contains(.underline))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 3, length: 2)).contains(.underline))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 3, length: 1)).contains(.underline))
 
-        XCTAssert(!textView.formatIdentifiersSpanningRange(NSRange(location: 2, length: 3)).contains(.underline))
-        XCTAssert(!textView.formatIdentifiersSpanningRange(NSRange(location: 4, length: 3)).contains(.underline))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(NSRange(location: 2, length: 3)).contains(.underline))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(NSRange(location: 4, length: 3)).contains(.underline))
     }
 
     func testStrikethroughSpansRange() {
         let textView = TextViewStub(withHTML: "foo<strike>bar</strike>baz")
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 3, length: 3)).contains(.strikethrough))
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 3, length: 2)).contains(.strikethrough))
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 3, length: 1)).contains(.strikethrough))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 3, length: 3)).contains(.strikethrough))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 3, length: 2)).contains(.strikethrough))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 3, length: 1)).contains(.strikethrough))
 
-        XCTAssert(!textView.formatIdentifiersSpanningRange(NSRange(location: 2, length: 3)).contains(.strikethrough))
-        XCTAssert(!textView.formatIdentifiersSpanningRange(NSRange(location: 4, length: 3)).contains(.strikethrough))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(NSRange(location: 2, length: 3)).contains(.strikethrough))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(NSRange(location: 4, length: 3)).contains(.strikethrough))
     }
 
     func testBlockquoteSpansRange() {
@@ -313,68 +313,68 @@ class TextViewTests: XCTestCase {
 
         textView.toggleBlockquote(range: range)
 
-        XCTAssert(textView.formatIdentifiersSpanningRange(NSRange(location: 0, length: length)).contains(.blockquote))
-        XCTAssert(!textView.formatIdentifiersSpanningRange(NSRange(location: 0, length: length + 1)).contains(.blockquote))
-        XCTAssert(!textView.formatIdentifiersSpanningRange(NSRange(location: 1, length: length)).contains(.blockquote))
+        XCTAssert(textView.formattingIdentifiersSpanningRange(NSRange(location: 0, length: length)).contains(.blockquote))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(NSRange(location: 0, length: length + 1)).contains(.blockquote))
+        XCTAssert(!textView.formattingIdentifiersSpanningRange(NSRange(location: 1, length: length)).contains(.blockquote))
     }
 
     func testBoldAtIndex() {
         let textView = TextViewStub(withHTML: "foo<b>bar</b>baz")
 
-        XCTAssert(textView.formatIdentifiersAtIndex(4).contains(.bold))
-        XCTAssert(textView.formatIdentifiersAtIndex(5).contains(.bold))
-        XCTAssert(textView.formatIdentifiersAtIndex(6).contains(.bold))
+        XCTAssert(textView.formattingIdentifiersAtIndex(4).contains(.bold))
+        XCTAssert(textView.formattingIdentifiersAtIndex(5).contains(.bold))
+        XCTAssert(textView.formattingIdentifiersAtIndex(6).contains(.bold))
 
-        XCTAssert(!textView.formatIdentifiersAtIndex(2).contains(.bold))
-        XCTAssert(!textView.formatIdentifiersAtIndex(7).contains(.bold))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(2).contains(.bold))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(7).contains(.bold))
     }
 
     func testItalicAtIndex() {
         let textView = TextViewStub(withHTML: "foo<i>bar</i>baz")
 
-        XCTAssert(textView.formatIdentifiersAtIndex(4).contains(.italic))
-        XCTAssert(textView.formatIdentifiersAtIndex(5).contains(.italic))
-        XCTAssert(textView.formatIdentifiersAtIndex(6).contains(.italic))
+        XCTAssert(textView.formattingIdentifiersAtIndex(4).contains(.italic))
+        XCTAssert(textView.formattingIdentifiersAtIndex(5).contains(.italic))
+        XCTAssert(textView.formattingIdentifiersAtIndex(6).contains(.italic))
 
-        XCTAssert(!textView.formatIdentifiersAtIndex(2).contains(.italic))
-        XCTAssert(!textView.formatIdentifiersAtIndex(7).contains(.italic))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(2).contains(.italic))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(7).contains(.italic))
     }
 
     func testUnderlineAtIndex() {
         let textView = TextViewStub(withHTML: "foo<u>bar</u>baz")
 
-        XCTAssert(textView.formatIdentifiersAtIndex(4).contains(.underline))
-        XCTAssert(textView.formatIdentifiersAtIndex(5).contains(.underline))
-        XCTAssert(textView.formatIdentifiersAtIndex(6).contains(.underline))
+        XCTAssert(textView.formattingIdentifiersAtIndex(4).contains(.underline))
+        XCTAssert(textView.formattingIdentifiersAtIndex(5).contains(.underline))
+        XCTAssert(textView.formattingIdentifiersAtIndex(6).contains(.underline))
 
-        XCTAssert(!textView.formatIdentifiersAtIndex(2).contains(.underline))
-        XCTAssert(!textView.formatIdentifiersAtIndex(7).contains(.underline))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(2).contains(.underline))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(7).contains(.underline))
     }
 
     func testStrikethroughAtIndex() {
         let textView = TextViewStub(withHTML: "foo<strike>bar</strike>baz")
 
-        XCTAssert(textView.formatIdentifiersAtIndex(4).contains(.strikethrough))
-        XCTAssert(textView.formatIdentifiersAtIndex(5).contains(.strikethrough))
-        XCTAssert(textView.formatIdentifiersAtIndex(6).contains(.strikethrough))
+        XCTAssert(textView.formattingIdentifiersAtIndex(4).contains(.strikethrough))
+        XCTAssert(textView.formattingIdentifiersAtIndex(5).contains(.strikethrough))
+        XCTAssert(textView.formattingIdentifiersAtIndex(6).contains(.strikethrough))
 
-        XCTAssert(!textView.formatIdentifiersAtIndex(2).contains(.strikethrough))
-        XCTAssert(!textView.formatIdentifiersAtIndex(7).contains(.strikethrough))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(2).contains(.strikethrough))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(7).contains(.strikethrough))
     }
 
     func testBlockquoteAtIndex() {
         let textView = createTextViewWithContent()
         let range = NSRange(location: 0, length: 1)
 
-        XCTAssert(!textView.formatIdentifiersAtIndex(1).contains(.blockquote))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(1).contains(.blockquote))
 
         textView.toggleBlockquote(range: range)
 
-        XCTAssert(textView.formatIdentifiersAtIndex(1).contains(.blockquote))
+        XCTAssert(textView.formattingIdentifiersAtIndex(1).contains(.blockquote))
 
         textView.toggleBlockquote(range: range)
 
-        XCTAssert(!textView.formatIdentifiersAtIndex(1).contains(.blockquote))
+        XCTAssert(!textView.formattingIdentifiersAtIndex(1).contains(.blockquote))
     }
 
 
@@ -755,7 +755,7 @@ class TextViewTests: XCTestCase {
         textView.selectedRange = NSMakeRange("Header".count, 0)
         textView.insertText("\n")
 
-        let identifiers = textView.formatIdentifiersAtIndex(textView.selectedRange.location)
+        let identifiers = textView.formattingIdentifiersAtIndex(textView.selectedRange.location)
         XCTAssert(identifiers.contains(.header1))
 
         XCTAssertEqual(textView.getHTML(prettify: false), "<h1>Header</h1><h1> Header</h1>")
@@ -1820,7 +1820,7 @@ class TextViewTests: XCTestCase {
         textView.toggleItalics(self)
 
         delegate.onDidChange = {
-            let identifiers = textView.formatIdentifiersForTypingAttributes()
+            let identifiers = textView.formattingIdentifiersForTypingAttributes()
 
             XCTAssert(identifiers.contains(.bold))
             XCTAssert(identifiers.contains(.italic))

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -398,9 +398,9 @@ class EditorDemoController: UIViewController {
 
         let identifiers: Set<FormattingIdentifier>
         if richTextView.selectedRange.length > 0 {
-            identifiers = richTextView.formatIdentifiersSpanningRange(richTextView.selectedRange)
+            identifiers = richTextView.formattingIdentifiersSpanningRange(richTextView.selectedRange)
         } else {
-            identifiers = richTextView.formatIdentifiersForTypingAttributes()
+            identifiers = richTextView.formattingIdentifiersForTypingAttributes()
         }
 
         toolbar.selectItemsMatchingIdentifiers(identifiers.map({ $0.rawValue }))
@@ -572,6 +572,8 @@ extension EditorDemoController {
             insertHorizontalRuler()
         case .code:
             toggleCode()
+        default:
+            break
         }
 
         updateFormatBar()
@@ -751,9 +753,9 @@ extension EditorDemoController {
     func headerLevelForSelectedText() -> Header.HeaderType {
         var identifiers = Set<FormattingIdentifier>()
         if (richTextView.selectedRange.length > 0) {
-            identifiers = richTextView.formatIdentifiersSpanningRange(richTextView.selectedRange)
+            identifiers = richTextView.formattingIdentifiersSpanningRange(richTextView.selectedRange)
         } else {
-            identifiers = richTextView.formatIdentifiersForTypingAttributes()
+            identifiers = richTextView.formattingIdentifiersForTypingAttributes()
         }
         let mapping: [FormattingIdentifier: Header.HeaderType] = [
             .header1 : .h1,
@@ -774,9 +776,9 @@ extension EditorDemoController {
     func listTypeForSelectedText() -> TextList.Style? {
         var identifiers = Set<FormattingIdentifier>()
         if (richTextView.selectedRange.length > 0) {
-            identifiers = richTextView.formatIdentifiersSpanningRange(richTextView.selectedRange)
+            identifiers = richTextView.formattingIdentifiersSpanningRange(richTextView.selectedRange)
         } else {
-            identifiers = richTextView.formatIdentifiersForTypingAttributes()
+            identifiers = richTextView.formattingIdentifiersForTypingAttributes()
         }
         let mapping: [FormattingIdentifier: TextList.Style] = [
             .orderedlist : .ordered,
@@ -1559,6 +1561,8 @@ extension FormattingIdentifier {
             return gridicon(.headingH6)
         case .code:
             return gridicon(.posts)
+        default:
+            return gridicon(.help)
         }
     }
 
@@ -1609,6 +1613,8 @@ extension FormattingIdentifier {
             return "formatToolbarToggleH6"
         case .code:
             return "formatToolbarCode"
+        default:
+            return ""
         }
     }
 
@@ -1654,6 +1660,8 @@ extension FormattingIdentifier {
             return NSLocalizedString("Heading 6", comment: "Accessibility label for selecting h6 paragraph style button on the formatting toolbar.")
         case .code:
             return NSLocalizedString("Code", comment: "Accessibility label for selecting code style button on the formatting toolbar.")
+        default:
+            return ""
         }
 
     }


### PR DESCRIPTION
### Description:

This is just a quick maintenance PR to try and organize the formatters code a bit, and try to make it easier to maintain and extend.  This will be used in upcoming PRs.

Format identifiers can now be extended.  This is just a quick maintenance PR.

### Testing:

Make sure the library and example app build fine.
Make sure the unit tests build and run fine.