### PR TITLE
Fixes a bug that was causing some headers to disappear.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -137,7 +137,7 @@ public class ElementNode: Node {
     override func needsClosingParagraphSeparator() -> Bool {
         return (!hasChildren())
             && (hasAttributes() || !isLastInTree())
-            && (hasRightBlockLevelSibling() || isLastInAncestorEndingInBlockLevelSeparation())
+            && (isBlockLevel() || hasRightBlockLevelSibling() || isLastInAncestorEndingInBlockLevelSeparation())
     }
 
     /// Checks if the specified node requires a closing paragraph separator in itself, or in the any of its descendants.

--- a/AztecTests/HTML/Nodes/ElementNodeTests.swift
+++ b/AztecTests/HTML/Nodes/ElementNodeTests.swift
@@ -89,4 +89,13 @@ class ElementNodeTests: XCTestCase {
 
         XCTAssertEqual(parent.firstChild(ofType: .em), bold)
     }
+    
+    func testNeedsClosingParagraphSeparator() {
+        let header = ElementNode(type: .h1)
+        let textNode = TextNode(text: "Some text")
+        let parent = RootNode(children: [header, textNode])
+        _ = parent // silence warnings
+        
+        XCTAssertEqual(header.needsClosingParagraphSeparator(), true)
+    }
 }


### PR DESCRIPTION
### Description:

Fixes an issue that was causing empty block-level elements to be removed.

### Testing:

To reproduce the original issue, you can test this in `develop`.  To test the fix, run the same steps in this branch:

1. Launch the editor
2. Switch to HTML mode and paste this:

```html
<h1></h1>
<h2></h2>
Hello there
```

3. Switch back to visual mode, don't do any edits.
4. Switch back to HTML.

The header tags should still be there.