### PR TITLE
Fix a crash when system pasteboard is empty

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -542,9 +542,8 @@ open class TextView: UITextView {
 
     // MARK: - Pasteboard Helpers
 
-    private func storeInPasteboard(encoded data: Data) {
-        let pasteboard = UIPasteboard.general
-        pasteboard.items[0][NSAttributedString.pastesboardUTI] = data
+    internal func storeInPasteboard(encoded data: Data, pasteboard: UIPasteboard = UIPasteboard.general) {
+        pasteboard.setData(data, forPasteboardType: NSAttributedString.pastesboardUTI)
     }
 
     // MARK: - Intercept keyboard operations

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1745,6 +1745,21 @@ class TextViewTests: XCTestCase {
         textView.cut(nil)
     }
 
+    /// This test verifies that trying to store data in an empty pasteboard
+    /// doesn't cause Aztec to crash.
+    ///
+    func testWritingIntoAnEmptyPasteboardDoesNotCauseAztecToCrash() {
+
+        let pasteboard = UIPasteboard.general
+        pasteboard.items.removeAll()
+
+        let data = "Foo".data(using: .utf8)!
+        let textView = TextViewStub(withSampleHTML: true)
+        textView.storeInPasteboard(encoded: data, pasteboard: pasteboard)
+
+        XCTAssertEqual(pasteboard.items.count, 1)
+    }
+
     /// This test verifies that Japanese Characters do not get hexa encoded anymore, since we actually support UTF8!
     /// Ref. Issue #632: Stop encoding non-latin characters
     ///


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/8826

### To Test

**Before**
- Launch the WP app on a simulator, immediately after doing Hardware > Erase all Content and Settings (and thus has a clean pasteboard)
- Copy some text out of an Aztec post
- App will crash due to out-of-bounds exception

**After**
- Launch the test WP app as before (don't forget to Erase all Content and Settings)
- Copy some text out of Aztec post
- App will not crash

You could also run the updated Unit Tests – they demonstrate the issue in a more reliable way – the steps above didn't cause the crash _every_ time for some reason – it may have to do with content synced between the simulator and the host computer? 🤔