### PR TITLE
Revert "Revert "Merge Release/1.3.3 into develop""

### DIFF
--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.3.2'
+  s.version          = '1.3.3'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.3.2'
+  s.version          = '1.3.3'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessor.swift
@@ -53,7 +53,7 @@ public class GutenbergOutputHTMLTreeProcessor: HTMLTreeProcessor {
         var result = [Node]()
         
         while let (index, gutenpack) = nextGutenpack(in: children) {
-            let nodesBeforeGutenpack = children.prefix(upTo: index)
+            let nodesBeforeGutenpack = children.prefix(index)
 
             if nodesBeforeGutenpack.count > 0 {
                 let newParagraph = deepCopy(paragraph, withChildren: Array(nodesBeforeGutenpack))

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergInputHTMLTreeProcessorTests.swift
@@ -127,7 +127,7 @@ class GutenbergInputHTMLTreeProcessorTests: XCTestCase {
     
     /// Verifies that a self closing block is properly processed
     ///
-    func testSelfClosedBlock() {
+    func testSelfClosingBlockInsideAnotherBlock() {
         let selfClosingCommentText = " wp:latest-posts /"
         let openingCommentText = " wp:paragraph {\"fontColor\": red, \"fontSize\": 12} "
         let closingCommentText = " /wp:paragraph "

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Gutenberg/GutenbergOutputHTMLTreeProcessorTests.swift
@@ -29,4 +29,38 @@ class GutenbergOutputHTMLTreeProcessorTests: XCTestCase {
         outputProcessor.process(rootNode)
         XCTAssertTrue(rootNode.rawText().contains("This text will be lost"))
     }
+    
+    /// There was an issue with Gutenberg posts crashing GutenbergOutputHTMLTreeProcessor.
+    ///
+    /// https://github.com/wordpress-mobile/AztecEditor-iOS/issues/1111
+    ///
+    func testNoCrashWhenTestingTwoGutenpacksInSequence() {
+        
+        let commentText = "wp:latestposts /"
+        let commentNode = CommentNode(text: commentText)
+        let gutenpackAttribute = encoder.selfClosingAttribute(for: commentNode)
+        let gutenpack = ElementNode(type: .gutenpack, attributes: [gutenpackAttribute], children: [])
+        
+        let commentText2 = "wp:latestposts /"
+        let commentNode2 = CommentNode(text: commentText2)
+        let gutenpackAttribute2 = encoder.selfClosingAttribute(for: commentNode2)
+        let gutenpack2 = ElementNode(type: .gutenpack, attributes: [gutenpackAttribute2], children: [])
+        
+        let paragraph = ElementNode(type: .p, attributes: [], children: [gutenpack, gutenpack2])
+        let rootNode = RootNode(children: [paragraph])
+        
+        outputProcessor.process(rootNode)
+        
+        let childComments = rootNode.children.compactMap { node -> CommentNode? in
+            guard let commentNode = node as? CommentNode else {
+                return nil
+            }
+            
+            return commentNode
+        }
+        
+        XCTAssertEqual(childComments.count, 2)
+        XCTAssertEqual(childComments[0].comment, commentText)
+        XCTAssertEqual(childComments[1].comment, commentText2)
+    }
 }


### PR DESCRIPTION
Reverts wordpress-mobile/AztecEditor-iOS#1114

I reverted this as I merged too quickly. Opening it to merge correctly this time.