### PR TITLE
Fix bold converting issue.

### DIFF
--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
@@ -233,7 +233,7 @@ private extension GenericElementConverter {
         let equivalentNames = element.type.equivalentNames
         
         for (key, formatter) in elementFormattersMap {
-            if equivalentNames.contains(key.rawValue) {
+            if equivalentNames.contains(key) {
                 return formatter
             }
         }

--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -128,19 +128,17 @@ extension Element {
     }
 
     var equivalentNames: [Element] {
-        get {
-            switch self {
-            case .h1: return [self]
-            case .strong: return [self, Element.b]
-            case .em: return [self, Element.i]
-            case .b: return [self, Element.strong]
-            case .i: return [self, Element.em]
-            case .s: return [self, Element.strike, Element.del]
-            case .del: return [self, Element.strike, Element.s]
-            case .strike: return [self, Element.del, Element.s]
-            default:
-                return [self]
-            }
+        switch self {
+        case .h1: return [self]
+        case .strong: return [self, Element.b]
+        case .em: return [self, Element.i]
+        case .b: return [self, Element.strong]
+        case .i: return [self, Element.em]
+        case .s: return [self, Element.strike, Element.del]
+        case .del: return [self, Element.strike, Element.s]
+        case .strike: return [self, Element.del, Element.s]
+        default:
+            return [self]
         }
     }    
 }

--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -43,7 +43,7 @@ public struct Element: RawRepresentable, Hashable {
     }
     
     public init(_ rawValue: RawValue) {
-        self.rawValue = rawValue
+        self.rawValue = rawValue.lowercased()
     }
     
     public func isBlockLevel() -> Bool {
@@ -127,19 +127,19 @@ extension Element {
         return Element(name).isBlockLevel()
     }
 
-    var equivalentNames: [String] {
+    var equivalentNames: [Element] {
         get {
             switch self {
-            case .h1: return [self.rawValue]
-            case .strong: return [self.rawValue, Element.b.rawValue]
-            case .em: return [self.rawValue, Element.i.rawValue]
-            case .b: return [self.rawValue, Element.strong.rawValue]
-            case .i: return [self.rawValue, Element.em.rawValue]
-            case .s: return [self.rawValue, Element.strike.rawValue, Element.del.rawValue]
-            case .del: return [self.rawValue, Element.strike.rawValue, Element.s.rawValue]
-            case .strike: return [self.rawValue, Element.del.rawValue, Element.s.rawValue]
+            case .h1: return [self]
+            case .strong: return [self, Element.b]
+            case .em: return [self, Element.i]
+            case .b: return [self, Element.strong]
+            case .i: return [self, Element.em]
+            case .s: return [self, Element.strike, Element.del]
+            case .del: return [self, Element.strike, Element.s]
+            case .strike: return [self, Element.del, Element.s]
             default:
-                return [self.rawValue]
+                return [self]
             }
         }
     }    

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -275,7 +275,7 @@ public class ElementNode: Node {
     }
 
     public func isNodeType(_ type: Element) -> Bool {
-        return type.equivalentNames.contains(name.lowercased())
+        return type.equivalentNames.contains(Element(name))
     }
     
     func hasChildren() -> Bool {

--- a/AztecTests/New Group/StringAttributesToAttributes/BoldStringAttributeConverterTests.swift
+++ b/AztecTests/New Group/StringAttributesToAttributes/BoldStringAttributeConverterTests.swift
@@ -77,6 +77,24 @@ class BoldStringAttributeConverterTests: XCTestCase {
         XCTAssertEqual(strongElement.attributes[0], exampleAttribute)
     }
     
+    func testBoldConversionWithEquivalentElementRepresentation() {
+        let exampleAttribute = Attribute(type: .style, value: .string("someStyle"))
+        let element = ElementNode(type: .b, attributes: [exampleAttribute], children: [])
+        let elementRepresentation = HTMLElementRepresentation(element)
+        var attributes = [NSAttributedStringKey: Any]()
+        
+        attributes[.font] = UIFont.boldSystemFont(ofSize: 14)
+        attributes[.boldHtmlRepresentation] = HTMLRepresentation(for: .element(elementRepresentation))
+        
+        let elementNodes = converter.convert(attributes: attributes, andAggregateWith: [])
+        
+        XCTAssertEqual(elementNodes.count, 1)
+        
+        let strongElement = elementNodes[0]
+        XCTAssertEqual(strongElement.type, .b)
+        XCTAssertEqual(strongElement.attributes.count, 1)
+        XCTAssertEqual(strongElement.attributes[0], exampleAttribute)
+    }
 
     func testBoldConversionWithElementRepresentation2() {
         let cssAttribute = CSSAttribute.italic


### PR DESCRIPTION
## Description:

There was an issue with a bold converter that was causing `b` tags to convert to a combination of `b` and `strong` tags.  This PR fixes that.

Fixes https://github.com/wordpress-mobile/AztecEditor-iOS/issues/1137

Additionally, this PR simplifies the `equivalentNames` calculated properly to work directly with `Elements` and to remove some extra code that wasn't needed.

## Testing:

### Test 1:

Run the unit tests.

### Test 2:

1. Open the empty editor demo.
2. Switch to HTML mode.
3. Type `<b>Hello!</b>`.
4. Switch to visual and back to HTML mode.

Make sure the bold tag hasn't been duplicated with a `strong` tag.