### PR TITLE
CircleCI: Update Specs repo when validating WordPress-Editor-iOS.podspec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,3 +27,5 @@ workflows:
           name: Validate WordPress-Editor-iOS.podspec
           podspec-path: WordPress-Editor-iOS.podspec
           bundle-install: false
+          # Updating specs is needed since WordPress-Editor-iOS depends on WordPress-Aztec-iOS
+          update-specs-repo: true


### PR DESCRIPTION
There were some failures on CircleCI last week due to the specs repo being out of date when validating `WordPress-Editor-iOS.podspec`. This ensures it is always updated.

Note that it is not needed for `WordPress-Aztec-iOS` as that has no dependencies.

To test:

- See that the checks are green and that the repo is updated (it will also run slower as a result).