### PR TITLE
Allow overriding Heading formatting behavior

### DIFF
--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
@@ -3,7 +3,7 @@ import UIKit
 
 /// Converts a generic element to `NSAttributedString`.  Should only be used if a specific converter is not found.
 ///
-class GenericElementConverter: ElementConverter {
+open class GenericElementConverter: ElementConverter {
     
     // MARK: - Element Support
     
@@ -35,7 +35,7 @@ class GenericElementConverter: ElementConverter {
     lazy var codeFormatter = CodeFormatter()
     lazy var liFormatter = LiFormatter()
     
-    public lazy var elementFormattersMap: [Element: AttributeFormatter] = {
+    private lazy var _elementFormattersMap: [Element: AttributeFormatter] = {
         return [
             .blockquote: self.blockquoteFormatter,
             .div: self.divFormatter,
@@ -59,9 +59,16 @@ class GenericElementConverter: ElementConverter {
         ]
     }()
     
+    open var elementFormattersMap: [Element: AttributeFormatter] {
+        return _elementFormattersMap
+    }
+    
+    // Public init to be able to initialize from other modules
+    public init() {}
+    
     // MARK: - ElementConverter
     
-    func convert(
+    public func convert(
         _ element: ElementNode,
         inheriting attributes: [NSAttributedStringKey: Any],
         contentSerializer serialize: ContentSerializer) -> NSAttributedString {

--- a/Aztec/Classes/Converters/StringAttributesToAttributes/ConditionalConverters/ConditionalItalicStringAttributeConverter.swift
+++ b/Aztec/Classes/Converters/StringAttributesToAttributes/ConditionalConverters/ConditionalItalicStringAttributeConverter.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 
-class ConditionalItalicStringAttributeConverter: ConditionalStringAttributeConverter {
+open class ConditionalItalicStringAttributeConverter: ConditionalStringAttributeConverter {
     
-    init() {
+    public init() {
         let citeBranch: Branch = {
             let predicate: ConditionalStringAttributeConverter.Predicate = { attributes -> Bool in
                 

--- a/Aztec/Classes/Converters/StringAttributesToAttributes/Implementations/BoldStringAttributeConverter.swift
+++ b/Aztec/Classes/Converters/StringAttributesToAttributes/Implementations/BoldStringAttributeConverter.swift
@@ -9,6 +9,8 @@ open class BoldStringAttributeConverter: StringAttributeConverter {
     
     let cssAttributeMatcher = BoldCSSAttributeMatcher()
     
+    public init() {}
+    
     public func convert(
         attributes: [NSAttributedStringKey: Any],
         andAggregateWith elementNodes: [ElementNode]) -> [ElementNode] {
@@ -24,13 +26,19 @@ open class BoldStringAttributeConverter: StringAttributeConverter {
             elementNodes.append(representationElement.toElementNode())
         }
         
-        if let font = attributes[.font] as? UIFont,
-            font.containsTraits(.traitBold) {
-            
+        if shouldEnableBold(for: attributes) {
             return enableBold(in: elementNodes)
         } else {
             return disableBold(in: elementNodes)
         }
+    }
+    
+    open func shouldEnableBold(for attributes: [NSAttributedStringKey: Any]) -> Bool {
+        if let font = attributes[.font] as? UIFont,
+            font.containsTraits(.traitBold) {
+            return true
+        }
+        return false
     }
     
     // MARK: - Enabling and Disabling Bold

--- a/Aztec/Classes/Converters/StringAttributesToAttributes/Implementations/UnderlineStringAttributeConverter.swift
+++ b/Aztec/Classes/Converters/StringAttributesToAttributes/Implementations/UnderlineStringAttributeConverter.swift
@@ -9,6 +9,8 @@ open class UnderlineStringAttributeConverter: StringAttributeConverter {
     
     let cssAttributeMatcher = UnderlineCSSAttributeMatcher()
     
+    public init() {}
+    
     public func convert(
         attributes: [NSAttributedStringKey: Any],
         andAggregateWith elementNodes: [ElementNode]) -> [ElementNode] {

--- a/Aztec/Classes/Extensions/UIFont+Traits.swift
+++ b/Aztec/Classes/Extensions/UIFont+Traits.swift
@@ -4,7 +4,7 @@ import UIKit
 
 // MARK: - UIFont Traits Helpers
 //
-extension UIFont {
+public extension UIFont {
 
     /// Returns a new instance of the current font with its SymbolicTraits Updated.
     ///
@@ -14,7 +14,7 @@ extension UIFont {
     ///
     /// - Returns: A new UIFont with the same descriptors as the current instance, but with its traits updated, as specified.
     ///
-    func modifyTraits(_ traits: UIFontDescriptorSymbolicTraits, enable: Bool) -> UIFont {
+    public func modifyTraits(_ traits: UIFontDescriptorSymbolicTraits, enable: Bool) -> UIFont {
         let descriptor = fontDescriptor
         var newTraits = descriptor.symbolicTraits
 

--- a/Aztec/Classes/Formatters/Base/AttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/Base/AttributeFormatter.swift
@@ -7,7 +7,7 @@ import UIKit
 /// attribute, it is useful to have a virtual attribute. 
 /// Toggling this attribute would also toggle the attributes for its defined style.
 ///
-protocol AttributeFormatter {
+public protocol AttributeFormatter {
 
     /// Toggles an attribute in the specified range of a text storage, and returns the new 
     /// Selected Range. This is required because, in several scenarios, we may need to add a "Zero Width Space",
@@ -74,7 +74,7 @@ protocol AttributeFormatter {
 
 // MARK: - Default Implementations
 //
-extension AttributeFormatter {
+public extension AttributeFormatter {
 
     /// The default implementation forwards the call.  This is probably good enough for all
     /// classes that implement this protocol.

--- a/Aztec/Classes/Formatters/Base/FontFormatter.swift
+++ b/Aztec/Classes/Formatters/Base/FontFormatter.swift
@@ -1,21 +1,21 @@
 import Foundation
 import UIKit
 
-class FontFormatter: AttributeFormatter {
+open class FontFormatter: AttributeFormatter {
     
     let htmlRepresentationKey: NSAttributedStringKey
     let traits: UIFontDescriptorSymbolicTraits
 
-    init(traits: UIFontDescriptorSymbolicTraits, htmlRepresentationKey: NSAttributedStringKey) {
+    public init(traits: UIFontDescriptorSymbolicTraits, htmlRepresentationKey: NSAttributedStringKey) {
         self.htmlRepresentationKey = htmlRepresentationKey
         self.traits = traits
     }
 
-    func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange {
+    public func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange {
         return range
     }
 
-    func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
+    public func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
 
         guard let font = attributes[.font] as? UIFont else {
             return attributes
@@ -31,7 +31,7 @@ class FontFormatter: AttributeFormatter {
         return resultingAttributes
     }
 
-    func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
+    public func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
         var resultingAttributes = attributes
         
         resultingAttributes.removeValue(forKey: htmlRepresentationKey)
@@ -45,7 +45,7 @@ class FontFormatter: AttributeFormatter {
         return resultingAttributes
     }
 
-    func present(in attributes: [NSAttributedStringKey : Any]) -> Bool {
+    public func present(in attributes: [NSAttributedStringKey : Any]) -> Bool {
         guard let font = attributes[.font] as? UIFont else {
             return false
         }

--- a/Aztec/Classes/Formatters/Base/ParagraphAttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/Base/ParagraphAttributeFormatter.swift
@@ -1,9 +1,9 @@
 import UIKit
 
-protocol ParagraphAttributeFormatter: AttributeFormatter {
+public protocol ParagraphAttributeFormatter: AttributeFormatter {
 }
 
-extension ParagraphAttributeFormatter {
+public extension ParagraphAttributeFormatter {
 
     func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange {
         return text.paragraphRange(for: range)

--- a/Aztec/Classes/Formatters/Base/StandardAttributeFormatter.swift
+++ b/Aztec/Classes/Formatters/Base/StandardAttributeFormatter.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 /// Formatter to apply simple value (NSNumber, UIColor) attributes to an attributed string. 
-class StandardAttributeFormatter: AttributeFormatter {
+open class StandardAttributeFormatter: AttributeFormatter {
 
     var placeholderAttributes: [NSAttributedStringKey: Any]? { return nil }
 
@@ -13,17 +13,17 @@ class StandardAttributeFormatter: AttributeFormatter {
 
     // MARK: - Init
 
-    init(attributeKey: NSAttributedStringKey, attributeValue: Any, htmlRepresentationKey: NSAttributedStringKey) {
+    public init(attributeKey: NSAttributedStringKey, attributeValue: Any, htmlRepresentationKey: NSAttributedStringKey) {
         self.attributeKey = attributeKey
         self.attributeValue = attributeValue
         self.htmlRepresentationKey = htmlRepresentationKey
     }
 
-    func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange {
+    public func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange {
         return range
     }
 
-    func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
+    public func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
         var resultingAttributes = attributes
         
         resultingAttributes[attributeKey] = attributeValue
@@ -32,7 +32,7 @@ class StandardAttributeFormatter: AttributeFormatter {
         return resultingAttributes
     }
 
-    func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
+    public func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
         var resultingAttributes = attributes
 
         resultingAttributes.removeValue(forKey: attributeKey)
@@ -41,7 +41,7 @@ class StandardAttributeFormatter: AttributeFormatter {
         return resultingAttributes
     }
 
-    func present(in attributes: [NSAttributedStringKey: Any]) -> Bool {
+    public func present(in attributes: [NSAttributedStringKey: Any]) -> Bool {
         let enabled = attributes[attributeKey] != nil
         return enabled
     }

--- a/Aztec/Classes/Formatters/Implementations/BoldFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/BoldFormatter.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class BoldFormatter: FontFormatter {
+open class BoldFormatter: FontFormatter {
     init() {
         super.init(traits: .traitBold, htmlRepresentationKey: .boldHtmlRepresentation)
     }

--- a/Aztec/Classes/Formatters/Implementations/FigcaptionFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/FigcaptionFormatter.swift
@@ -9,7 +9,7 @@ open class FigcaptionFormatter: ParagraphAttributeFormatter {
 
     // MARK: - Overwriten Methods
 
-    func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
+    public func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
         
         let defaultFont = self.defaultFont(from: attributes)
         
@@ -28,7 +28,7 @@ open class FigcaptionFormatter: ParagraphAttributeFormatter {
         return finalAttributes
     }
 
-    func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
+    public func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
         
         guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle,
             let figcaption = paragraphStyle.property(where: { $0 is Figcaption }) as? Figcaption else {
@@ -46,7 +46,7 @@ open class FigcaptionFormatter: ParagraphAttributeFormatter {
         return finalAttributes
     }
 
-    func present(in attributes: [NSAttributedStringKey: Any]) -> Bool {
+    public func present(in attributes: [NSAttributedStringKey: Any]) -> Bool {
         guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle else {
             return false
         }

--- a/Aztec/Classes/Formatters/Implementations/FigureFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/FigureFormatter.swift
@@ -8,7 +8,7 @@ open class FigureFormatter: ParagraphAttributeFormatter {
 
     // MARK: - Overwriten Methods
 
-    func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
+    public func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
         let figure = Figure(with: representation)
         let paragraphStyle = attributes.paragraphStyle()
         
@@ -21,7 +21,7 @@ open class FigureFormatter: ParagraphAttributeFormatter {
         return finalAttributes
     }
 
-    func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
+    public func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
         
         guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle,
             paragraphStyle.hasProperty(where: { $0 is Figure }) else {
@@ -38,7 +38,7 @@ open class FigureFormatter: ParagraphAttributeFormatter {
         return finalAttributes
     }
 
-    func present(in attributes: [NSAttributedStringKey: Any]) -> Bool {
+    public func present(in attributes: [NSAttributedStringKey: Any]) -> Bool {
         guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle else {
             return false
         }

--- a/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HTMLParagraphFormatter.swift
@@ -20,7 +20,7 @@ public class HTMLParagraphFormatter: ParagraphAttributeFormatter {
 
     // MARK: - Overwriten Methods
 
-    func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
+    public func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
         let newParagraphStyle = ParagraphStyle()
 
         if let paragraphStyle = attributes[.paragraphStyle] as? NSParagraphStyle {
@@ -50,7 +50,7 @@ public class HTMLParagraphFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func present(in attributes: [NSAttributedStringKey: Any]) -> Bool {
+    public func present(in attributes: [NSAttributedStringKey: Any]) -> Bool {
         guard let style = attributes[.paragraphStyle] as? ParagraphStyle else {
             return false
         }

--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -8,12 +8,17 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
 
     /// Heading Level of this formatter
     ///
-    let headerLevel: Header.HeaderType
+    public let headerLevel: Header.HeaderType
 
+    /// HeaderType and font size map of this formatter
+    //
+    let fontSizeMap: [Header.HeaderType: Float]?
+    
     /// Designated Initializer
     ///
-    public init(headerLevel: Header.HeaderType = .h1) {
+    public init(headerLevel: Header.HeaderType = .h1, fontSizeMap: [Header.HeaderType: Float]? = nil) {
         self.headerLevel = headerLevel
+        self.fontSizeMap = fontSizeMap
     }
 
 
@@ -30,14 +35,14 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         }
 
         let defaultSize = defaultFontSize(from: attributes)
-        let header = Header(level: headerLevel, with: representation, defaultFontSize: defaultSize)
+        let header = Header(level: headerLevel, with: representation, defaultFontSize: defaultSize, fontSizeMap: fontSizeMap)
         if newParagraphStyle.headers.isEmpty {
             newParagraphStyle.appendProperty(header)
         } else {
             newParagraphStyle.replaceProperty(ofType: Header.self, with: header)
         }
  
-        let targetFontSize = CGFloat(headerFontSize(for: headerLevel, defaultSize: defaultSize))
+        let targetFontSize = CGFloat(header.fontSize())
         var resultingAttributes = attributes
         
         let newDescriptor = font.fontDescriptor.addingAttributes([.size: targetFontSize])
@@ -98,11 +103,4 @@ private extension HeaderFormatter {
         return nil
     }
 
-    func headerFontSize(for type: Header.HeaderType, defaultSize: Float?) -> Float {
-        guard type == .none, let defaultSize = defaultSize else {
-            return type.fontSize
-        }
-
-        return defaultSize
-    }
 }

--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -24,7 +24,7 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
 
     // MARK: - Overwriten Methods
 
-    public func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
+    open func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
         guard let font = attributes[.font] as? UIFont else {
             return attributes
         }
@@ -53,7 +53,7 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
+    public func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
         guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle,
             let header = paragraphStyle.headers.last,
             header.level != .none
@@ -75,7 +75,7 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func present(in attributes: [NSAttributedStringKey: Any]) -> Bool {
+    public func present(in attributes: [NSAttributedStringKey: Any]) -> Bool {
         guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle else {
             return false
         }

--- a/Aztec/Classes/Formatters/Implementations/LiFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/LiFormatter.swift
@@ -20,7 +20,7 @@ open class LiFormatter: ParagraphAttributeFormatter {
 
     // MARK: - Overwriten Methods
 
-    func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
+    public func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
         var resultingAttributes = attributes
         let newParagraphStyle = ParagraphStyle()
         if let paragraphStyle = attributes[.paragraphStyle] as? NSParagraphStyle {
@@ -34,7 +34,7 @@ open class LiFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
+    public func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
         guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle
             else {
                 return attributes
@@ -50,7 +50,7 @@ open class LiFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func present(in attributes: [NSAttributedStringKey : Any]) -> Bool {
+    public func present(in attributes: [NSAttributedStringKey : Any]) -> Bool {
         guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle
             else {
                 return false

--- a/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
@@ -33,7 +33,7 @@ open class PreFormatter: ParagraphAttributeFormatter {
 
     // MARK: - Overwriten Methods
 
-    func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
+    public func apply(to attributes: [NSAttributedStringKey: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedStringKey: Any] {
         var resultingAttributes = attributes
         let newParagraphStyle = attributes.paragraphStyle()
 
@@ -45,7 +45,7 @@ open class PreFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
+    public func remove(from attributes: [NSAttributedStringKey: Any]) -> [NSAttributedStringKey: Any] {
         guard let placeholderAttributes = placeholderAttributes else {
             return attributes
         }
@@ -58,7 +58,7 @@ open class PreFormatter: ParagraphAttributeFormatter {
         return resultingAttributes
     }
 
-    func present(in attributes: [NSAttributedStringKey : Any]) -> Bool {
+    public func present(in attributes: [NSAttributedStringKey : Any]) -> Bool {
         guard let paragraphStyle = attributes[.paragraphStyle] as? ParagraphStyle else {
             return false
         }

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -5,11 +5,11 @@ import libxml2
 /// This protocol can be implemented by an object that wants to modify the behavior
 /// of the AttributedStringParser.
 ///
-protocol AttributedStringParserCustomizer: ParagraphPropertyConverter, BaseAttachmentToElementConverter {}
+public protocol AttributedStringParserCustomizer: ParagraphPropertyConverter, BaseAttachmentToElementConverter {}
 
 /// Parses an attributed string into an HTML tree.
 ///
-class AttributedStringParser {
+open class AttributedStringParser {
     
     // MARK: - Plugin Manager
     
@@ -17,17 +17,23 @@ class AttributedStringParser {
     
     // MARK: - Initializers
     
-    init(customizer: AttributedStringParserCustomizer? = nil) {
+    public init(customizer: AttributedStringParserCustomizer? = nil) {
         self.customizer = customizer
     }
     
     // MARK: - String Attribute Converters
     
-    private let stringAttributeConverters: [StringAttributeConverter] = [
+    private let _stringAttributeConverters: [StringAttributeConverter] = [
         BoldStringAttributeConverter(),
         ConditionalItalicStringAttributeConverter(),
         UnderlineStringAttributeConverter(),
     ]
+    
+    /// List of StringAttributeConverter implementations that can convert
+    /// NSAttributedString attributes into either ElementNodes or Attributes
+    open var stringAttributeConverters: [StringAttributeConverter] {
+        return _stringAttributeConverters
+    }
     
     // MARK: - Attachment Converters
     

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -1,13 +1,13 @@
 import Foundation
 import UIKit
 
-protocol AttributedStringSerializerCustomizer {
+public protocol AttributedStringSerializerCustomizer {
     func converter(for: ElementNode) -> ElementConverter?
 }
 
 /// Composes an attributed string from an HTML tree.
 ///
-class AttributedStringSerializer {
+open class AttributedStringSerializer {
     private let customizer: AttributedStringSerializerCustomizer?
     
     // MARK: - Element Converters
@@ -33,7 +33,7 @@ class AttributedStringSerializer {
     
     // MARK: - Initializers
 
-    required init(
+    public required init(
         customizer: AttributedStringSerializerCustomizer? = nil) {
         
         self.customizer = customizer
@@ -156,8 +156,12 @@ class AttributedStringSerializer {
     // This converter should not be added to `elementFormattersMap`.  This converter is returned
     // whenever the map doesn't find a proper match.
     //
-    private(set) lazy var genericElementConverter = GenericElementConverter()
+    open var genericElementConverter: GenericElementConverter {
+        return _genericElementConverter
+    }
     
+    lazy var _genericElementConverter = GenericElementConverter()
+
     lazy var contentSerializer: ElementConverter.ContentSerializer = { [unowned self] (elementNode, intrinsicRepresentation, attributes) in
         let content = NSMutableAttributedString()
         

--- a/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
@@ -3,11 +3,11 @@ import Foundation
 /// This is the main converter class in Aztec.
 /// It takes care of converting HTML text to NSAttributedString and vice-versa.
 ///
-public class HTMLConverter {
+open class HTMLConverter {
     
     // MARK: - Plugins & Parsing
     
-    let pluginManager: PluginManager
+    public let pluginManager: PluginManager
     
     // MARK: - Initializers
     
@@ -23,15 +23,23 @@ public class HTMLConverter {
     
     let htmlToTree = HTMLParser()
     
-    private(set) lazy var treeToAttributedString: AttributedStringSerializer = {
+    private(set) lazy var _treeToAttributedString: AttributedStringSerializer = {
         return AttributedStringSerializer(customizer: pluginManager)
     }()
     
+    open var treeToAttributedString: AttributedStringSerializer {
+        return _treeToAttributedString
+    }
+    
     // MARK: - Converters: AttributedString -> HTML
     
-    private(set) lazy var attributedStringToTree: AttributedStringParser = {
+    private(set) lazy var _attributedStringToTree: AttributedStringParser = {
         return AttributedStringParser(customizer: pluginManager)
     }()
+    
+    open var attributedStringToTree: AttributedStringParser {
+        return _attributedStringToTree
+    }
     
     private(set) lazy var treeToHTML: HTMLSerializer = {
         return HTMLSerializer(customizer: pluginManager)

--- a/Aztec/Classes/Plugin/PluginManager.swift
+++ b/Aztec/Classes/Plugin/PluginManager.swift
@@ -3,7 +3,7 @@ import UIKit
 
 /// This class managed the loading and provides an execution interface for plugins.
 ///
-class PluginManager {
+public class PluginManager {
     
     // MARK: - Plugin Loading
     
@@ -77,7 +77,7 @@ class PluginManager {
 // MARK: - AttributedStringSerializerCustomizer
 
 extension PluginManager: AttributedStringSerializerCustomizer {
-    func converter(for element: ElementNode) -> ElementConverter? {
+    public func converter(for element: ElementNode) -> ElementConverter? {
         for plugin in plugins {
             if let customizer = plugin.inputCustomizer,
                 let converter = customizer.converter(for: element) as ElementConverter? {
@@ -92,7 +92,7 @@ extension PluginManager: AttributedStringSerializerCustomizer {
 // MARK: - AttributedStringParserCustomizer
 
 extension PluginManager: AttributedStringParserCustomizer {
-    func convert(_ paragraphProperty: ParagraphProperty) -> ElementNode? {
+    public func convert(_ paragraphProperty: ParagraphProperty) -> ElementNode? {
         for plugin in plugins {
             if let customizer = plugin.outputCustomizer,
                 let element = customizer.convert(paragraphProperty) {
@@ -104,7 +104,7 @@ extension PluginManager: AttributedStringParserCustomizer {
         return nil
     }
     
-    func convert(_ attachment: NSTextAttachment, attributes: [NSAttributedStringKey : Any]) -> [Node]? {
+    public func convert(_ attachment: NSTextAttachment, attributes: [NSAttributedStringKey : Any]) -> [Node]? {
         for plugin in plugins {
             if let customizer = plugin.outputCustomizer,
                 let elements = customizer.convert(attachment, attributes: attributes) {

--- a/Aztec/Classes/TextKit/ParagraphProperty/Header.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/Header.swift
@@ -19,7 +19,7 @@ open class Header: ParagraphProperty {
         case h5 = 5
         case h6 = 6
 
-        public static var fontSizeMap: [HeaderType: Float] = {
+        public static var defaultFontSizeMap: [HeaderType: Float] = {
             return [
                 .h1: 36,
                 .h2: 24,
@@ -30,9 +30,13 @@ open class Header: ParagraphProperty {
                 .none: Constants.defaultFontSize
                 ]
         }()
-
-        public var fontSize: Float {
-            let fontSize = HeaderType.fontSizeMap[self] ?? Constants.defaultFontSize
+        
+        public func fontSize(for fontSizeMap: [HeaderType: Float]?) -> Float {
+            var effectiveFontSizeMap: [HeaderType: Float] = HeaderType.defaultFontSizeMap
+            if let fontSizeMap = fontSizeMap {
+                effectiveFontSizeMap = fontSizeMap
+            }
+            let fontSize = effectiveFontSizeMap[self] ?? Constants.defaultFontSize
 
             if #available(iOS 11.0, *) {
                 return Float(UIFontMetrics.default.scaledValue(for: CGFloat(fontSize)))
@@ -52,12 +56,20 @@ open class Header: ParagraphProperty {
     ///
     let defaultFontSize: Float
 
+    /// HeaderType and font size map
+    //
+    let fontSizeMap: [Header.HeaderType: Float]?
 
     // MARK: - Initializers
 
-    init(level: HeaderType, with representation: HTMLRepresentation? = nil, defaultFontSize: Float? = nil) {
+    init(level: HeaderType,
+         with representation: HTMLRepresentation? = nil,
+         defaultFontSize: Float? = nil,
+         fontSizeMap: [Header.HeaderType: Float]? = nil)
+    {
         self.defaultFontSize = defaultFontSize ?? Constants.defaultFontSize
         self.level = level
+        self.fontSizeMap = fontSizeMap
         super.init(with: representation)
     }
     
@@ -75,11 +87,18 @@ open class Header: ParagraphProperty {
         } else {
             defaultFontSize = Constants.defaultFontSize
         }
-
+        fontSizeMap = nil
         super.init(coder: aDecoder)
     }
 
-
+    func fontSize() -> Float {
+        guard level == .none else {
+            return level.fontSize(for: fontSizeMap)
+        }
+        
+        return defaultFontSize
+    }
+    
     // MARK: - NSCoder
 
     public override func encode(with aCoder: NSCoder) {

--- a/Aztec/Classes/TextKit/ParagraphProperty/Header.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/Header.swift
@@ -31,6 +31,10 @@ open class Header: ParagraphProperty {
                 ]
         }()
         
+        public var fontSize: Float {
+            return fontSize(for: nil)
+        }
+        
         public func fontSize(for fontSizeMap: [HeaderType: Float]?) -> Float {
             var effectiveFontSizeMap: [HeaderType: Float] = HeaderType.defaultFontSizeMap
             if let fontSizeMap = fontSizeMap {

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -81,7 +81,11 @@ open class TextStorage: NSTextStorage {
     
     // MARK: - HTML Conversion
     
-    let htmlConverter = HTMLConverter()
+    private var _htmlConverter = HTMLConverter()
+
+    open var htmlConverter: HTMLConverter {
+        return _htmlConverter
+    }
     
     // MARK: - PluginManager
     

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -911,13 +911,6 @@ open class TextView: UITextView {
         }
         notifyTextViewDidChange()
     }
-
-    public func apply(formattingIdentifier: FormattingIdentifier, atRange range: NSRange, remove: Bool) {
-        guard let formatter = formatterMap[formattingIdentifier] else {
-            return
-        }
-        apply(formatter: formatter, atRange: range, remove: remove)
-    }
     
     func apply(formatter: AttributeFormatter, atRange range: NSRange, remove: Bool) {
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -221,7 +221,20 @@ open class TextView: UITextView {
 
     // MARK: - Properties: UI Defaults
 
-    public let defaultFont: UIFont
+    public var defaultFont: UIFont {
+        set {
+            if #available(iOS 11.0, *) {
+                _defaultFont = UIFontMetrics.default.scaledFont(for: newValue)
+            } else {
+                _defaultFont = newValue
+            }
+        }
+        get {
+            return _defaultFont
+        }
+    }
+    private var _defaultFont: UIFont
+    
     public let defaultParagraphStyle: ParagraphStyle
     var defaultMissingImage: UIImage
     
@@ -399,9 +412,9 @@ open class TextView: UITextView {
         defaultMissingImage: UIImage) {
 
         if #available(iOS 11.0, *) {
-            self.defaultFont = UIFontMetrics.default.scaledFont(for: defaultFont)
+            self._defaultFont = UIFontMetrics.default.scaledFont(for: defaultFont)
         } else {
-            self.defaultFont = defaultFont
+            self._defaultFont = defaultFont
         }
         self.defaultParagraphStyle = defaultParagraphStyle
         self.defaultMissingImage = defaultMissingImage
@@ -421,9 +434,9 @@ open class TextView: UITextView {
     required public init?(coder aDecoder: NSCoder) {
         let font = UIFont.systemFont(ofSize: 14)
         if #available(iOS 11.0, *) {
-            self.defaultFont = UIFontMetrics.default.scaledFont(for: font)
+            self._defaultFont = UIFontMetrics.default.scaledFont(for: font)
         } else {
-            self.defaultFont = font
+            self._defaultFont = font
         }
 
         defaultParagraphStyle = ParagraphStyle.default

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -920,6 +920,13 @@ open class TextView: UITextView {
         notifyTextViewDidChange()
     }
 
+    public func apply(formattingIdentifier: FormattingIdentifier, atRange range: NSRange, remove: Bool) {
+        guard let formatter = TextView.formatterMap[formattingIdentifier] else {
+            return
+        }
+        apply(formatter: formatter, atRange: range, remove: remove)
+    }
+    
     func apply(formatter: AttributeFormatter, atRange range: NSRange, remove: Bool) {
 
         let applicationRange = formatter.applicationRange(for: range, in: textStorage)


### PR DESCRIPTION
This PR is child PR of https://github.com/wordpress-mobile/gutenberg-mobile/pull/517

Basically some access modifiers are updated to be able to override some classes related to Heading formatting.

To test:
Test with steps in:
https://github.com/wordpress-mobile/gutenberg-mobile/pull/517
WPiOS PR: TBD

