### PR TITLE
Make heading styling distinguishable from paragraph

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		599F25541D8BC9A1002871D6 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25321D8BC9A1002871D6 /* TextView.swift */; };
 		74EEC71B1FAB6EC900B989E3 /* UIImage+Resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74EEC71A1FAB6EC900B989E3 /* UIImage+Resize.swift */; };
 		914CD9E72200B2D200DDD5C9 /* ShadowBoldFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914CD9E62200B2D200DDD5C9 /* ShadowBoldFormatter.swift */; };
+		917E22132201D2A5008AC826 /* ShadowBoldFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917E22122201D2A5008AC826 /* ShadowBoldFormatterTests.swift */; };
 		B52220D31F86A05400D7E092 /* TextViewStubDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52220D21F86A05400D7E092 /* TextViewStubDelegate.swift */; };
 		B524228D1F30C039002E7C6C /* HTMLDiv.swift in Sources */ = {isa = PBXBuildFile; fileRef = B524228C1F30C039002E7C6C /* HTMLDiv.swift */; };
 		B524228F1F30C098002E7C6C /* HTMLDivFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B524228E1F30C098002E7C6C /* HTMLDivFormatter.swift */; };
@@ -301,6 +302,7 @@
 		59FEA06D1D8BDFA700D138DF /* InNodeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InNodeConverterTests.swift; sourceTree = "<group>"; };
 		74EEC71A1FAB6EC900B989E3 /* UIImage+Resize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resize.swift"; sourceTree = "<group>"; };
 		914CD9E62200B2D200DDD5C9 /* ShadowBoldFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowBoldFormatter.swift; sourceTree = "<group>"; };
+		917E22122201D2A5008AC826 /* ShadowBoldFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowBoldFormatterTests.swift; sourceTree = "<group>"; };
 		B52220D21F86A05400D7E092 /* TextViewStubDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewStubDelegate.swift; sourceTree = "<group>"; };
 		B524228C1F30C039002E7C6C /* HTMLDiv.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLDiv.swift; sourceTree = "<group>"; };
 		B524228E1F30C098002E7C6C /* HTMLDivFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLDivFormatter.swift; sourceTree = "<group>"; };
@@ -830,6 +832,7 @@
 				FFD436971E3180A500A0E26F /* FontFormatterTests.swift */,
 				B542D6411E9EB122009D12D3 /* PreFormaterTests.swift */,
 				B5C16A621F4DF77300B113CF /* HeaderFormatterTests.swift */,
+				917E22122201D2A5008AC826 /* ShadowBoldFormatterTests.swift */,
 			);
 			path = Formatters;
 			sourceTree = "<group>";
@@ -1704,6 +1707,7 @@
 				B542D6421E9EB122009D12D3 /* PreFormaterTests.swift in Sources */,
 				B5D575811F226FF4003A62F6 /* UnsupportedHTMLTests.swift in Sources */,
 				F17BC8A51F4E4F5A00398E2B /* TextNodeTests.swift in Sources */,
+				917E22132201D2A5008AC826 /* ShadowBoldFormatterTests.swift in Sources */,
 				F185A5B12123C0DA00DDFAB1 /* NSAttributedStringAttachmentsTests.swift in Sources */,
 				F1FC705321383F98007AAFB3 /* UIStackViewHelpersTests.swift in Sources */,
 				F126ADC721553E3C008F7DD1 /* BoldElementAttributeConverterTests.swift in Sources */,

--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		599F25531D8BC9A1002871D6 /* TextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25311D8BC9A1002871D6 /* TextStorage.swift */; };
 		599F25541D8BC9A1002871D6 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599F25321D8BC9A1002871D6 /* TextView.swift */; };
 		74EEC71B1FAB6EC900B989E3 /* UIImage+Resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74EEC71A1FAB6EC900B989E3 /* UIImage+Resize.swift */; };
+		914CD9E72200B2D200DDD5C9 /* ShadowBoldFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914CD9E62200B2D200DDD5C9 /* ShadowBoldFormatter.swift */; };
 		B52220D31F86A05400D7E092 /* TextViewStubDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52220D21F86A05400D7E092 /* TextViewStubDelegate.swift */; };
 		B524228D1F30C039002E7C6C /* HTMLDiv.swift in Sources */ = {isa = PBXBuildFile; fileRef = B524228C1F30C039002E7C6C /* HTMLDiv.swift */; };
 		B524228F1F30C098002E7C6C /* HTMLDivFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B524228E1F30C098002E7C6C /* HTMLDivFormatter.swift */; };
@@ -299,6 +300,7 @@
 		59FEA06B1D8BDFA700D138DF /* InAttributeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAttributeConverterTests.swift; sourceTree = "<group>"; };
 		59FEA06D1D8BDFA700D138DF /* InNodeConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InNodeConverterTests.swift; sourceTree = "<group>"; };
 		74EEC71A1FAB6EC900B989E3 /* UIImage+Resize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resize.swift"; sourceTree = "<group>"; };
+		914CD9E62200B2D200DDD5C9 /* ShadowBoldFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowBoldFormatter.swift; sourceTree = "<group>"; };
 		B52220D21F86A05400D7E092 /* TextViewStubDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewStubDelegate.swift; sourceTree = "<group>"; };
 		B524228C1F30C039002E7C6C /* HTMLDiv.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLDiv.swift; sourceTree = "<group>"; };
 		B524228E1F30C098002E7C6C /* HTMLDivFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLDivFormatter.swift; sourceTree = "<group>"; };
@@ -958,6 +960,7 @@
 			children = (
 				F12F58561EF20394008AE298 /* BlockquoteFormatter.swift */,
 				F18986E21EF204180060EDBA /* BoldFormatter.swift */,
+				914CD9E62200B2D200DDD5C9 /* ShadowBoldFormatter.swift */,
 				F1BDDDE420603C18000714E1 /* FigcaptionFormatter.swift */,
 				F1BDDDE62060403B000714E1 /* FigureFormatter.swift */,
 				F12F58571EF20394008AE298 /* ColorFormatter.swift */,
@@ -1506,6 +1509,7 @@
 				F1656FDE2152A6A6009C7E3A /* CiteStringAttributeConverter.swift in Sources */,
 				599F254B1D8BC9A1002871D6 /* String+RangeConversion.swift in Sources */,
 				599F25481D8BC9A1002871D6 /* Metrics.swift in Sources */,
+				914CD9E72200B2D200DDD5C9 /* ShadowBoldFormatter.swift in Sources */,
 				F1BDDDE72060403B000714E1 /* FigureFormatter.swift in Sources */,
 				B59C9F9F1DF74BB80073B1D6 /* UIFont+Traits.swift in Sources */,
 				F10BE61A1EA7AE9D002E4625 /* NSAttributedString+ReplaceOcurrences.swift in Sources */,

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
@@ -16,7 +16,7 @@ class GenericElementConverter: ElementConverter {
     // MARK: - Built-in formatter instances
     
     lazy var blockquoteFormatter = BlockquoteFormatter()
-    lazy var boldFormatter = BoldFormatter()
+    lazy var boldFormatter = ShadowBoldFormatter()
     lazy var divFormatter = HTMLDivFormatter()
     lazy var h1Formatter = HeaderFormatter(headerLevel: .h1)
     lazy var h2Formatter = HeaderFormatter(headerLevel: .h2)

--- a/Aztec/Classes/Converters/StringAttributesToAttributes/Implementations/BoldStringAttributeConverter.swift
+++ b/Aztec/Classes/Converters/StringAttributesToAttributes/Implementations/BoldStringAttributeConverter.swift
@@ -24,9 +24,7 @@ open class BoldStringAttributeConverter: StringAttributeConverter {
             elementNodes.append(representationElement.toElementNode())
         }
         
-        if let font = attributes[.font] as? UIFont,
-            font.containsTraits(.traitBold) {
-            
+        if shouldEnableBoldElement(for: attributes) {
             return enableBold(in: elementNodes)
         } else {
             return disableBold(in: elementNodes)
@@ -72,6 +70,31 @@ open class BoldStringAttributeConverter: StringAttributeConverter {
         // Nothing was found to represent bold... just add the element.
         elementNodes.append(ElementNode(type: .strong))
         return elementNodes
+    }
+    
+    func shouldEnableBoldElement(for attributes: [NSAttributedString.Key : Any]) -> Bool {
+        if isHeading(for: attributes) {
+            // If this is a heading then shadow represents <strong> element since
+            // headings are bold by default
+            return hasShadowTrait(for: attributes)
+        }
+        return hasBoldTrait(for: attributes)
+    }
+    
+    func isHeading(for attributes: [NSAttributedString.Key : Any]) -> Bool {
+        return attributes[.headingRepresentation] != nil
+    }
+    
+    func hasShadowTrait(for attributes: [NSAttributedString.Key : Any]) -> Bool {
+        return attributes[.shadow] != nil
+    }
+    
+    func hasBoldTrait(for attributes: [NSAttributedString.Key : Any]) -> Bool {
+        if let font = attributes[.font] as? UIFont,
+            font.containsTraits(.traitBold) {
+            return true
+        }
+        return false
     }
 }
 

--- a/Aztec/Classes/Extensions/NSAttributedStringKey+Aztec.swift
+++ b/Aztec/Classes/Extensions/NSAttributedStringKey+Aztec.swift
@@ -2,6 +2,10 @@ import UIKit
 
 public extension NSAttributedStringKey {
 
+    /// Key used to store Header tags Metadata, by our HeaderFormatter.
+    ///
+    public static let headingRepresentation: NSAttributedString.Key = NSAttributedString.Key("headingRepresentation")
+
     /// Key used to store Bold Tag Metadata, by our BoldFormatter.
     ///
     public static let boldHtmlRepresentation = NSAttributedStringKey("Bold.htmlRepresentation")

--- a/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/HeaderFormatter.swift
@@ -41,10 +41,12 @@ open class HeaderFormatter: ParagraphAttributeFormatter {
         var resultingAttributes = attributes
         
         let newDescriptor = font.fontDescriptor.addingAttributes([.size: targetFontSize])
-        
+        var newFont = UIFont(descriptor: newDescriptor, size: targetFontSize)
+        newFont = newFont.modifyTraits(.traitBold, enable: true)
+
         resultingAttributes[.paragraphStyle] = newParagraphStyle
-        resultingAttributes[.font] = UIFont(descriptor: newDescriptor, size: targetFontSize)
-        
+        resultingAttributes[.font] = newFont
+        resultingAttributes[.headingRepresentation] = headerLevel.rawValue
         return resultingAttributes
     }
 

--- a/Aztec/Classes/Formatters/Implementations/ShadowBoldFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/ShadowBoldFormatter.swift
@@ -12,11 +12,12 @@ class ShadowBoldFormatter: AttributeFormatter {
         }
         
         static let blurRadiusNoBlur: CGFloat = 0.0
+        static let defaultColor: UIColor = .black
         
         // Creates a no blur NSShadow instance with given offset values
         static func shadow(width: CGFloat = DefaultOffset.width,
                            height: CGFloat = DefaultOffset.height,
-                           color: UIColor = UIColor.black) -> NSShadow {
+                           color: UIColor) -> NSShadow {
             let shadow = NSShadow()
             shadow.shadowBlurRadius = Shadow.blurRadiusNoBlur
             shadow.shadowOffset = CGSize(width: width, height: height)
@@ -49,13 +50,13 @@ class ShadowBoldFormatter: AttributeFormatter {
         }
         var resultingAttributes = attributes
         guard let font = resultingAttributes[.font] as? UIFont else {
-            resultingAttributes[.shadow] = Shadow.shadow()
+            resultingAttributes[.shadow] = Shadow.shadow(color: shadowColor(from: attributes))
             resultingAttributes[.kern] =  Shadow.DefaultOffset.width
             return resultingAttributes
         }
         //Calculate letter spacing and shadow offset with respect to the font size
         let shadowOffsetWidth = Shadow.offset(with: font.pointSize)
-        resultingAttributes[.shadow] = Shadow.shadow(width: shadowOffsetWidth)
+        resultingAttributes[.shadow] = Shadow.shadow(width: shadowOffsetWidth, color: shadowColor(from: attributes))
         resultingAttributes[.kern] = shadowOffsetWidth
         resultingAttributes[.boldHtmlRepresentation] = representation
         
@@ -86,5 +87,12 @@ class ShadowBoldFormatter: AttributeFormatter {
     
     func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange {
         return range
+    }
+    
+    private func shadowColor(from attributes: [NSAttributedString.Key: Any]) -> UIColor {
+        if let color = attributes[.foregroundColor] as? UIColor {
+            return color
+        }
+        return Shadow.defaultColor
     }
 }

--- a/Aztec/Classes/Formatters/Implementations/ShadowBoldFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/ShadowBoldFormatter.swift
@@ -1,0 +1,90 @@
+import UIKit
+
+/// ShadowBoldFormatter uses 2 different mechanisms to apply bold effect:
+/// 1. Headings: Applies shadow effect because headings are already bold by default
+/// 2. Other texts: Applies bold font trait. Uses BoldFormatter inside.
+class ShadowBoldFormatter: AttributeFormatter {
+    
+    private enum Shadow {
+        enum DefaultOffset {
+            static let width: CGFloat = 0.75
+            static let height: CGFloat = 0.0
+        }
+        
+        static let blurRadiusNoBlur: CGFloat = 0.0
+        
+        // Creates a no blur NSShadow instance with given offset values
+        static func shadow(width: CGFloat = DefaultOffset.width,
+                           height: CGFloat = DefaultOffset.height,
+                           color: UIColor = UIColor.black) -> NSShadow {
+            let shadow = NSShadow()
+            shadow.shadowBlurRadius = Shadow.blurRadiusNoBlur
+            shadow.shadowOffset = CGSize(width: width, height: height)
+            shadow.shadowColor = color
+            return shadow
+        }
+        
+        // Calculate Shadow offset due to font size
+        static func offset(with fontSize: CGFloat) -> CGFloat {
+            if fontSize >= 22 {
+                return 0.82
+            } else if fontSize >= 20 && fontSize < 22 {
+                return 0.78
+            } else if fontSize >= 18 && fontSize < 20 {
+                return 0.75
+            } else if fontSize >= 16 && fontSize < 18 {
+                return 0.72
+            } else {
+                return 0.7
+            }
+        }
+    }
+    
+    private let htmlRepresentationKey: NSAttributedString.Key = .boldHtmlRepresentation
+    private let plainBoldFormatter = BoldFormatter()
+    
+    func apply(to attributes: [NSAttributedString.Key: Any], andStore representation: HTMLRepresentation?) -> [NSAttributedString.Key: Any] {
+        guard attributes[.headingRepresentation] != nil else {
+            return plainBoldFormatter.apply(to: attributes, andStore: representation)
+        }
+        var resultingAttributes = attributes
+        guard let font = resultingAttributes[.font] as? UIFont else {
+            resultingAttributes[.shadow] = Shadow.shadow()
+            resultingAttributes[.kern] =  Shadow.DefaultOffset.width
+            return resultingAttributes
+        }
+        //Calculate letter spacing and shadow offset with respect to the font size
+        let shadowOffsetWidth = Shadow.offset(with: font.pointSize)
+        resultingAttributes[.shadow] = Shadow.shadow(width: shadowOffsetWidth)
+        resultingAttributes[.kern] = shadowOffsetWidth
+        resultingAttributes[.boldHtmlRepresentation] = representation
+        
+        return resultingAttributes
+    }
+    
+    func remove(from attributes: [NSAttributedString.Key: Any]) -> [NSAttributedString.Key: Any] {
+        guard attributes[.headingRepresentation] != nil else {
+            return plainBoldFormatter.remove(from: attributes)
+        }
+        var resultingAttributes = attributes
+        
+        resultingAttributes.removeValue(forKey: .shadow)
+        resultingAttributes.removeValue(forKey: .kern)
+        
+        resultingAttributes.removeValue(forKey: .boldHtmlRepresentation)
+        
+        return resultingAttributes
+    }
+    
+    func present(in attributes: [NSAttributedString.Key: Any]) -> Bool {
+        guard attributes[.headingRepresentation] != nil else {
+            return plainBoldFormatter.present(in: attributes)
+        }
+
+        return attributes[.shadow] != nil
+    }
+    
+    func applicationRange(for range: NSRange, in text: NSAttributedString) -> NSRange {
+        return range
+    }
+}

--- a/Aztec/Classes/TextKit/ParagraphProperty/Header.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/Header.swift
@@ -21,12 +21,12 @@ open class Header: ParagraphProperty {
 
         public static var fontSizeMap: [HeaderType: Float] = {
             return [
-                .h1: 36,
-                .h2: 24,
-                .h3: 21,
-                .h4: 16,
-                .h5: 14,
-                .h6: 11,
+                .h1: 24,
+                .h2: 22,
+                .h3: 20,
+                .h4: 18,
+                .h5: 16,
+                .h6: 14,
                 .none: Constants.defaultFontSize
                 ]
         }()
@@ -98,7 +98,7 @@ open class Header: ParagraphProperty {
 //
 private extension Header {
     struct Constants {
-        static let defaultFontSize = Float(14)
+        static let defaultFontSize = Float(16)
     }
 
     struct Keys {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -769,7 +769,7 @@ open class TextView: UITextView {
     // MARK: - Getting format identifiers
 
     private static let formatterMap: [FormattingIdentifier: AttributeFormatter] = [
-        .bold: BoldFormatter(),
+        .bold: ShadowBoldFormatter(),
         .italic: ItalicFormatter(),
         .underline: UnderlineFormatter(),
         .strikethrough: StrikethroughFormatter(),
@@ -939,7 +939,7 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleBold(range: NSRange) {
-        let formatter = BoldFormatter()
+        let formatter = ShadowBoldFormatter()
         toggle(formatter: formatter, atRange: range)
     }
 

--- a/AztecTests/Formatters/ShadowBoldFormatterTests.swift
+++ b/AztecTests/Formatters/ShadowBoldFormatterTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import Aztec
+
+class ShadowBoldFormatterTests: XCTestCase {
+
+    private let shadowBoldFormatter = ShadowBoldFormatter()
+    
+    func testApplyAttributesOnHeading() {
+        var attributes: [NSAttributedStringKey : Any] = [.font: UIFont.systemFont(ofSize: UIFont.systemFontSize)]
+        var font: UIFont?
+        attributes[.headingRepresentation] = Header.HeaderType.h1.rawValue
+        attributes = shadowBoldFormatter.apply(to: attributes)
+        font = attributes[.font] as? UIFont
+        XCTAssertNotNil(font)
+        XCTAssertNotNil(attributes[.shadow])
+        XCTAssertNotNil(attributes[.kern])
+    }
+    
+    func testApplyAttributesOnNonHeading() {
+        var attributes: [NSAttributedStringKey : Any] = [.font: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)]
+        var font: UIFont?
+        attributes = shadowBoldFormatter.apply(to: attributes)
+        font = attributes[.font] as? UIFont
+        XCTAssertNotNil(font)
+        XCTAssertTrue(font!.containsTraits(.traitBold))
+        XCTAssertNil(attributes[.shadow])
+        XCTAssertNil(attributes[.kern])
+    }
+
+    func testRemoveAttributesOnHeading() {
+        var attributes: [NSAttributedStringKey : Any] = [.font: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)]
+        var font: UIFont?
+        attributes[.headingRepresentation] = Header.HeaderType.h1.rawValue
+
+        //test removing a existent attribute
+        attributes = shadowBoldFormatter.remove(from: attributes)
+        font = attributes[.font] as? UIFont
+        XCTAssertNotNil(font)
+        XCTAssertTrue(font!.containsTraits(.traitBold)) //we should keep bold trait for hedings
+        XCTAssertNil(attributes[.shadow])
+        XCTAssertNil(attributes[.kern])
+    }
+
+    func testRemoveAttributesOnNonHeading() {
+        var attributes: [NSAttributedStringKey : Any] = [.font: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)]
+        var font: UIFont?
+        attributes = shadowBoldFormatter.remove(from: attributes)
+        font = attributes[.font] as? UIFont
+        XCTAssertNotNil(font)
+        XCTAssertFalse(font!.containsTraits(.traitBold))
+        XCTAssertNil(attributes[.shadow])
+        XCTAssertNil(attributes[.kern])
+    }
+    
+    func testPresentAttributesOnHeading() {
+        var attributes: [NSAttributedStringKey : Any] = [.font: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)]
+        attributes[.headingRepresentation] = Header.HeaderType.h1.rawValue
+        XCTAssertFalse(shadowBoldFormatter.present(in: attributes))
+        attributes[.shadow] = NSShadow()
+        XCTAssertTrue(shadowBoldFormatter.present(in: attributes))
+    }
+    
+    func testPresentAttributesOnNonHeading() {
+        var attributes: [NSAttributedStringKey : Any] = [.font: UIFont.boldSystemFont(ofSize: UIFont.systemFontSize)]
+        XCTAssertTrue(shadowBoldFormatter.present(in: attributes))
+        attributes = [.font: UIFont.systemFont(ofSize: UIFont.systemFontSize)]
+        XCTAssertFalse(shadowBoldFormatter.present(in: attributes))
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/351

This PR updates the style of Heading block based on https://github.com/wordpress-mobile/gutenberg-mobile/issues/351#issuecomment-456522533 

WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/10912
mobile-gutenberg PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/525

**Changes Made**
1. Heading font sizes are updated
2. Headings made bold by default
3. ShadowBoldFormatter is added to mimic bolding on already bold headings, it uses shadow attribute to mimic the extra boldness.

**The Problem**
We want to use bold font with Heading blocks by default. However, we don't want to generate bold output in the html unless user intentionally selects B option from toolbar. That makes it a bit challenging for us to decide how to make this happen. This PR proposes a solution that mimics bolding behavior by giving extra shadow and letter spacing.

**To Test**

1. Example app

1.1. Test Heading

- Verify that the font looks bolder than it was before
- Select part of the text and tap B button
- Verify that the selected area gets bolder
- Switch between H2 H3 H4 types of heading sizes
- Verify that the boldness of selected area is kept

1.2 Test paragraph

Test that paragraph is not effected:
- Paragraphs should continue to appear non-bold by default
- Select part of the text and tap B button
- Verify that the selected area gets bolder

2. Test with Gutenberg and Classic editor by Test Steps in WPiOS PR
https://github.com/wordpress-mobile/WordPress-iOS/pull/10912