### PR TITLE
Use video shortcodes  processors  on Gutenberg.

### DIFF
--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/WordPressInputCustomizer.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/WordPressInputCustomizer.swift
@@ -18,6 +18,11 @@ open class WordPressInputCustomizer: PluginInputCustomizer {
         VideoShortcodeProcessor.wordPressVideoPreProcessor,
         AutoPProcessor()
         ])
+
+    private let gutenbergInputHTMLProcessor = PipelineProcessor([
+        VideoShortcodeProcessor.videoPressPreProcessor,
+        VideoShortcodeProcessor.wordPressVideoPreProcessor
+        ])
     
     // MARK: - Gutenberg
     
@@ -38,7 +43,7 @@ open class WordPressInputCustomizer: PluginInputCustomizer {
     
     open func process(html: String) -> String {
         guard !isGutenbergContent(html) else {
-            return html
+            return gutenbergInputHTMLProcessor.process(html)
         }
         
         return calypsoinputHTMLProcessor.process(html)

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/WordPressOutputCustomizer.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/WordPressOutputCustomizer.swift
@@ -18,6 +18,11 @@ open class WordPressOutputCustomizer: PluginOutputCustomizer {
         VideoShortcodeProcessor.wordPressVideoPostProcessor,
         RemovePProcessor(),
         ])
+
+    private let gutenbergOutputHTMLProcessor = PipelineProcessor([
+        VideoShortcodeProcessor.videoPressPostProcessor,
+        VideoShortcodeProcessor.wordPressVideoPostProcessor,
+        ])
     
     // MARK: - Gutenberg
     
@@ -37,7 +42,7 @@ open class WordPressOutputCustomizer: PluginOutputCustomizer {
     
     open func process(html: String) -> String {
         guard !isGutenbergContent(html) else {
-            return html
+            return gutenbergOutputHTMLProcessor.process(html)
         }
         
         return calypsoOutputHTMLProcessor.process(html)


### PR DESCRIPTION
Fixes #1160 

This PR make sure the shortcode video processors are run in Aztec Gutenberg mode.

To test:

1. Open an Gutenberg empty demo and switch to HTML mode.
2. Paste the following: ```<!-- wp:shortcode -->[video src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" ]<!-- /wp:shortcode -->```
3. Switch to visual mode
4. The video of the shorcode is displayed.
5. Switch back to HTML and check the shortcode is there.
