### PR TITLE
Fixes a bug that was stripping self-closing blocks.

### DIFF
--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/HRElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/HRElementConverter.swift
@@ -22,7 +22,10 @@ class HRElementConverter: AttachmentElementConverter {
         let attributes = combine(attributes, with: representation)
         let attachment = self.attachment(for: element)
         
-        return (attachment, NSAttributedString(attachment: attachment, attributes: attributes))
+        let intrinsicRepresentation = NSAttributedString(attachment: attachment, attributes: attributes)
+        let serialization = serialize(element, intrinsicRepresentation, attributes)
+        
+        return (attachment, serialization)
     }
     
     // MARK: - Attachment Creation

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
@@ -15,8 +15,10 @@ class VideoElementConverter: AttachmentElementConverter {
         contentSerializer serialize: ContentSerializer) -> (attachment: VideoAttachment, string: NSAttributedString) {
         
         let attachment = self.attachment(for: element)
+        let intrinsicRepresentation = NSAttributedString(attachment: attachment, attributes: attributes)
+        let serialization = serialize(element, intrinsicRepresentation, attributes)
         
-        return (attachment, NSAttributedString(attachment: attachment, attributes: attributes))
+        return (attachment, serialization)
     }
     
     // MARK: - Attachment Creation

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -183,11 +183,9 @@ open class TextStorage: NSTextStorage {
             switch textAttachment {
             case _ as LineAttachment:
                 break
-            case let attachment as CommentAttachment:
-                attachment.delegate = self
-            case let attachment as HTMLAttachment:
-                attachment.delegate = self
             case let attachment as MediaAttachment:
+                attachment.delegate = self
+            case let attachment as RenderableAttachment:
                 attachment.delegate = self
             default:
                 guard let image = textAttachment.image else {

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenpackConverter.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenpackConverter.swift
@@ -17,12 +17,17 @@ public class GutenpackConverter: ElementConverter {
         precondition(element.type == .gutenpack)
 
         let decoder = GutenbergAttributeDecoder()
+        
         guard let content = decoder.attribute(.selfCloser, from: element) else {
             let serializer = HTMLSerializer()
             let attachment = HTMLAttachment()
+            
             attachment.rootTagName = element.name
             attachment.rawHTML = serializer.serialize(element)
-            return NSAttributedString(attachment: attachment, attributes: attributes)
+            
+            let representation = NSAttributedString(attachment: attachment, attributes: attributes)
+            
+            return serialize(element, representation, attributes)
         }
 
         let blockContent = String(content[content.startIndex ..< content.index(before: content.endIndex)])
@@ -30,7 +35,9 @@ public class GutenpackConverter: ElementConverter {
             char != " "
         }))
         let attachment = GutenpackAttachment(name: blockName, content: blockContent)
-        return NSAttributedString(attachment: attachment, attributes: attributes)
+        let representation = NSAttributedString(attachment: attachment, attributes: attributes)
+        
+        return serialize(element, representation, attributes)
     }
         
 }

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
@@ -217,6 +217,29 @@ class WordpressPluginTests: XCTestCase {
         XCTAssertEqual(outputHtml, expectedOutput)
     }
     
+    /// Spawned from: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1116#issuecomment-449064390
+    ///
+    func testGutenpackAddsNewlineInVisualModeIfNeeded2() {
+        let html = """
+<!-- wp:separator -->
+<hr class="wp-block-separator" />
+<!-- /wp:separator -->
+
+<!-- wp:video -->
+<figure class="wp-block-video"><video controls src="https://videos.files.wordpress.com/AvC6H2JI/video-de223da1f6.mp4"></video></figure>
+<!-- /wp:video -->
+"""
+        let expectedOutput = """
+<!-- wp:separator --><hr class="wp-block-separator"><!-- /wp:separator -->
+<!-- wp:video --><figure class="wp-block-video"><video src="https://videos.files.wordpress.com/AvC6H2JI/video-de223da1f6.mp4"></video></figure><!-- /wp:video -->
+"""
+        
+        let attributedString = htmlConverter.attributedString(from: html)
+        let outputHtml = htmlConverter.html(from: attributedString)
+        
+        XCTAssertEqual(outputHtml, expectedOutput)
+    }
+    
     // MARK: - Spacer Block
     
     /// This test was spawned off this issue:

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
@@ -240,6 +240,30 @@ class WordpressPluginTests: XCTestCase {
         XCTAssertEqual(outputHtml, expectedOutput)
     }
     
+
+    /// Spawned from: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1116#issuecomment-449064390
+    ///
+    func testGutenpackAddsNewlineInVisualModeIfNeeded3() {
+        let html = """
+<!-- wp:video -->
+<figure class="wp-block-video"><video src="https://videos.files.wordpress.com/AvC6H2JI/video-de223da1f6.mp4"></video></figure>
+<!-- /wp:video -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator" />
+<!-- /wp:separator -->
+"""
+        let expectedOutput = """
+<!-- wp:video --><figure class="wp-block-video"><video src="https://videos.files.wordpress.com/AvC6H2JI/video-de223da1f6.mp4"></video></figure><!-- /wp:video -->
+<!-- wp:separator --><hr class="wp-block-separator"><!-- /wp:separator -->
+"""
+        
+        let attributedString = htmlConverter.attributedString(from: html)
+        let outputHtml = htmlConverter.html(from: attributedString)
+        
+        XCTAssertEqual(outputHtml, expectedOutput)
+    }
+    
     // MARK: - Spacer Block
     
     /// This test was spawned off this issue:

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
@@ -194,7 +194,30 @@ class WordpressPluginTests: XCTestCase {
         XCTAssertEqual(finalHTML, expected)
     }
     
-    //  MARK: - Spacer Block
+    // MARK: - Gutenpack + Gutenblock
+    
+    /// Spawned from: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1116#issuecomment-449056392
+    ///
+    func testGutenpackAddsNewlineInVisualModeIfNeeded() {
+        let html = """
+<!-- wp:latestposts /-->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator">
+<!-- /wp:separator -->
+"""
+        let expectedOutput = """
+<!-- wp:latestposts /-->
+<!-- wp:separator --><hr class="wp-block-separator"><!-- /wp:separator -->
+"""
+        
+        let attributedString = htmlConverter.attributedString(from: html)
+        let outputHtml = htmlConverter.html(from: attributedString)
+        
+        XCTAssertEqual(outputHtml, expectedOutput)
+    }
+    
+    // MARK: - Spacer Block
     
     /// This test was spawned off this issue:
     /// https://github.com/wordpress-mobile/AztecEditor-iOS/issues/1078

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/WordPressPluginTests.swift
@@ -30,6 +30,13 @@ class WordpressPluginTests: XCTestCase {
         return AttributedStringParser(customizer: pluginManager)
     }()
     
+    func testThatRoundConversion(fromInputHTML inputHTML: String, resultsInOutputHTML expectedHTML: String) {
+        let attributedString = htmlConverter.attributedString(from: inputHTML)
+        let outputHtml = htmlConverter.html(from: attributedString)
+        
+        XCTAssertEqual(outputHtml, expectedHTML)
+    }
+    
     // MARK: - Full Conversion
     
     func testFullConversionOfParagraphBlock() {
@@ -199,6 +206,7 @@ class WordpressPluginTests: XCTestCase {
     /// Spawned from: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1116#issuecomment-449056392
     ///
     func testGutenpackAddsNewlineInVisualModeIfNeeded() {
+        
         let html = """
 <!-- wp:latestposts /-->
 
@@ -211,10 +219,7 @@ class WordpressPluginTests: XCTestCase {
 <!-- wp:separator --><hr class="wp-block-separator"><!-- /wp:separator -->
 """
         
-        let attributedString = htmlConverter.attributedString(from: html)
-        let outputHtml = htmlConverter.html(from: attributedString)
-        
-        XCTAssertEqual(outputHtml, expectedOutput)
+        testThatRoundConversion(fromInputHTML: html, resultsInOutputHTML: expectedOutput)
     }
     
     /// Spawned from: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1116#issuecomment-449064390
@@ -234,10 +239,7 @@ class WordpressPluginTests: XCTestCase {
 <!-- wp:video --><figure class="wp-block-video"><video src="https://videos.files.wordpress.com/AvC6H2JI/video-de223da1f6.mp4"></video></figure><!-- /wp:video -->
 """
         
-        let attributedString = htmlConverter.attributedString(from: html)
-        let outputHtml = htmlConverter.html(from: attributedString)
-        
-        XCTAssertEqual(outputHtml, expectedOutput)
+        testThatRoundConversion(fromInputHTML: html, resultsInOutputHTML: expectedOutput)
     }
     
 
@@ -258,10 +260,7 @@ class WordpressPluginTests: XCTestCase {
 <!-- wp:separator --><hr class="wp-block-separator"><!-- /wp:separator -->
 """
         
-        let attributedString = htmlConverter.attributedString(from: html)
-        let outputHtml = htmlConverter.html(from: attributedString)
-        
-        XCTAssertEqual(outputHtml, expectedOutput)
+        testThatRoundConversion(fromInputHTML: html, resultsInOutputHTML: expectedOutput)
     }
     
     // MARK: - Spacer Block


### PR DESCRIPTION
### Description:

Fixes a bug that was causing self-closing blocks to be stripped from posts.

Example self-closing block:

```html
<!-- wp:latestposts /-->
```

### Testing:

1. Launch the Gutenberg editor demo.
2. Go to HTML and paste the example self-closing block provided above.
3. Switch to visual mode.  The self-closing block will have a visual representation.
4. Switch to HTML mode, the self-closing block should still be there.

Feel free to play with variants of this test.