### PR TITLE
Standardize string-attribute-conversion logic.

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		F1C05B9D1E37FA77007510EA /* String+CharacterName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B9C1E37FA77007510EA /* String+CharacterName.swift */; };
 		F1C05B9F1E37FD2F007510EA /* NSAttributedString+CharacterName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C05B9E1E37FD2F007510EA /* NSAttributedString+CharacterName.swift */; };
 		F1CF7F9020E14E2200B24173 /* AttributedStringParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CF7F8F20E14E2200B24173 /* AttributedStringParser.swift */; };
+		F1D7F525221CE2D20065555D /* HTMLStyleToggler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D7F524221CE2D20065555D /* HTMLStyleToggler.swift */; };
 		F1DC21B42199D5D6007C189E /* GenericElementConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DC21B32199D5D6007C189E /* GenericElementConverterTests.swift */; };
 		F1DE83D51EF20493009269E6 /* UIColor+Parsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DE83D41EF20493009269E6 /* UIColor+Parsers.swift */; };
 		F1E1B7782062BE6B004642BB /* ParagraphStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E1B7772062BE6B004642BB /* ParagraphStyleTests.swift */; };
@@ -458,6 +459,7 @@
 		F1C05B9C1E37FA77007510EA /* String+CharacterName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+CharacterName.swift"; sourceTree = "<group>"; };
 		F1C05B9E1E37FD2F007510EA /* NSAttributedString+CharacterName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+CharacterName.swift"; sourceTree = "<group>"; };
 		F1CF7F8F20E14E2200B24173 /* AttributedStringParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributedStringParser.swift; sourceTree = "<group>"; };
+		F1D7F524221CE2D20065555D /* HTMLStyleToggler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLStyleToggler.swift; sourceTree = "<group>"; };
 		F1DC21B32199D5D6007C189E /* GenericElementConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericElementConverterTests.swift; sourceTree = "<group>"; };
 		F1DE83D41EF20493009269E6 /* UIColor+Parsers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Parsers.swift"; sourceTree = "<group>"; };
 		F1E1B7772062BE6B004642BB /* ParagraphStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParagraphStyleTests.swift; sourceTree = "<group>"; };
@@ -1039,6 +1041,7 @@
 				F15BA60421514F2B00424120 /* Base */,
 				F1656FE22152AB3E009C7E3A /* ConditionalConverters */,
 				F15BA60521514F3700424120 /* Implementations */,
+				F1D7F52D221CEF7D0065555D /* Utility */,
 			);
 			path = StringAttributesToAttributes;
 			sourceTree = "<group>";
@@ -1260,6 +1263,14 @@
 				F1AFD65720B45E5700CB0279 /* HTMLAttachmentRenderer.swift */,
 			);
 			path = Renderers;
+			sourceTree = "<group>";
+		};
+		F1D7F52D221CEF7D0065555D /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				F1D7F524221CE2D20065555D /* HTMLStyleToggler.swift */,
+			);
+			path = Utility;
 			sourceTree = "<group>";
 		};
 		F1DC21B22199D58B007C189E /* ElementToAttributedString */ = {
@@ -1643,6 +1654,7 @@
 				B524228F1F30C098002E7C6C /* HTMLDivFormatter.swift in Sources */,
 				F1079D67208F80FE009717FA /* EditorView.swift in Sources */,
 				F15A8B6520BED08900C57ED2 /* ParagraphPropertyConverter.swift in Sources */,
+				F1D7F525221CE2D20065555D /* HTMLStyleToggler.swift in Sources */,
 				F1FA0E811E6EF514009D98EE /* Attribute.swift in Sources */,
 				F16A2ADD20CC503F00BF3A0A /* VideoAttachmentToElementConverter.swift in Sources */,
 			);

--- a/Aztec/Classes/Converters/StringAttributesToAttributes/Implementations/ItalicStringAttributeConverter.swift
+++ b/Aztec/Classes/Converters/StringAttributesToAttributes/Implementations/ItalicStringAttributeConverter.swift
@@ -7,7 +7,7 @@ import UIKit
 ///
 open class ItalicStringAttributeConverter: StringAttributeConverter {
     
-    let cssAttributeMatcher = ItalicCSSAttributeMatcher()
+    private let toggler = HTMLStyleToggler(defaultElement: .em, cssAttributeMatcher: ItalicCSSAttributeMatcher())
     
     public func convert(
         attributes: [NSAttributedStringKey: Any],
@@ -24,54 +24,26 @@ open class ItalicStringAttributeConverter: StringAttributeConverter {
             elementNodes.append(representationElement.toElementNode())
         }
         
-        if let font = attributes[.font] as? UIFont,
-            font.containsTraits(.traitItalic) {
-            
-            return enableItalic(in: elementNodes)
+        if shouldEnableItalic(for: attributes) {
+            return toggler.enable(in: elementNodes)
         } else {
-            return disableItalic(in: elementNodes)
+            return toggler.disable(in: elementNodes)
         }
     }
 
-    // MARK: - Enabling and Disabling Bold
+    // MARK: - Style Detection
 
-    private func disableItalic(in elementNodes: [ElementNode]) -> [ElementNode] {
-        
-        let elementNodes = elementNodes.compactMap { (elementNode) -> ElementNode? in
-            guard elementNode.type != .em  else {
-                if elementNode.attributes.count > 0 {
-                    return ElementNode(type: .span, attributes: elementNode.attributes, children: elementNode.children)
-                } else {
-                    return nil
-                }
-            }
-            
-            return elementNode
-        }
-        
-        for elementNode in elementNodes {
-            elementNode.removeCSSAttributes(matching: cssAttributeMatcher)
-        }
-        
-        return elementNodes
+    func shouldEnableItalic(for attributes: [NSAttributedString.Key : Any]) -> Bool {
+        return hasItalicTrait(for: attributes)
     }
     
-    private func enableItalic(in elementNodes: [ElementNode]) -> [ElementNode] {
-        
-        var elementNodes = elementNodes
-        
-        // We can now check if we have any CSS attribute representing bold.  If that's the case we can completely skip
-        // adding the element.
-        //
-        for elementNode in elementNodes {
-            if elementNode.type == .em || elementNode.containsCSSAttribute(matching: cssAttributeMatcher) {
-                return elementNodes
-            }
+    func hasItalicTrait(for attributes: [NSAttributedString.Key : Any]) -> Bool {
+        guard let font = attributes[.font] as? UIFont,
+            font.containsTraits(.traitItalic) else {
+                return false
         }
         
-        // Nothing was found to represent bold... just add the element.
-        elementNodes.append(ElementNode(type: .em))
-        return elementNodes
+        return true
     }
 }
 

--- a/Aztec/Classes/Converters/StringAttributesToAttributes/Implementations/UnderlineStringAttributeConverter.swift
+++ b/Aztec/Classes/Converters/StringAttributesToAttributes/Implementations/UnderlineStringAttributeConverter.swift
@@ -7,7 +7,7 @@ import UIKit
 ///
 open class UnderlineStringAttributeConverter: StringAttributeConverter {
     
-    let cssAttributeMatcher = UnderlineCSSAttributeMatcher()
+    private let toggler = HTMLStyleToggler(defaultElement: .u, cssAttributeMatcher: UnderlineCSSAttributeMatcher())
     
     public func convert(
         attributes: [NSAttributedStringKey: Any],
@@ -27,51 +27,10 @@ open class UnderlineStringAttributeConverter: StringAttributeConverter {
         if let underlineStyle = attributes[.underlineStyle] as? Int,
             underlineStyle != 0 {
             
-            return enableUnderline(in: elementNodes)
+            return toggler.enable(in: elementNodes)
         } else {
-            return disableUnderline(in: elementNodes)
+            return toggler.disable(in: elementNodes)
         }
-    }
-    
-    // MARK: - Enabling and Disabling Bold
-    
-    private func disableUnderline(in elementNodes: [ElementNode]) -> [ElementNode] {
-        
-        let elementNodes = elementNodes.compactMap { (elementNode) -> ElementNode? in
-            guard elementNode.type != .u else {
-                if elementNode.attributes.count > 0 {
-                    return ElementNode(type: .span, attributes: elementNode.attributes, children: elementNode.children)
-                } else {
-                    return nil
-                }
-            }
-            
-            return elementNode
-        }
-        
-        for elementNode in elementNodes {
-            elementNode.removeCSSAttributes(matching: cssAttributeMatcher)
-        }
-        
-        return elementNodes
-    }
-    
-    private func enableUnderline(in elementNodes: [ElementNode]) -> [ElementNode] {
-        
-        var elementNodes = elementNodes
-        
-        // We can now check if we have any CSS attribute representing bold.  If that's the case we can completely skip
-        // adding the element.
-        //
-        for elementNode in elementNodes {
-            if elementNode.type == .u || elementNode.containsCSSAttribute(matching: cssAttributeMatcher) {
-                return elementNodes
-            }
-        }
-        
-        // Nothing was found to represent bold... just add the element.
-        elementNodes.append(ElementNode(type: .u))
-        return elementNodes
     }
 }
 

--- a/Aztec/Classes/Converters/StringAttributesToAttributes/Utility/HTMLStyleToggler.swift
+++ b/Aztec/Classes/Converters/StringAttributesToAttributes/Utility/HTMLStyleToggler.swift
@@ -43,7 +43,7 @@ open class HTMLStyleToggler {
     open func enable(in elementNodes: [ElementNode]) -> [ElementNode] {
         var elementNodes = elementNodes
         
-        // We can now check if we have any CSS attribute representing bold.  If that's the case we can completely skip
+        // We can now check if we have any CSS attribute that triggers the matcher.  If that's the case we can completely skip
         // adding the element.
         //
         for elementNode in elementNodes {
@@ -54,7 +54,7 @@ open class HTMLStyleToggler {
             }
         }
         
-        // Nothing was found to represent bold... just add the element.
+        // Since there's no existing representation of the style, we will add the default one.
         elementNodes.append(ElementNode(type: defaultElement))
         return elementNodes
     }

--- a/Aztec/Classes/Converters/StringAttributesToAttributes/Utility/HTMLStyleToggler.swift
+++ b/Aztec/Classes/Converters/StringAttributesToAttributes/Utility/HTMLStyleToggler.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// This is a utility class that contains some common logic for toggling styles in
+/// an array of element nodes.
+///
+open class HTMLStyleToggler {
+    private let cssAttributeMatcher: CSSAttributeMatcher
+    private let defaultElement: Element
+
+    init(
+        defaultElement: Element,
+        cssAttributeMatcher: CSSAttributeMatcher) {
+        
+        self.cssAttributeMatcher = cssAttributeMatcher
+        self.defaultElement = defaultElement
+    }
+
+    // MARK: - Enabling & Disabling
+    
+    open func disable(in elementNodes: [ElementNode]) -> [ElementNode] {
+        
+        let elementNodes = elementNodes.compactMap { (elementNode) -> ElementNode? in
+            let elementRepresentsStyle = defaultElement.equivalentNames.contains(elementNode.type)
+            
+            guard elementRepresentsStyle else {
+                return elementNode
+            }
+            
+            if elementNode.attributes.count > 0 {
+                return ElementNode(type: .span, attributes: elementNode.attributes, children: elementNode.children)
+            } else {
+                return nil
+            }
+        }
+        
+        for elementNode in elementNodes {
+            elementNode.removeCSSAttributes(matching: cssAttributeMatcher)
+        }
+        
+        return elementNodes
+    }
+    
+    open func enable(in elementNodes: [ElementNode]) -> [ElementNode] {
+        var elementNodes = elementNodes
+        
+        // We can now check if we have any CSS attribute representing bold.  If that's the case we can completely skip
+        // adding the element.
+        //
+        for elementNode in elementNodes {
+            let elementRepresentsStyle = defaultElement.equivalentNames.contains(elementNode.type)
+            
+            if elementRepresentsStyle || elementNode.containsCSSAttribute(matching: cssAttributeMatcher) {
+                return elementNodes
+            }
+        }
+        
+        // Nothing was found to represent bold... just add the element.
+        elementNodes.append(ElementNode(type: defaultElement))
+        return elementNodes
+    }
+}

--- a/Aztec/Classes/Extensions/Dictionary+AttributedStringKey.swift
+++ b/Aztec/Classes/Extensions/Dictionary+AttributedStringKey.swift
@@ -36,4 +36,21 @@ extension Dictionary where Key == NSAttributedStringKey, Value == Any {
         
         return finalAttributes
     }
+    
+    /// Use this method to retrieve an `ElementNode` obtained from the specified key.
+    ///
+    /// - Parameters:
+    ///     - key: the key to retrieve the element representation from the attributed string.
+    ///
+    /// - Returns: the requested element, or `nil` if there's no stored representation for it.
+    ///
+    func storedElement(for key: NSAttributedStringKey) -> ElementNode? {
+        if let representation = self[key] as? HTMLRepresentation,
+            case let .element(representationElement) = representation.kind {
+            
+            return representationElement.toElementNode()
+        }
+        
+        return nil
+    }
 }

--- a/AztecTests/New Group/StringAttributesToAttributes/ItalicStringAttributeConverterTests.swift
+++ b/AztecTests/New Group/StringAttributesToAttributes/ItalicStringAttributeConverterTests.swift
@@ -98,7 +98,7 @@ class ItalicStringAttributeConverterTests: XCTestCase {
         XCTAssertEqual(spanElement.attributes[0], exampleAttribute)
     }
     
-    func testBoldConversionWithEquivalentElementRepresentation() {
+    func testItalicConversionWithEquivalentElementRepresentation() {
         let exampleAttribute = Attribute(type: .style, value: .string("someStyle"))
         let element = ElementNode(type: .i, attributes: [exampleAttribute], children: [])
         let elementRepresentation = HTMLElementRepresentation(element)
@@ -120,7 +120,7 @@ class ItalicStringAttributeConverterTests: XCTestCase {
         XCTAssertEqual(elementNode.attributes[0], exampleAttribute)
     }
     
-    func testBoldConversionWithEquivalentElementRepresentation2() {
+    func testItalicConversionWithEquivalentElementRepresentation2() {
         let exampleAttribute = Attribute(type: .style, value: .string("someStyle"))
         let element = ElementNode(type: .em, attributes: [exampleAttribute], children: [])
         let elementRepresentation = HTMLElementRepresentation(element)

--- a/AztecTests/New Group/StringAttributesToAttributes/ItalicStringAttributeConverterTests.swift
+++ b/AztecTests/New Group/StringAttributesToAttributes/ItalicStringAttributeConverterTests.swift
@@ -97,4 +97,48 @@ class ItalicStringAttributeConverterTests: XCTestCase {
         XCTAssertEqual(spanElement.attributes.count, 1)
         XCTAssertEqual(spanElement.attributes[0], exampleAttribute)
     }
+    
+    func testBoldConversionWithEquivalentElementRepresentation() {
+        let exampleAttribute = Attribute(type: .style, value: .string("someStyle"))
+        let element = ElementNode(type: .i, attributes: [exampleAttribute], children: [])
+        let elementRepresentation = HTMLElementRepresentation(element)
+        var attributes = [NSAttributedStringKey: Any]()
+        
+        var font = UIFont.systemFont(ofSize: 14)
+        font = font.modifyTraits([.traitItalic], enable: true)
+        
+        attributes[.font] = font
+        attributes[.italicHtmlRepresentation] = HTMLRepresentation(for: .element(elementRepresentation))
+        
+        let elementNodes = converter.convert(attributes: attributes, andAggregateWith: [])
+        
+        XCTAssertEqual(elementNodes.count, 1)
+        
+        let elementNode = elementNodes[0]
+        XCTAssertEqual(elementNode.type, .i)
+        XCTAssertEqual(elementNode.attributes.count, 1)
+        XCTAssertEqual(elementNode.attributes[0], exampleAttribute)
+    }
+    
+    func testBoldConversionWithEquivalentElementRepresentation2() {
+        let exampleAttribute = Attribute(type: .style, value: .string("someStyle"))
+        let element = ElementNode(type: .em, attributes: [exampleAttribute], children: [])
+        let elementRepresentation = HTMLElementRepresentation(element)
+        var attributes = [NSAttributedStringKey: Any]()
+        
+        var font = UIFont.systemFont(ofSize: 14)
+        font = font.modifyTraits([.traitItalic], enable: true)
+        
+        attributes[.font] = font
+        attributes[.italicHtmlRepresentation] = HTMLRepresentation(for: .element(elementRepresentation))
+        
+        let elementNodes = converter.convert(attributes: attributes, andAggregateWith: [])
+        
+        XCTAssertEqual(elementNodes.count, 1)
+        
+        let elementNode = elementNodes[0]
+        XCTAssertEqual(elementNode.type, .em)
+        XCTAssertEqual(elementNode.attributes.count, 1)
+        XCTAssertEqual(elementNode.attributes[0], exampleAttribute)
+    }
 }


### PR DESCRIPTION
## Details:

It propagates the same changes across different attribute converters (`em` and `u`).

It also adds unit tests for the case of `em` and `i`.  Running those tests in `develop` should fail.

## Dependencies:

This PR builds up on the fix in https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1138.

## Testing:

### Test 1:

Run the provided tests in develop and make sure the first one fails.
Run the tests in this PR and make sure none fail.

### Test 2:

1. Open the empty editor.
2. Switch to HTML mode.
3. Type `<i>Hello!</i>`.
4. Switch to visual mode and back to HTML mode.

Make sure the final conversion doesn't have an extra `em` tag.

### Test 3:

1. Open the empty editor.
2. Switch to HTML mode.
3. Type `<b>Hello!</b>`.
4. Switch to visual mode and back to HTML mode.

Make sure the final conversion doesn't have an extra `strong` tag.

### Test 4:

1. Open the empty editor.
2. Switch to HTML mode.
3. Type `<u>Hello!</u>`.
4. Switch to visual mode and back to HTML mode.

Make sure the output conversion looks good.