### PR TITLE
Refactor TextView key commands.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -486,15 +486,27 @@ open class TextView: UITextView {
     
     // MARK: - Intercept Keystrokes
 
+    public lazy var carriageReturnKeyCommand: UIKeyCommand = {
+        return UIKeyCommand(input: String(.carriageReturn), modifierFlags: .shift, action: #selector(handleShiftEnter(command:)))
+    }()
+
+    public lazy var tabKeyCommand: UIKeyCommand = {
+        return UIKeyCommand(input: String(.tab), modifierFlags: [], action: #selector(handleTab(command:)))
+    }()
+
+    public lazy var shiftTabKeyCommand: UIKeyCommand = {
+        return  UIKeyCommand(input: String(.tab), modifierFlags: .shift, action: #selector(handleShiftTab(command:)))
+    }()
+
     override open var keyCommands: [UIKeyCommand]? {
         get {
             // When the keyboard "enter" key is pressed, the keycode corresponds to .carriageReturn,
             // even if it's later converted to .lineFeed by default.
             //
             return [
-                UIKeyCommand(input: String(.carriageReturn), modifierFlags: .shift, action: #selector(handleShiftEnter(command:))),
-                UIKeyCommand(input: String(.tab), modifierFlags: .shift, action: #selector(handleShiftTab(command:))),
-                UIKeyCommand(input: String(.tab), modifierFlags: [], action: #selector(handleTab(command:)))
+                carriageReturnKeyCommand,
+                shiftTabKeyCommand,
+                tabKeyCommand,
             ]
         }
     }


### PR DESCRIPTION
Refactor TextView key commands to make key commands publicly and independently accessible.

This is needed to override `override open var keyCommands: [UIKeyCommand]? ` using the key commands defined internally by Aztec, without depending on the array indexing of them.

This PR has no change in logic.

To test:
- All unit tests should pass.
- Smoke test the example app.
- Test steps in `gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/889