### PR TITLE
Empty list

### DIFF
--- a/Aztec/Classes/Extensions/String+EndOfLine.swift
+++ b/Aztec/Classes/Extensions/String+EndOfLine.swift
@@ -9,7 +9,7 @@ extension String {
     ///
     /// - Returns: `true` if the specified index is in an empty line, `false` otherwise.
     ///
-    func isEmptyLine(at index: String.Index) -> Bool {
+    public func isEmptyLine(at index: String.Index) -> Bool {
         return isStartOfNewLine(at: index) && isEndOfLine(at: index)
     }
 
@@ -20,7 +20,7 @@ extension String {
     ///
     /// - Returns: `true` if the specified offset is in an empty line, `false` otherwise.
     ///
-    func isEmptyLine(at offset: Int) -> Bool {
+    public func isEmptyLine(at offset: Int) -> Bool {
         guard let index = self.indexFromLocation(offset) else {
             return true
         }

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -135,6 +135,9 @@ public class ElementNode: Node {
     // MARK: - Node Overrides
     
     override func needsClosingParagraphSeparator() -> Bool {
+        if type == .li && !hasChildren() {
+            return true
+        }
         return (!hasChildren())
             && (hasAttributes() || !isLastInTree())
             && (isBlockLevel() || hasRightBlockLevelSibling() || isLastInAncestorEndingInBlockLevelSeparation())

--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -135,11 +135,8 @@ public class ElementNode: Node {
     // MARK: - Node Overrides
     
     override func needsClosingParagraphSeparator() -> Bool {
-        if type == .li && !hasChildren() {
-            return true
-        }
         return (!hasChildren())
-            && (hasAttributes() || !isLastInTree())
+            && (canBeLastInTree() || !isLastInTree())
             && (isBlockLevel() || hasRightBlockLevelSibling() || isLastInAncestorEndingInBlockLevelSeparation())
     }
 
@@ -259,6 +256,14 @@ public class ElementNode: Node {
         }
 
         return false
+    }
+
+    /// Check if the node can be the last one in a tree
+    ///
+    /// - Returns: Returns `true` if it can be the last one, false otherwise.
+    ///
+    func canBeLastInTree() -> Bool {
+        return hasAttributes() || type == .li
     }
 
     /// Find out if this is a block-level element.

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1980,4 +1980,13 @@ class TextViewTests: XCTestCase {
         
         XCTAssertEqual(output, expected)
     }
+
+    /// This test makes sure that if an empty list is in the original HTML, it will still get output after our processing.
+    func testEmptyListsPersistsAfterAztec() {
+        let textView = TextViewStub(withHTML: "<ul><li></li></ul>")
+
+        let html = textView.getHTML(prettify: false)
+
+        XCTAssertEqual(html, "<ul><li></li></ul>")
+    }
 }


### PR DESCRIPTION
Fixes #1159

This PR implements a fix to support empty list elements like this: `<ul><li></li></ul>`

To test:
- Open an empty demo 
- Switch to HTML and add this: `<ul><li></li></ul>`
- Switch to Visual and see if the element is displayed.
