### PR TITLE
Improves the plugin input and output customizers.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -171,6 +171,8 @@
 		F18986E51EF2043E0060EDBA /* ItalicFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18986E41EF2043E0060EDBA /* ItalicFormatter.swift */; };
 		F18A1EA921C0586E00F1AA9E /* NSAttributedString+ParagraphRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18A1EA821C0586E00F1AA9E /* NSAttributedString+ParagraphRange.swift */; };
 		F18A1EAB21C058E500F1AA9E /* NSAttributedStringParagraphRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18A1EAA21C058E500F1AA9E /* NSAttributedStringParagraphRangeTests.swift */; };
+		F18A1EBA21C0828700F1AA9E /* PluginInputCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18A1EB821C0828700F1AA9E /* PluginInputCustomizer.swift */; };
+		F18A1EBB21C0828700F1AA9E /* PluginOutputCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18A1EB921C0828700F1AA9E /* PluginOutputCustomizer.swift */; };
 		F18B81ED1EA560B700885F43 /* StringUTF16+RangeConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B81EC1EA560B700885F43 /* StringUTF16+RangeConversion.swift */; };
 		F193AD6720C5A40A00BBA8F4 /* ShortcodeAttributeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F193AD6620C5A40A00BBA8F4 /* ShortcodeAttributeParser.swift */; };
 		F1953E251F4E544A00C717C9 /* HTMLParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1953E241F4E544A00C717C9 /* HTMLParserTests.swift */; };
@@ -435,6 +437,8 @@
 		F18986E41EF2043E0060EDBA /* ItalicFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItalicFormatter.swift; sourceTree = "<group>"; };
 		F18A1EA821C0586E00F1AA9E /* NSAttributedString+ParagraphRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+ParagraphRange.swift"; sourceTree = "<group>"; };
 		F18A1EAA21C058E500F1AA9E /* NSAttributedStringParagraphRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringParagraphRangeTests.swift; sourceTree = "<group>"; };
+		F18A1EB821C0828700F1AA9E /* PluginInputCustomizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginInputCustomizer.swift; sourceTree = "<group>"; };
+		F18A1EB921C0828700F1AA9E /* PluginOutputCustomizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginOutputCustomizer.swift; sourceTree = "<group>"; };
 		F18B81EC1EA560B700885F43 /* StringUTF16+RangeConversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StringUTF16+RangeConversion.swift"; sourceTree = "<group>"; };
 		F193AD6620C5A40A00BBA8F4 /* ShortcodeAttributeParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcodeAttributeParser.swift; sourceTree = "<group>"; };
 		F1953E241F4E544A00C717C9 /* HTMLParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLParserTests.swift; sourceTree = "<group>"; };
@@ -826,7 +830,9 @@
 			isa = PBXGroup;
 			children = (
 				F1065DB520ADD928008C72CC /* Plugin.swift */,
+				F18A1EB821C0828700F1AA9E /* PluginInputCustomizer.swift */,
 				F13E8AD720B71BAA007C9F8A /* PluginManager.swift */,
+				F18A1EB921C0828700F1AA9E /* PluginOutputCustomizer.swift */,
 			);
 			path = Plugin;
 			sourceTree = "<group>";
@@ -1507,6 +1513,7 @@
 				FF20D6421EDC389A00294B78 /* Processor.swift in Sources */,
 				599F253B1D8BC9A1002871D6 /* InNodesConverter.swift in Sources */,
 				F127F7141F0591AD008A00D7 /* CSSAttribute.swift in Sources */,
+				F18A1EBB21C0828700F1AA9E /* PluginOutputCustomizer.swift in Sources */,
 				F11326B31EF1AA91007FEE9A /* ParagraphProperty.swift in Sources */,
 				F11326B11EF1AA91007FEE9A /* HTMLParagraph.swift in Sources */,
 				FF20D6401EDC389A00294B78 /* ShortcodeAttribute.swift in Sources */,
@@ -1515,6 +1522,7 @@
 				FF4E26601EA8DF1E005E8E42 /* ImageAttachment.swift in Sources */,
 				599F254F1D8BC9A1002871D6 /* FormatBarItem.swift in Sources */,
 				F17BC8931F4E4BA500398E2B /* HTMLRepresentation.swift in Sources */,
+				F18A1EBA21C0828700F1AA9E /* PluginInputCustomizer.swift in Sources */,
 				F15BA60F21515C0F00424120 /* UnderlineStringAttributeConverter.swift in Sources */,
 				F18B81ED1EA560B700885F43 /* StringUTF16+RangeConversion.swift in Sources */,
 				F16A2AD520CC437E00BF3A0A /* LineAttachmentToElementConverter.swift in Sources */,

--- a/Aztec/Classes/Plugin/Plugin.swift
+++ b/Aztec/Classes/Plugin/Plugin.swift
@@ -5,58 +5,14 @@ import UIKit
 ///
 open class Plugin {
     
-    open class InputCustomizer {
-        
-        public init() {}
-        
-        /// Processes an HTML string right before parsing it to convert it into a nodes tree in
-        /// the input conversion process.
-        ///
-        open func process(html: String) -> String { return html }
-        
-        /// Processes a nodes tree right after it's been parsed from a string, and before finalizing
-        /// the input conversion process.
-        ///
-        open func process(htmlTree: RootNode) { return }
-        
-        open func converter(for elementNode: ElementNode) -> ElementConverter? { return nil }
-    }
-    
-    open class OutputCustomizer {
-        
-        public init() {}
-        
-        /// Processes an HTML string right after converting it from a nodes tree in the output
-        /// conversion process.
-        ///
-        open func process(html: String) -> String { return html }
-        
-        /// Processes a nodes tree right before it'll bee converted to a string, and before finalizing
-        /// the output conversion process.
-        ///
-        open func process(htmlTree: RootNode) { return }
-        
-        /// Converts a paragraph property into the ElementNode that represents it.
-        /// When a conversion is not implemented, just return nil.
-        ///
-        open func convert(_ paragraphProperty: ParagraphProperty) -> ElementNode? { return nil }
-        
-        /// Converts an attachment into the `[Node]`s that represent it.
-        /// When a conversion is not implemented, just return nil.
-        ///
-        open func convert(_ attachment: NSTextAttachment, attributes: [NSAttributedStringKey: Any]) -> [Node]? { return nil }
-        
-        open func converter(for elementNode: ElementNode) -> ElementToTagConverter? { return nil }
-    }
-    
     // MARK: - Customizers
     
-    public let inputCustomizer: InputCustomizer?
-    public let outputCustomizer: OutputCustomizer?
+    public let inputCustomizer: PluginInputCustomizer?
+    public let outputCustomizer: PluginOutputCustomizer?
     
     // MARK: - Initializers
     
-    public init(inputCustomizer: InputCustomizer? = nil, outputCustomizer: OutputCustomizer? = nil) {
+    public init(inputCustomizer: PluginInputCustomizer? = nil, outputCustomizer: PluginOutputCustomizer? = nil) {
         self.inputCustomizer = inputCustomizer
         self.outputCustomizer = outputCustomizer
     }

--- a/Aztec/Classes/Plugin/PluginInputCustomizer.swift
+++ b/Aztec/Classes/Plugin/PluginInputCustomizer.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public protocol PluginInputCustomizer {
+    
+    /// Processes an HTML string right before parsing it to convert it into a nodes tree in
+    /// the input conversion process.
+    ///
+    func process(html: String) -> String
+    
+    /// Processes a nodes tree right after it's been parsed from a string, and before finalizing
+    /// the input conversion process.
+    ///
+    func process(htmlTree: RootNode)
+    
+    func converter(for elementNode: ElementNode) -> ElementConverter?
+}
+
+extension PluginInputCustomizer {
+
+    func process(html: String) -> String { return html }
+    func process(htmlTree: RootNode) { return }
+    func converter(for elementNode: ElementNode) -> ElementConverter? { return nil }
+}

--- a/Aztec/Classes/Plugin/PluginOutputCustomizer.swift
+++ b/Aztec/Classes/Plugin/PluginOutputCustomizer.swift
@@ -1,0 +1,34 @@
+import Foundation
+import UIKit
+
+public protocol PluginOutputCustomizer {
+    
+    /// Processes an HTML string right after converting it from a nodes tree in the output
+    /// conversion process.
+    ///
+    func process(html: String) -> String
+    
+    /// Processes a nodes tree right before it'll bee converted to a string, and before finalizing
+    /// the output conversion process.
+    ///
+    func process(htmlTree: RootNode)
+    
+    /// Converts a paragraph property into the ElementNode that represents it.
+    ///
+    func convert(_ paragraphProperty: ParagraphProperty) -> ElementNode?
+    
+    /// Converts an attachment into the `[Node]`s that represent it.
+    ///
+    func convert(_ attachment: NSTextAttachment, attributes: [NSAttributedStringKey: Any]) -> [Node]?
+    
+    func converter(for elementNode: ElementNode) -> ElementToTagConverter?
+}
+
+extension PluginOutputCustomizer {
+    
+    func process(html: String) -> String { return html }
+    func process(htmlTree: RootNode) { return }
+    func convert(_ paragraphProperty: ParagraphProperty) -> ElementNode? { return nil }
+    func convert(_ attachment: NSTextAttachment, attributes: [NSAttributedStringKey: Any]) -> [Node]? { return nil }
+    func converter(for elementNode: ElementNode) -> ElementToTagConverter? { return nil }
+}

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/WordPressInputCustomizer.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/WordPressInputCustomizer.swift
@@ -7,7 +7,7 @@ import Aztec
 ///
 /// The Gutenberg processors are harmless on Calypso posts.
 ///
-open class WordPressInputCustomizer: Plugin.InputCustomizer {
+open class WordPressInputCustomizer: PluginInputCustomizer {
     
     // MARK: - Calypso
     
@@ -32,13 +32,11 @@ open class WordPressInputCustomizer: Plugin.InputCustomizer {
     
     public required init(gutenbergContentVerifier isGutenbergContent: @escaping (String) -> Bool) {
         self.isGutenbergContent = isGutenbergContent
-        
-        super.init()
     }
     
     // MARK: - Input Processing
     
-    override open func process(html: String) -> String {
+    open func process(html: String) -> String {
         guard !isGutenbergContent(html) else {
             return html
         }
@@ -46,11 +44,11 @@ open class WordPressInputCustomizer: Plugin.InputCustomizer {
         return calypsoinputHTMLProcessor.process(html)
     }
     
-    override open func process(htmlTree: RootNode) {
+    open func process(htmlTree: RootNode) {
         gutenbergInputHTMLTreeProcessor.process(htmlTree)
     }
     
-    override open func converter(for elementNode: ElementNode) -> ElementConverter? {
+    open func converter(for elementNode: ElementNode) -> ElementConverter? {
         guard let converter = inputElementConverters[elementNode.type] else {
             return nil
         }

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/WordPressOutputCustomizer.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/WordPressOutputCustomizer.swift
@@ -8,7 +8,7 @@ import UIKit
 ///
 /// The Gutenberg processors are harmless on Calypso posts.
 ///
-open class WordPressOutputCustomizer: Plugin.OutputCustomizer {
+open class WordPressOutputCustomizer: PluginOutputCustomizer {
     
     // MARK: - Calypso
     
@@ -31,13 +31,11 @@ open class WordPressOutputCustomizer: Plugin.OutputCustomizer {
     
     public required init(gutenbergContentVerifier isGutenbergContent: @escaping (String) -> Bool) {
         self.isGutenbergContent = isGutenbergContent
-        
-        super.init()
     }
     
     // MARK: - Output Processing
     
-    override open func process(html: String) -> String {
+    open func process(html: String) -> String {
         guard !isGutenbergContent(html) else {
             return html
         }
@@ -45,11 +43,11 @@ open class WordPressOutputCustomizer: Plugin.OutputCustomizer {
         return calypsoOutputHTMLProcessor.process(html)
     }
     
-    override open func process(htmlTree: RootNode) {
+    open func process(htmlTree: RootNode) {
         gutenbergOutputHTMLTreeProcessor.process(htmlTree)
     }
     
-    override open func convert(_ attachment: NSTextAttachment, attributes: [NSAttributedStringKey : Any]) -> [Node]? {
+    open func convert(_ attachment: NSTextAttachment, attributes: [NSAttributedStringKey : Any]) -> [Node]? {
         for converter in attachmentToElementConverters {
             if let element = converter.convert(attachment, attributes: attributes) {
                 return element
@@ -59,7 +57,7 @@ open class WordPressOutputCustomizer: Plugin.OutputCustomizer {
         return nil
     }
     
-    override open func converter(for elementNode: ElementNode) -> ElementToTagConverter? {
+    open func converter(for elementNode: ElementNode) -> ElementToTagConverter? {
         guard let converter = elementToTagConverters[elementNode.type] else {
             return nil
         }
@@ -69,7 +67,7 @@ open class WordPressOutputCustomizer: Plugin.OutputCustomizer {
     
     // MARK: - AttributedStringParserCustomizer
     
-    override open func convert(_ paragraphProperty: ParagraphProperty) -> ElementNode? {
+    open func convert(_ paragraphProperty: ParagraphProperty) -> ElementNode? {
         guard let gutenblockProperty = paragraphProperty as? Gutenblock,
             let representation = gutenblockProperty.representation,
             case let .element(gutenblock) = representation.kind else {


### PR DESCRIPTION
### Description:

These improvements are part of [a larger upcoming PR](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1101), but I split them into a separate PR to make reviews easier.

### Testing:

This PR just relocates code and converts a class into a protocol.  Building and running the unit tests fine should be enough proof that the changes are fine.