### PR TITLE
Removes iOS 11 formatting workarounds

### DIFF
--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -859,11 +859,9 @@ class TextViewTests: XCTestCase {
     ///
     func testNewLinesGetBulletStyleEvenAfterDeletingEndOfDocumentNewline() {
         let newline = String(.lineFeed)
-
         let textView = TextViewStub(withHTML: "")
 
         textView.toggleOrderedList(range: .zero)
-
         textView.insertText(Constants.sampleText0)
 
         // Select the end of the document
@@ -1913,7 +1911,9 @@ class TextViewTests: XCTestCase {
     func testAutoCompletionReplacementHackWhenUsingEmoji() {
         let textView = TextViewStub(withHTML: "Love")
         let uiTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.endOfDocument)!
-        textView.replaceRangeWithTextWithoutClosingTyping(uiTextRange, replacementText:"😘")
+        
+        textView.replace(uiTextRange, withText: "😘")
+        
         let html = textView.getHTML()
 
         XCTAssertEqual(html, "<p>😘</p>")


### PR DESCRIPTION
## Description:

Removes several workarounds we had added for iOS 11 support.

This PR also fixes a unit test that had bad logic (that was being "hidden" by the iOS 11 workarounds).

This PR should offer us the advantage of improving performance in Aztec slightly, since we're running less code at each keystroke.

## Related Issues:

Format bar style desynch: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/753
Delete Backwards workaround: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/752
Losing styles after typing 1 character: https://github.com/wordpress-mobile/AztecEditor-iOS/issues/725

## Testing:

### Test 1:

1. Download the oldest iOS 11 simulator you can find.
2. Run the unit tests.
3. Run the app and test the issues reported above.

### Test 2:

Repeat test 1 in iOS 12.