### PR TITLE
Issue/1153 support for source elements inside videos

### DIFF
--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
@@ -62,9 +62,18 @@ class VideoElementConverter: AttachmentElementConverter {
     }
 
     func extractSources(from element: ElementNode) -> [VideoSource] {
-        var sources:[VideoSource] = []
         var children = element.children
+
         //search for source subelements
+        let sources = searchSources(in: element)
+
+        children.removeAll(where: { $0 is ElementNode && $0.name == "source"})
+        element.children = children
+        return sources
+    }
+
+    func searchSources(in element: ElementNode) -> [VideoSource] {
+        var sources:[VideoSource] = []
         for node in element.children {
             guard let sourceElement = node as? ElementNode, sourceElement.name == "source" else {
                 continue
@@ -72,9 +81,8 @@ class VideoElementConverter: AttachmentElementConverter {
             let src = sourceElement.attributes.first(where: { $0.name == "src"} )?.value.toString()
             let type = sourceElement.attributes.first(where: { $0.name == "type"} )?.value.toString()
             sources.append(VideoSource(src: src, type: type) )
+            sources.append(contentsOf: searchSources(in: sourceElement))
         }
-        children.removeAll(where: { $0 is ElementNode && $0.name == "source"})
-        element.children = children
         return sources
     }
 }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
@@ -16,11 +16,9 @@ class VideoElementConverter: AttachmentElementConverter {
         
         let attachment = self.attachment(for: element)
         let intrinsicRepresentation = NSAttributedString(attachment: attachment, attributes: attributes)
-        //QUESTION :This line is commented out to avoid serialization of elements inside a video element like source.
-        //The source element are already parsed by the attachment so should we remove this line altogether or just remove the source elements and proceed.
-        //let serialization = serialize(element, intrinsicRepresentation, attributes)
+        let serialization = serialize(element, intrinsicRepresentation, attributes)
         
-        return (attachment, intrinsicRepresentation)
+        return (attachment, serialization)
     }
     
     // MARK: - Attachment Creation
@@ -54,8 +52,18 @@ class VideoElementConverter: AttachmentElementConverter {
             posterURL = nil
         }
 
+        let sources = extractSources(from: element)
 
+        let attachment = VideoAttachment(identifier: UUID().uuidString, srcURL: srcURL, posterURL: posterURL, sources: sources)
+
+        attachment.extraAttributes = extraAttributes
+
+        return attachment
+    }
+
+    func extractSources(from element: ElementNode) -> [VideoSource] {
         var sources:[VideoSource] = []
+        var children = element.children
         //search for source subelements
         for node in element.children {
             guard let sourceElement = node as? ElementNode, sourceElement.name == "source" else {
@@ -65,11 +73,8 @@ class VideoElementConverter: AttachmentElementConverter {
             let type = sourceElement.attributes.first(where: { $0.name == "type"} )?.value.toString()
             sources.append(VideoSource(src: src, type: type) )
         }
-
-        let attachment = VideoAttachment(identifier: UUID().uuidString, srcURL: srcURL, posterURL: posterURL, sources: sources)
-
-        attachment.extraAttributes = extraAttributes
-
-        return attachment
+        children.removeAll(where: { $0 is ElementNode && $0.name == "source"})
+        element.children = children
+        return sources
     }
 }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
@@ -16,9 +16,11 @@ class VideoElementConverter: AttachmentElementConverter {
         
         let attachment = self.attachment(for: element)
         let intrinsicRepresentation = NSAttributedString(attachment: attachment, attributes: attributes)
-        let serialization = serialize(element, intrinsicRepresentation, attributes)
+        //QUESTION :This line is commented out to avoid serialization of elements inside a video element like source.
+        //The source element are already parsed by the attachment so should we remove this line altogether or just remove the source elements and proceed.
+        //let serialization = serialize(element, intrinsicRepresentation, attributes)
         
-        return (attachment, serialization)
+        return (attachment, intrinsicRepresentation)
     }
     
     // MARK: - Attachment Creation
@@ -52,7 +54,19 @@ class VideoElementConverter: AttachmentElementConverter {
             posterURL = nil
         }
 
-        let attachment = VideoAttachment(identifier: UUID().uuidString, srcURL: srcURL, posterURL: posterURL)
+
+        var sources:[VideoSource] = []
+        //search for source subelements
+        for node in element.children {
+            guard let sourceElement = node as? ElementNode, sourceElement.name == "source" else {
+                continue
+            }
+            let src = sourceElement.attributes.first(where: { $0.name == "src"} )?.value.toString()
+            let type = sourceElement.attributes.first(where: { $0.name == "type"} )?.value.toString()
+            sources.append(VideoSource(src: src, type: type) )
+        }
+
+        let attachment = VideoAttachment(identifier: UUID().uuidString, srcURL: srcURL, posterURL: posterURL, sources: sources)
 
         attachment.extraAttributes = extraAttributes
 

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
@@ -61,7 +61,13 @@ class VideoElementConverter: AttachmentElementConverter {
         return attachment
     }
 
-    func extractSources(from element: ElementNode) -> [VideoSource] {
+
+    /// This method search for source elements on the children of the video element and return an array of VideoSource with the corresponding information.<#Description#>
+    ///
+    /// - Parameter element: the video element to search for sources
+    /// - Returns: an array with the source information found
+    ///
+    private func extractSources(from element: ElementNode) -> [VideoSource] {
         var children = element.children
 
         //search for source subelements
@@ -72,7 +78,12 @@ class VideoElementConverter: AttachmentElementConverter {
         return sources
     }
 
-    func searchSources(in element: ElementNode) -> [VideoSource] {
+    /// This method recursively searches for source elements on the children of element provided and return an array of VideoSource with the corresponding information.
+    ///
+    /// - Parameter element: the element to search for sources
+    /// - Returns: an array with the source information found
+    ///
+    private func searchSources(in element: ElementNode) -> [VideoSource] {
         var sources:[VideoSource] = []
         for node in element.children {
             guard let sourceElement = node as? ElementNode, sourceElement.name == "source" else {

--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -19,7 +19,7 @@ public struct Element: RawRepresentable, Hashable {
     ///
     /// Ref. http://w3c.github.io/html/syntax.html#void-elements
     ///
-    public static var voidElements: [Element] = [.area, .base, .br, .col, .embed, .hr, .img, .input, .link, .meta, .param, .source, .track, .wbr]
+    public static var voidElements: [Element] = [.area, .base, .br, .col, .embed, .hr, .img, .input, .link, .meta, .param, .source, .track, .wbr, .source]
     
     /// This should hardly be anything other than .pre, but has been made customizable anyway.
     ///

--- a/Aztec/Classes/NSAttributedString/Conversions/AttachmentToElementConverter/VideoAttachmentToElementConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttachmentToElementConverter/VideoAttachmentToElementConverter.swift
@@ -25,20 +25,8 @@ class VideoAttachmentToElementConverter: AttachmentToElementConverter {
             element.updateAttribute(named: attribute.name, value: attribute.value)
         }
 
-        var newChildren = element.children
-        for source in attachment.sources {
-            var attributes = [Attribute]()
-            if let src = source.src {
-                let sourceAttribute = Attribute(type: .src, value: .string(src))
-                attributes.append(sourceAttribute)
-            }
-            if let type = source.type {
-                let typeAttribute = Attribute(name: "type", value: .string(type))
-                attributes.append(typeAttribute)
-            }
-            newChildren.append(ElementNode(type: .source, attributes: attributes, children: []))
-        }
-        element.children = newChildren
+        element.children = element.children + videoSourceElements(from: attachment)
+
         return [element]
     }
     
@@ -61,5 +49,24 @@ class VideoAttachmentToElementConverter: AttachmentToElementConverter {
         }
         
         return Attribute(name: "poster", value: .string(poster))
+    }
+
+    /// Extracts the Video source elements from a VideoAttachment Instance.
+    ///
+    private func videoSourceElements(from attachment: VideoAttachment) -> [Node] {
+        var nodes = [Node]()
+        for source in attachment.sources {
+            var attributes = [Attribute]()
+            if let src = source.src {
+                let sourceAttribute = Attribute(type: .src, value: .string(src))
+                attributes.append(sourceAttribute)
+            }
+            if let type = source.type {
+                let typeAttribute = Attribute(name: "type", value: .string(type))
+                attributes.append(typeAttribute)
+            }
+            nodes.append(ElementNode(type: .source, attributes: attributes, children: []))
+        }
+        return nodes
     }
 }

--- a/Aztec/Classes/NSAttributedString/Conversions/AttachmentToElementConverter/VideoAttachmentToElementConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttachmentToElementConverter/VideoAttachmentToElementConverter.swift
@@ -24,7 +24,21 @@ class VideoAttachmentToElementConverter: AttachmentToElementConverter {
         for attribute in attachment.extraAttributes {
             element.updateAttribute(named: attribute.name, value: attribute.value)
         }
-        
+
+        var newChildren = element.children
+        for source in attachment.sources {
+            var attributes = [Attribute]()
+            if let src = source.src {
+                let sourceAttribute = Attribute(type: .src, value: .string(src))
+                attributes.append(sourceAttribute)
+            }
+            if let type = source.type {
+                let typeAttribute = Attribute(name: "type", value: .string(type))
+                attributes.append(typeAttribute)
+            }
+            newChildren.append(ElementNode(type: .source, attributes: attributes, children: []))
+        }
+        element.children = newChildren
         return [element]
     }
     

--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -38,6 +38,13 @@ open class MediaAttachment: NSTextAttachment {
     ///
     fileprivate(set) public var url: URL?
 
+    // The url that represents the media source, by default is the source url
+    public var mediaURL: URL? {
+        get {
+            return url;
+        }
+    }
+
     /// Indicates if a new Asset should be retrieved, or we're current!.
     ///
     fileprivate var needsNewAsset = true
@@ -510,7 +517,7 @@ private extension MediaAttachment {
     /// Requests a new asset (asynchronously), and on completion, triggers a relayout cycle.
     ///
     private func updateImage(in textContainer: NSTextContainer?) {
-        guard let url = url else {
+        guard let url = mediaURL else {
             return
         }
 

--- a/Aztec/Classes/TextKit/VideoAttachment.swift
+++ b/Aztec/Classes/TextKit/VideoAttachment.swift
@@ -1,6 +1,15 @@
 import Foundation
 import UIKit
 
+public struct VideoSource {
+    public var src: String?
+    public var type: String?
+
+    public init(src: String?, type: String?) {
+        self.src = src
+        self.type = type
+    }
+}
 /// Custom text attachment.
 ///
 open class VideoAttachment: MediaAttachment {
@@ -8,6 +17,8 @@ open class VideoAttachment: MediaAttachment {
     /// Video poster image to show, while the video is not played.
     ///
     open var posterURL: URL?
+
+    open var sources = [VideoSource]()
     
     /// Creates a new attachment
     ///
@@ -15,10 +26,11 @@ open class VideoAttachment: MediaAttachment {
     /// - parameter srcURL: the url for the video to display
     /// - parameter posterURL: the url for a poster image for the video
     ///
-    required public init(identifier: String, srcURL: URL? = nil, posterURL: URL? = nil) {
+    required public init(identifier: String, srcURL: URL? = nil, posterURL: URL? = nil, sources: [VideoSource] = []) {
         super.init(identifier: identifier, url: srcURL)
         self.posterURL = posterURL
         self.overlayImage = Assets.playIcon
+        self.sources = sources
     }
 
     /// Required Initializer
@@ -95,6 +107,19 @@ open class VideoAttachment: MediaAttachment {
             return 0
         }
     }
+
+    override public var mediaURL: URL? {
+        get {
+            if url != nil {
+                return url
+            }
+            if let url = sources.first(where: {$0.src != nil})?.src {
+                return URL(string: url)
+            }
+
+            return nil
+        }
+    }
 }
 
 
@@ -108,6 +133,7 @@ extension VideoAttachment {
         }
 
         clone.posterURL = posterURL
+        clone.sources = sources
 
         return clone
     }

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1547,7 +1547,22 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(textView.getHTML(), "<p><video src=\"newVideo.mp4\" poster=\"video.jpg\" data-wpvideopress=\"ABCDE\"></video></p>")
     }
 
+    func testParseVideoWithSourceElements() {
+        let videoHTML = "<video poster=\"video.jpg\"><source src=\"newVideo.mp4\"></video>"
+        let textView = TextViewStub(withHTML: videoHTML)
 
+        XCTAssertEqual(textView.getHTML(), "<p><video poster=\"video.jpg\"><source src=\"newVideo.mp4\"></video></p>")
+
+        guard let attachment = textView.storage.mediaAttachments.first as? VideoAttachment else {
+            XCTFail("An video attachment should be present")
+            return
+        }
+        XCTAssertEqual(attachment.sources.count, 1, "One source should be available")
+
+        XCTAssertEqual(attachment.sources[0].src, "newVideo.mp4", "Video source should match")
+
+        XCTAssertEqual(attachment.mediaURL, URL(string:"newVideo.mp4"), "Video source should match")
+    }
     // MARK: - Comments
 
     /// This test check if the insertion of a Comment Attachment works correctly and the expected tag gets inserted

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		F1D3610B20929F0200B4E7A5 /* WordPressEditor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1D3610420929E6D00B4E7A5 /* WordPressEditor.framework */; };
 		FF149F4A20E3C49A0070FECB /* imagesOverlays.html in Resources */ = {isa = PBXBuildFile; fileRef = FF149F4920E3C49A0070FECB /* imagesOverlays.html */; };
 		FF1FD05C20932EDE00186384 /* gutenberg.html in Resources */ = {isa = PBXBuildFile; fileRef = FF1FD05B20932EDE00186384 /* gutenberg.html */; };
+		FF629DC9223BC418004C4106 /* videoShortcodes.html in Resources */ = {isa = PBXBuildFile; fileRef = FF629DC8223BC418004C4106 /* videoShortcodes.html */; };
 		FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */; };
 		FFC41BDE20DBC7BA004DFB4D /* video.html in Resources */ = {isa = PBXBuildFile; fileRef = FFC41BDD20DBC7BA004DFB4D /* video.html */; };
 /* End PBXBuildFile section */
@@ -154,6 +155,7 @@
 		F1D360FC20929E6D00B4E7A5 /* WordPressEditor.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = WordPressEditor.xcodeproj; path = ../WordPressEditor/WordPressEditor.xcodeproj; sourceTree = "<group>"; };
 		FF149F4920E3C49A0070FECB /* imagesOverlays.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = imagesOverlays.html; sourceTree = "<group>"; };
 		FF1FD05B20932EDE00186384 /* gutenberg.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = gutenberg.html; sourceTree = "<group>"; };
+		FF629DC8223BC418004C4106 /* videoShortcodes.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = videoShortcodes.html; sourceTree = "<group>"; };
 		FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AttachmentDetailsViewController.storyboard; sourceTree = "<group>"; };
 		FFC41BDD20DBC7BA004DFB4D /* video.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = video.html; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -199,6 +201,7 @@
 				59280F291D47CAF40083FB59 /* SampleText.rtf */,
 				FF1FD05B20932EDE00186384 /* gutenberg.html */,
 				FFC41BDD20DBC7BA004DFB4D /* video.html */,
+				FF629DC8223BC418004C4106 /* videoShortcodes.html */,
 			);
 			path = SampleContent;
 			sourceTree = "<group>";
@@ -435,6 +438,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FF629DC9223BC418004C4106 /* videoShortcodes.html in Resources */,
 				7E45CBBF2187A54200C0B2AB /* gallery.html in Resources */,
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1022,7 +1022,11 @@ extension EditorDemoController: TextViewAttachmentDelegate {
         case let videoAttachment as VideoAttachment:
             guard let posterURL = videoAttachment.posterURL else {
                 // Let's get a frame from the video directly
-                exportPreviewImageForVideo(atURL: url, onCompletion: success, onError: failure)
+                if let videoURL = videoAttachment.mediaURL {
+                    exportPreviewImageForVideo(atURL: videoURL, onCompletion: success, onError: failure)
+                } else {
+                    exportPreviewImageForVideo(atURL: url, onCompletion: success, onError: failure)
+                }
                 return
             }
             downloadImage(from: posterURL, success: success, onFailure: failure)
@@ -1382,7 +1386,7 @@ private extension EditorDemoController
                                                 self?.displayDetailsForAttachment(imageAttachment, position: position)
             })
             alertController.addAction(detailsAction)
-        } else if let videoAttachment = attachment as? VideoAttachment, let videoURL = videoAttachment.url {
+        } else if let videoAttachment = attachment as? VideoAttachment, let videoURL = videoAttachment.mediaURL {
             let detailsAction = UIAlertAction(title:NSLocalizedString("Play Video", comment: "User action to play video."),
                                               style: .default,
                                               handler: { [weak self] (action) in

--- a/Example/Example/SampleContent/video.html
+++ b/Example/Example/SampleContent/video.html
@@ -4,7 +4,14 @@
 <h1>Standard Video no poster image</h1>
 <video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" alt="Another video with bunnies"></video>
 
-<h1>Standard Video with multiple sources</h1>
+<h1>Standard Video with source element</h1>
 <video alt="Another video with bunnies">
     <source src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" type="video/mp4">
 </video>
+
+<h1>Standard Video with multiple source elements</h1>
+<video alt="Another video with bunnies">
+    <source src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" type="video/mp4">
+    <source src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_fmt1.ogv" type="video/ogg">
+</video>
+

--- a/Example/Example/SampleContent/video.html
+++ b/Example/Example/SampleContent/video.html
@@ -4,6 +4,7 @@
 <h1>Standard Video no poster image</h1>
 <video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" alt="Another video with bunnies"></video>
 
-<h1>WordPress Video Shortcode</h1>
-[video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg" alt="Another video with bunnies"/]
-
+<h1>Standard Video with multiple sources</h1>
+<video alt="Another video with bunnies">
+    <source src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" type="video/mp4">
+</video>

--- a/Example/Example/SampleContent/videoShortcodes.html
+++ b/Example/Example/SampleContent/videoShortcodes.html
@@ -1,0 +1,3 @@
+<h1>WordPress Video Shortcode</h1>
+[video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg" alt="Another video with bunnies"/]
+

--- a/Example/Example/SampleContent/videoShortcodes.html
+++ b/Example/Example/SampleContent/videoShortcodes.html
@@ -1,3 +1,8 @@
 <h1>WordPress Video Shortcode</h1>
 [video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" poster="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal_scruberthumbnail_2.jpg" alt="Another video with bunnies"/]
 
+<h1>Standard Video with source element</h1>
+<video alt="Another video with bunnies">
+    <source src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" type="video/mp4">
+</video>
+

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -18,12 +18,13 @@ class ViewController: UITableViewController
                 DemoRow(title: "Standard Demo", action: { self.showEditorDemo(filename: "content") }),
                 DemoRow(title: "Captions Demo", action: { self.showEditorDemo(filename: "captions") }),
                 DemoRow(title: "Image Overlays", action: { self.showEditorDemo(filename: "imagesOverlays") }),
+                DemoRow(title: "Video Demo", action: { self.showEditorDemo(filename: "video", wordPressMode: false) }),
                 DemoRow(title: "Empty Demo", action: { self.showEditorDemo() })
                 ]
             ),
             DemoSection(title: "WordPressEditor (Calypso & Gutenberg)", rows: [
                 DemoRow(title: "Gutenberg Demo", action: { self.showEditorDemo(filename: "gutenberg", wordPressMode: true) }),
-                DemoRow(title: "Video Shortcode Demo", action: { self.showEditorDemo(filename: "video", wordPressMode: true) }),
+                DemoRow(title: "Video Shortcode Demo", action: { self.showEditorDemo(filename: "videoShortcodes", wordPressMode: true) }),
                 DemoRow(title: "Gutenberg Gallery", action: { self.showEditorDemo(filename: "gallery", wordPressMode: true) }),
                 DemoRow(title: "Empty Demo", action: { self.showEditorDemo(wordPressMode: true) })
                 ]

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.4.4'
+  s.version          = '1.5.0.beta.1'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.5.0.beta.1'
+  s.version          = '1.5.0.beta.2'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.5.0.beta.1'
+  s.version          = '1.5.0.beta.2'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.4.4'
+  s.version          = '1.5.0.beta.1'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPressEditor/WordPressEditor/Classes/Extensions/ImageAttachment+WordPress.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Extensions/ImageAttachment+WordPress.swift
@@ -5,7 +5,7 @@ import Aztec
 ///
 extension ImageAttachment {
 
-    @objc var alt: String? {
+    @objc public var alt: String? {
         get {
             return extraAttributes["alt"]?.toString()
         }
@@ -18,7 +18,7 @@ extension ImageAttachment {
         }
     }
 
-    var width: Int? {
+    public var width: Int? {
         get {
             guard let stringInt = extraAttributes["width"]?.toString() else {
                 return nil
@@ -35,7 +35,7 @@ extension ImageAttachment {
         }
     }
 
-    var height: Int? {
+    public var height: Int? {
         get {
             guard let stringInt = extraAttributes["height"]?.toString() else {
                 return nil
@@ -51,7 +51,7 @@ extension ImageAttachment {
         }
     }
 
-    var imageID: Int? {
+    public var imageID: Int? {
         get {
             guard let classAttribute = extraAttributes["class"]?.toString() else {
                 return nil

--- a/WordPressEditor/WordPressEditor/Classes/Extensions/MediaAttachment+WordPress.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Extensions/MediaAttachment+WordPress.swift
@@ -8,7 +8,7 @@ extension MediaAttachment {
 
     static let uploadKey = "data-wp_upload_id"
 
-    var uploadID: String? {
+    public var uploadID: String? {
         get {
             return extraAttributes[MediaAttachment.uploadKey]?.toString()
         }

--- a/WordPressEditor/WordPressEditor/Classes/Extensions/MediaAttachment+WordPress.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Extensions/MediaAttachment+WordPress.swift
@@ -6,7 +6,7 @@ import Aztec
 //
 extension MediaAttachment {
 
-    static let uploadKey = "data-wp_upload_id"
+    public static let uploadKey = "data-wp_upload_id"
 
     public var uploadID: String? {
         get {

--- a/WordPressEditor/WordPressEditor/Classes/Extensions/VideoAttachment+WordPress.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Extensions/VideoAttachment+WordPress.swift
@@ -6,7 +6,7 @@ import Aztec
 //
 extension VideoAttachment {
 
-    @objc var videoPressID: String? {
+    @objc public var videoPressID: String? {
         get {
             return extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute]?.toString()
         }
@@ -19,7 +19,7 @@ extension VideoAttachment {
         }
     }
 
-    @objc var isShortcode: Bool {
+    @objc public var isShortcode: Bool {
         get {
             return extraAttributes[VideoShortcodeProcessor.videoWPShortcodeHTMLAttribute]?.toString() == "true"
         }

--- a/WordPressEditor/WordPressEditor/Classes/Extensions/VideoAttachment+WordPress.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Extensions/VideoAttachment+WordPress.swift
@@ -18,4 +18,17 @@ extension VideoAttachment {
             }
         }
     }
+
+    @objc var isShortcode: Bool {
+        get {
+            return extraAttributes[VideoShortcodeProcessor.videoWPShortcodeHTMLAttribute]?.toString() == "true"
+        }
+        set {
+            if newValue {
+                extraAttributes[VideoShortcodeProcessor.videoWPShortcodeHTMLAttribute] = .string(String("true"))
+            } else {
+                extraAttributes.remove(named: VideoShortcodeProcessor.videoWPShortcodeHTMLAttribute)
+            }
+        }
+    }
 }

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/VideoShortcode/VideoShortcodeProcessor.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Calypso/VideoShortcode/VideoShortcodeProcessor.swift
@@ -5,6 +5,7 @@ public class VideoShortcodeProcessor {
 
     static public var videoPressScheme = "videopress"
     static public var videoPressHTMLAttribute = "data-wpvideopress"
+    static public var videoWPShortcodeHTMLAttribute = "data-wpvideoshortcode"
     
     /// Shortcode processor to process videopress shortcodes to html video element
     /// More info here: https://en.support.wordpress.com/videopress/
@@ -107,6 +108,8 @@ public class VideoShortcodeProcessor {
             if let uploadID = shortcode.attributes[MediaAttachment.uploadKey] {
                 html += shortcodeAttributeSerializer.serialize(uploadID) + " "
             }
+
+            html += shortcodeAttributeSerializer.serialize(ShortcodeAttribute(key: videoWPShortcodeHTMLAttribute, value: "true")) + " "
             
             html += "/>"
             
@@ -122,6 +125,11 @@ public class VideoShortcodeProcessor {
         let shortcodeAttributeSerializer = ShortcodeAttributeSerializer()
         
         let postWordPressVideoProcessor = HTMLProcessor(for: "video", replacer: { (element) in
+
+            guard element.attributes[videoWPShortcodeHTMLAttribute]?.value != nil else {
+                    return nil
+            }
+
             var html = "[video "
             
             if let src = element.attributes["src"] {

--- a/WordPressEditor/WordPressEditorTests/Processors/ShortcodeProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Processors/ShortcodeProcessorTests.swift
@@ -24,7 +24,7 @@ class ShortcodeProcessorTests: XCTestCase {
         let sampleText = "[video src=\"video-source.mp4\"]"
         let parsedText = shortCodeParser.process(sampleText)
         
-        XCTAssertEqual(parsedText, "<video src=\"video-source.mp4\" />")
+        XCTAssertEqual(parsedText, "<video src=\"video-source.mp4\" data-wpvideoshortcode=\"true\" />")
     }
 
     func testOutputParserOfVideoPressCode() {
@@ -42,7 +42,7 @@ class ShortcodeProcessorTests: XCTestCase {
 
         let shortCodeParser = VideoShortcodeProcessor.wordPressVideoPostProcessor
 
-        let sampleText = "<video src=\"video-source.mp4\" />"
+        let sampleText = "<video src=\"video-source.mp4\" data-wpvideoshortcode=\"true\" />"
         let parsedText = shortCodeParser.process(sampleText)
         let expected = "[video src=\"video-source.mp4\" ]"
         XCTAssertEqual(parsedText, expected)


### PR DESCRIPTION
Fixes #1153 

This PR improves the parsing and serialization of video elements to support the reading and writing of source elements inside the video elements.

To test:
 - Open the demo app
 - Run the video demo
 - Check that all videos display correctly
 - Switch to HTML mode and check if HTML is still correct
 - Switch to Visual mode and check if video are correct
 - Tap on the last video, and see if video preview works correctly

