### PR TITLE
Fixes a crashing bug in GutenbergOutputHTMLTreeProcessor.

### DIFF
--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessor.swift
@@ -53,7 +53,7 @@ public class GutenbergOutputHTMLTreeProcessor: HTMLTreeProcessor {
         var result = [Node]()
         
         while let (index, gutenpack) = nextGutenpack(in: children) {
-            let nodesBeforeGutenpack = children.prefix(upTo: index)
+            let nodesBeforeGutenpack = children.prefix(index)
 
             if nodesBeforeGutenpack.count > 0 {
                 let newParagraph = deepCopy(paragraph, withChildren: Array(nodesBeforeGutenpack))

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
@@ -127,7 +127,7 @@ class GutenbergInputHTMLTreeProcessorTests: XCTestCase {
     
     /// Verifies that a self closing block is properly processed
     ///
-    func testSelfClosedBlock() {
+    func testSelfClosingBlockInsideAnotherBlock() {
         let selfClosingCommentText = " wp:latest-posts /"
         let openingCommentText = " wp:paragraph {\"fontColor\": red, \"fontSize\": 12} "
         let closingCommentText = " /wp:paragraph "

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessorTests.swift
@@ -29,4 +29,25 @@ class GutenbergOutputHTMLTreeProcessorTests: XCTestCase {
         outputProcessor.process(rootNode)
         XCTAssertTrue(rootNode.rawText().contains("This text will be lost"))
     }
+    
+    /// There was an issue with Gutenberg posts losing edits.  This automated test makes sure the issues we found don't regress.
+    ///
+    /// https://github.com/wordpress-mobile/AztecEditor-iOS/issues/1052
+    ///
+    func testNoCrashWhenTestingTwoGutenpacksInSequence() {
+        
+        let commentNode = CommentNode(text: "wp:latestposts /")
+        let gutenpackAttribute = encoder.selfClosingAttribute(for: commentNode)
+        let gutenpack = ElementNode(type: .gutenpack, attributes: [gutenpackAttribute], children: [])
+        
+        let commentNode2 = CommentNode(text: "wp:latestposts /")
+        let gutenpackAttribute2 = encoder.selfClosingAttribute(for: commentNode2)
+        let gutenpack2 = ElementNode(type: .gutenpack, attributes: [gutenpackAttribute2], children: [])
+        
+        let paragraph = ElementNode(type: .p, attributes: [], children: [gutenpack, gutenpack2])
+        let rootNode = RootNode(children: [paragraph])
+        
+        outputProcessor.process(rootNode)
+        XCTAssertTrue(rootNode.rawText().contains("This text will be lost"))
+    }
 }

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessorTests.swift
@@ -30,9 +30,9 @@ class GutenbergOutputHTMLTreeProcessorTests: XCTestCase {
         XCTAssertTrue(rootNode.rawText().contains("This text will be lost"))
     }
     
-    /// There was an issue with Gutenberg posts losing edits.  This automated test makes sure the issues we found don't regress.
+    /// There was an issue with Gutenberg posts crashing GutenbergOutputHTMLTreeProcessor.
     ///
-    /// https://github.com/wordpress-mobile/AztecEditor-iOS/issues/1052
+    /// https://github.com/wordpress-mobile/AztecEditor-iOS/issues/1111
     ///
     func testNoCrashWhenTestingTwoGutenpacksInSequence() {
         

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessorTests.swift
@@ -36,11 +36,13 @@ class GutenbergOutputHTMLTreeProcessorTests: XCTestCase {
     ///
     func testNoCrashWhenTestingTwoGutenpacksInSequence() {
         
-        let commentNode = CommentNode(text: "wp:latestposts /")
+        let commentText = "wp:latestposts /"
+        let commentNode = CommentNode(text: commentText)
         let gutenpackAttribute = encoder.selfClosingAttribute(for: commentNode)
         let gutenpack = ElementNode(type: .gutenpack, attributes: [gutenpackAttribute], children: [])
         
-        let commentNode2 = CommentNode(text: "wp:latestposts /")
+        let commentText2 = "wp:latestposts /"
+        let commentNode2 = CommentNode(text: commentText2)
         let gutenpackAttribute2 = encoder.selfClosingAttribute(for: commentNode2)
         let gutenpack2 = ElementNode(type: .gutenpack, attributes: [gutenpackAttribute2], children: [])
         
@@ -48,6 +50,17 @@ class GutenbergOutputHTMLTreeProcessorTests: XCTestCase {
         let rootNode = RootNode(children: [paragraph])
         
         outputProcessor.process(rootNode)
-        XCTAssertTrue(rootNode.rawText().contains("This text will be lost"))
+        
+        let childComments = rootNode.children.compactMap { node -> CommentNode? in
+            guard let commentNode = node as? CommentNode else {
+                return nil
+            }
+            
+            return commentNode
+        }
+        
+        XCTAssertEqual(childComments.count, 2)
+        XCTAssertEqual(childComments[0].comment, commentText)
+        XCTAssertEqual(childComments[1].comment, commentText2)
     }
 }


### PR DESCRIPTION
### Description:

Fixes #1111.

Fixes a crashing bug in GutenbergOutputHTMLTreeProcessor.

Also adds a unit test to prevent a regression.

### Testing:

Run the newly added unit test.
If you run the same test after changing `prefix()` to `prefix(upTo:)` you'll notice it'll crash.