### PR TITLE
Fix AutoPProcessor for Swift 5

### DIFF
--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.6.0'
+  s.version          = '1.6.1'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.6.0'
+  s.version          = '1.6.1'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPressEditor/WordPressEditor/Classes/Extensions/String+RegEx.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Extensions/String+RegEx.swift
@@ -57,17 +57,17 @@ extension String {
         var newString = self
 
         for match in matches.reversed() {
-            guard let matchRange = Range(match.range, in: self) else {
+            guard let matchRange = Range(match.range, in: newString) else {
                 continue
             }
-            
-            let matchString = String(self[matchRange])
+
+            let matchString = String(newString[matchRange])
 
             var submatchStrings = [String]()
 
             for submatchIndex in 0 ..< match.numberOfRanges {
-                let submatchRange = self.range(fromUTF16NSRange: match.range(at: submatchIndex))
-                let submatchString = String(self[submatchRange])
+                let submatchRange = newString.range(fromUTF16NSRange: match.range(at: submatchIndex))
+                let submatchString = String(newString[submatchRange])
 
                 submatchStrings.append(submatchString)
             }

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/AutopRemovep/AutoPProcessorTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/AutopRemovep/AutoPProcessorTests.swift
@@ -101,4 +101,18 @@ class AutoPProcessorTests: XCTestCase {
         let output = processor.process(input)
         XCTAssertEqual(output, expected)
     }
+
+
+    /// After the migration to Swift 5, there were problems with ranges.
+    /// This test ensures there are no regresions related to this issue:
+    /// https://github.com/wordpress-mobile/WordPress-iOS/issues/11515
+    /// Where the `—` character was messing up the range used to replace the `</blockquote>` string.
+    /// This is independent of the kind of tag. It needs two different tags with a `new line` character in between to happen.
+    func testHTMLWithUTF16Characters() {
+        let html = "<blockquote>A Quote. —— Someone</blockquote>\n<img src=\"#\" />"
+        let expected = "<blockquote><p>A Quote. —— Someone</p></blockquote>\n<p><img src=\"#\" /></p>\n"
+        let finalHTML = processor.process(html)
+
+        XCTAssertEqual(finalHTML, expected)
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/11515
WPiOS related PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/11529

The original issue describes the introduction of `e>` characters when saving a post.

I was able to reproduce this issue under these conditions:
- Any two pair of tags where the first tag holds text (as the `blockquote` tag)
- Both tags separated by a new line.
- The first tags contains a utf16 character as part of its content (as `—`).

In this case, the range used to insert `</blockquote>` when inserting the p tags was shifted by that character, inserting it earlier, and leaving the last two characters behind (`e>`).

The issue was that even though `newString` is a copy of the original string, the range created by `let matchRange = Range(match.range, in: self)` was different for each of them:

<img width="263" alt="Screen Shot 2019-04-23 at 5 34 21 PM" src="https://user-images.githubusercontent.com/9772967/56597611-1c6eea00-65f3-11e9-9a8d-61fbe1282dc0.png">

<img width="579" alt="Screen Shot 2019-04-23 at 5 42 24 PM" src="https://user-images.githubusercontent.com/9772967/56597680-41fbf380-65f3-11e9-96d5-1d5f858fdfe1.png">

The issue was fixed by calculating the range from `newString`, that's where the range will be used to replace the matched tags:

`newString.replaceSubrange(matchRange, with: block(matchString, submatchStrings))`


**To test:**
- Check that the new test pass. (You can also see it fail by rolling back the changes).
- Open the Empty Demo in the WordPressEditor section (Calypso & Gutenberg).
- Paste this snippet in the html view:
```html
Thanks for joining me!
<blockquote>Good company in a journey makes the way seem shorter. — Izaak Walton</blockquote>
<img class="size-full wp-image-7" src="https://twentysixteendemo.files.wordpress.com/2015/11/post.png" alt="post" width="1000" height="563" />
```
- Go to visual mode and html mode several times.
- Check that no extra `e>` is added to the content.
- Smoke test Gutenberg to verify that it's not affected. (https://github.com/wordpress-mobile/WordPress-iOS/pull/11529)

cc @jkmassel 