### PR TITLE
Adding public access level HeaderFormatter

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
@@ -4,7 +4,7 @@ import UIKit
 
 // MARK: - HTMLParagraph Formatter
 //
-class HTMLParagraphFormatter: ParagraphAttributeFormatter {
+public class HTMLParagraphFormatter: ParagraphAttributeFormatter {
 
     /// Attributes to be added by default
     ///
@@ -34,7 +34,7 @@ class HTMLParagraphFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func remove(from attributes:[NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
+    public func remove(from attributes:[NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
         guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle,
             !paragraphStyle.htmlParagraph.isEmpty
             else {

--- a/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
@@ -13,7 +13,7 @@ public class HTMLParagraphFormatter: ParagraphAttributeFormatter {
 
     /// Designated Initializer
     ///
-    init(placeholderAttributes: [NSAttributedStringKey: Any]? = nil) {
+    public init(placeholderAttributes: [NSAttributedStringKey: Any]? = nil) {
         self.placeholderAttributes = placeholderAttributes
     }
 

--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -12,14 +12,14 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
 
     /// Designated Initializer
     ///
-    init(headerLevel: Header.HeaderType = .h1) {
+    public init(headerLevel: Header.HeaderType = .h1) {
         self.headerLevel = headerLevel
     }
 
 
     // MARK: - Overwriten Methods
 
-    func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
+    public func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
         guard let font = attributes[.font] as? UIFont else {
             return attributes
         }


### PR DESCRIPTION
This is needed for Gutenberg's RNAztecView.

Implemented in this PR https://github.com/wordpress-mobile/react-native-aztec/pull/98
This will be merged if the previously mentioned PR is approved with the proposed solution, or if any other solution need these changes.

To test:
- Check that there are no build errors.