### PR TITLE
Remove the placeholderAttributes formatter property.

### DIFF
--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigcaptionElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigcaptionElementConverter.swift
@@ -5,7 +5,7 @@ import UIKit
 ///
 class FigcaptionElementConverter: ElementConverter {
     
-    let figcaptionFormatter = FigcaptionFormatter(placeholderAttributes: nil)
+    let figcaptionFormatter = FigcaptionFormatter()
 
     // MARK: - ElementConverter
 

--- a/Aztec/Classes/Formatters/Base/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/Base/AttributeFormatter.swift
@@ -9,10 +9,6 @@ import UIKit
 ///
 protocol AttributeFormatter {
 
-    /// Attributes to be used the Content Placeholder, when / if needed.
-    ///
-    var placeholderAttributes: [NSAttributedStringKey: Any]? { get }
-
     /// Toggles an attribute in the specified range of a text storage, and returns the new 
     /// Selected Range. This is required because, in several scenarios, we may need to add a "Zero Width Space",
     /// just to get the style to render properly.

--- a/Aztec/Classes/Formatters/Base/FontFormatter.swift
+++ b/Aztec/Classes/Formatters/Base/FontFormatter.swift
@@ -2,8 +2,6 @@ import Foundation
 import UIKit
 
 class FontFormatter: AttributeFormatter {
-
-    var placeholderAttributes: [NSAttributedStringKey: Any]? { return nil }
     
     let htmlRepresentationKey: NSAttributedStringKey
     let traits: UIFontDescriptorSymbolicTraits

--- a/Aztec/Classes/Formatters/Implementations/FigcaptionFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/FigcaptionFormatter.swift
@@ -6,13 +6,6 @@ import UIKit
 /// instance.
 ///
 open class FigcaptionFormatter: ParagraphAttributeFormatter {
-    var placeholderAttributes: [NSAttributedStringKey : Any]?
-
-    /// Designated Initializer
-    ///
-    init(placeholderAttributes: [NSAttributedStringKey: Any]? = nil) {
-        self.placeholderAttributes = placeholderAttributes
-    }
 
     // MARK: - Overwriten Methods
 

--- a/Aztec/Classes/Formatters/Implementations/FigureFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/FigureFormatter.swift
@@ -5,14 +5,6 @@ import UIKit
 // MARK: - Figure Formatter
 //
 open class FigureFormatter: ParagraphAttributeFormatter {
-    var placeholderAttributes: [NSAttributedStringKey : Any]?
-
-    /// Designated Initializer
-    ///
-    init(placeholderAttributes: [NSAttributedStringKey: Any]? = nil) {
-        self.placeholderAttributes = placeholderAttributes
-    }
-
 
     // MARK: - Overwriten Methods
 

--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -10,16 +10,10 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
     ///
     let headerLevel: Header.HeaderType
 
-    /// Attributes to be added by default
-    ///
-    let placeholderAttributes: [NSAttributedStringKey: Any]?
-
-
     /// Designated Initializer
     ///
-    init(headerLevel: Header.HeaderType = .h1, placeholderAttributes: [NSAttributedStringKey: Any]? = nil) {
+    init(headerLevel: Header.HeaderType = .h1) {
         self.headerLevel = headerLevel
-        self.placeholderAttributes = placeholderAttributes
     }
 
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -176,14 +176,14 @@ open class TextView: UITextView {
     // MARK: - Behavior configuration
     
     private static let singleLineParagraphFormatters: [AttributeFormatter] = [
-        HeaderFormatter(headerLevel: .h1, placeholderAttributes: [:]),
-        HeaderFormatter(headerLevel: .h2, placeholderAttributes: [:]),
-        HeaderFormatter(headerLevel: .h3, placeholderAttributes: [:]),
-        HeaderFormatter(headerLevel: .h4, placeholderAttributes: [:]),
-        HeaderFormatter(headerLevel: .h5, placeholderAttributes: [:]),
-        HeaderFormatter(headerLevel: .h6, placeholderAttributes: [:]),
-        FigureFormatter(placeholderAttributes: [:]),
-        FigcaptionFormatter(placeholderAttributes: [:]),
+        HeaderFormatter(headerLevel: .h1),
+        HeaderFormatter(headerLevel: .h2),
+        HeaderFormatter(headerLevel: .h3),
+        HeaderFormatter(headerLevel: .h4),
+        HeaderFormatter(headerLevel: .h5),
+        HeaderFormatter(headerLevel: .h6),
+        FigureFormatter(),
+        FigcaptionFormatter(),
     ]
 
     // MARK: - Properties: Text Lists
@@ -744,12 +744,12 @@ open class TextView: UITextView {
         .orderedlist: TextListFormatter(style: .ordered),
         .unorderedlist: TextListFormatter(style: .unordered),
         .blockquote: BlockquoteFormatter(),
-        .header1: HeaderFormatter(headerLevel: .h1, placeholderAttributes: nil),
-        .header2: HeaderFormatter(headerLevel: .h2, placeholderAttributes: nil),
-        .header3: HeaderFormatter(headerLevel: .h3, placeholderAttributes: nil),
-        .header4: HeaderFormatter(headerLevel: .h4, placeholderAttributes: nil),
-        .header5: HeaderFormatter(headerLevel: .h5, placeholderAttributes: nil),
-        .header6: HeaderFormatter(headerLevel: .h6, placeholderAttributes: nil),
+        .header1: HeaderFormatter(headerLevel: .h1),
+        .header2: HeaderFormatter(headerLevel: .h2),
+        .header3: HeaderFormatter(headerLevel: .h3),
+        .header4: HeaderFormatter(headerLevel: .h4),
+        .header5: HeaderFormatter(headerLevel: .h5),
+        .header6: HeaderFormatter(headerLevel: .h6),
         .p: HTMLParagraphFormatter(),
         .code: CodeFormatter()
     ]
@@ -1029,7 +1029,7 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleHeader(_ headerType: Header.HeaderType, range: NSRange) {
-        let formatter = HeaderFormatter(headerLevel: headerType, placeholderAttributes: typingAttributesSwifted)
+        let formatter = HeaderFormatter(headerLevel: headerType)
         toggle(formatter: formatter, atRange: range)
         forceRedrawCursorAfterDelay()
     }

--- a/AztecTests/Formatters/HeaderFormatterTests.swift
+++ b/AztecTests/Formatters/HeaderFormatterTests.swift
@@ -20,7 +20,7 @@ class HeaderFormatterTests: XCTestCase {
     /// Verifies that the default font size is effectively restored after the Header Formatter is removed.
     ///
     func testDefaultFontIsRestoredWhenFormattingIsRemoved() {
-        let formatter = HeaderFormatter(headerLevel: .h1, placeholderAttributes: nil)
+        let formatter = HeaderFormatter(headerLevel: .h1)
 
         let updatedAttrs = formatter.apply(to: attributes, andStore: nil)
         let updatedFont = updatedAttrs[.font] as! UIFont
@@ -34,12 +34,12 @@ class HeaderFormatterTests: XCTestCase {
     /// Verifies that the Default Font is preserved whenever a Header Style is applied on top of an existant Header.
     ///
     func testDefaultFontIsPreservedWheneverTheHeaderLevelIsUpdated() {
-        let formatterH1 = HeaderFormatter(headerLevel: .h1, placeholderAttributes: nil)
+        let formatterH1 = HeaderFormatter(headerLevel: .h1)
         let updatedH1Attrs = formatterH1.apply(to: attributes, andStore: nil)
         let updatedH1Font = updatedH1Attrs[.font] as! UIFont
         XCTAssert(updatedH1Font.pointSize == CGFloat(formatterH1.headerLevel.fontSize))
 
-        let formatterH2 = HeaderFormatter(headerLevel: .h2, placeholderAttributes: nil)
+        let formatterH2 = HeaderFormatter(headerLevel: .h2)
         let updatedH2Attrs = formatterH2.apply(to: attributes, andStore: nil)
         let updatedH2Font = updatedH2Attrs[.font] as! UIFont
         XCTAssert(updatedH2Font.pointSize == CGFloat(formatterH2.headerLevel.fontSize))

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
@@ -379,7 +379,7 @@ class AttributedStringParserTests: XCTestCase {
         let levels: [Header.HeaderType] = [.h1, .h2, .h3, .h4, .h5, .h6]
 
         for level in levels {
-            let formatter = HeaderFormatter(headerLevel: level, placeholderAttributes: [:])
+            let formatter = HeaderFormatter(headerLevel: level)
 
             let headingStyle = formatter.apply(to: Constants.sampleAttributes)
             let headingText = NSAttributedString(string: "Aztec Rocks\n", attributes: headingStyle)
@@ -515,7 +515,7 @@ class AttributedStringParserTests: XCTestCase {
     /// - Output: <h1>Hello</h1><h1>World</h1>
     ///
     func testNewlineDoesNotGetAddedBetweenTwoBlocklevelElements() {
-        let formatter = HeaderFormatter(headerLevel: .h1, placeholderAttributes: nil)
+        let formatter = HeaderFormatter(headerLevel: .h1)
         let headingStyle = formatter.apply(to: Constants.sampleAttributes)
 
         let testingString = NSAttributedString(string: "Hello\nWorld", attributes: headingStyle)

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringSerializerTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringSerializerTests.swift
@@ -196,7 +196,7 @@ class AttributedStringSerializerTests: XCTestCase {
             return
         }
 
-        let formatter = HeaderFormatter(headerLevel: .h1, placeholderAttributes: [:])
+        let formatter = HeaderFormatter(headerLevel: .h1)
         XCTAssertTrue(formatter.present(in: caption, at: 0))
     }
 }


### PR DESCRIPTION
### Description:

Formatters had a property named `placeholderAttributes` which once had a purpose, but currently has none.

This is a small maintenance PR that will be followed up with a simplification of formatters.  This is a small step towards fixing #1090.

To do so, I'll unify all registered formatters in a single spot in `Aztec.TextView`.

### Testing:

Make sure the example app runs fine.
Make sure the unit tests run fine.