### PR TITLE
Release v. 1.5.0

### DIFF
--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.5.0.beta.2'
+  s.version          = '1.5.0'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.5.0.beta.2'
+  s.version          = '1.5.0'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
This PR merges release/1.5.0 into master. 
Note that  WordPress-Aztec-iOS pod has been already pushed to Cocoapods trunk in order to allow the validation of WordPress-Editor-iOS.

To test:
1. Verify that CI tests pass. 
