### PR TITLE
Remove Travis CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.17
+  ios: wordpress-mobile/ios@0.0.22
 
 workflows:
   test_and_validate:

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,18 +1,13 @@
-if [ ! $TRAVIS ]; then
-	TRAVIS_XCODE_WORKSPACE=Aztec.xcworkspace
-	TRAVIS_XCODE_PROJECT=Aztec.xcodeproj
-	TRAVIS_XCODE_SCHEME=AztecExample
-    TRAVIS_XCODE_SDK=iphonesimulator
-fi
+XCODE_WORKSPACE=Aztec.xcworkspace
+XCODE_PROJECT=Aztec.xcodeproj
+XCODE_SCHEME=AztecExample
+XCODE_SDK=iphonesimulator
 
 xcodebuild build test \
-	-workspace "$TRAVIS_XCODE_WORKSPACE" \
-	-scheme "$TRAVIS_XCODE_SCHEME" \
-	-sdk "$TRAVIS_XCODE_SDK" \
+	-workspace "$XCODE_WORKSPACE" \
+	-scheme "$XCODE_SCHEME" \
+	-sdk "$XCODE_SDK" \
     -destination "name=iPhone SE" \
 	-configuration Debug | xcpretty -c && exit ${PIPESTATUS[0]}
 
-
-
-
-	
+exit ${PIPESTATUS[0]}


### PR DESCRIPTION
This removes the Travis config and does some related cleanup.

To test:

- CircleCI checks are still green.

