### PR TITLE
Fix nested lists rendering

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		F9982CF621877663001E606B /* TextViewPasteboardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9982CF521877663001E606B /* TextViewPasteboardDelegate.swift */; };
 		F99D5CF321B989FF0089314A /* StringRangeMultibyteConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99D5CF221B989FF0089314A /* StringRangeMultibyteConversionTests.swift */; };
 		FF0714021EFD78AF00E50713 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FF0714001EFD78AF00E50713 /* Media.xcassets */; };
+		FF17B2D2227A589F0022AECE /* LIElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF17B2D1227A589F0022AECE /* LIElementConverter.swift */; };
 		FF20D6401EDC389A00294B78 /* ShortcodeAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF20D63D1EDC389A00294B78 /* ShortcodeAttribute.swift */; };
 		FF20D6411EDC389A00294B78 /* HTMLProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF20D63E1EDC389A00294B78 /* HTMLProcessor.swift */; };
 		FF20D6421EDC389A00294B78 /* Processor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF20D63F1EDC389A00294B78 /* Processor.swift */; };
@@ -491,6 +492,7 @@
 		F9982CF521877663001E606B /* TextViewPasteboardDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewPasteboardDelegate.swift; sourceTree = "<group>"; };
 		F99D5CF221B989FF0089314A /* StringRangeMultibyteConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringRangeMultibyteConversionTests.swift; sourceTree = "<group>"; };
 		FF0714001EFD78AF00E50713 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
+		FF17B2D1227A589F0022AECE /* LIElementConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LIElementConverter.swift; sourceTree = "<group>"; };
 		FF20D63D1EDC389A00294B78 /* ShortcodeAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcodeAttribute.swift; sourceTree = "<group>"; };
 		FF20D63E1EDC389A00294B78 /* HTMLProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLProcessor.swift; sourceTree = "<group>"; };
 		FF20D63F1EDC389A00294B78 /* Processor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Processor.swift; sourceTree = "<group>"; };
@@ -539,6 +541,7 @@
 			isa = PBXGroup;
 			children = (
 				40359F271FD88A7900B1C1D2 /* BRElementConverter.swift */,
+				FF17B2D1227A589F0022AECE /* LIElementConverter.swift */,
 				F1E2323120C17F70008DA49F /* CiteElementConverter.swift */,
 				B5E94D0F1FE01334000E7C20 /* FigureElementConverter.swift */,
 				F1FF7DA0201A1D3E007B0B32 /* FigcaptionElementConverter.swift */,
@@ -1561,6 +1564,7 @@
 				F177FF751FB6404D00CBBE35 /* UILayoutPriority+Swift4.swift in Sources */,
 				F1C05B9D1E37FA77007510EA /* String+CharacterName.swift in Sources */,
 				F1FF7D9F201A1D24007B0B32 /* Figcaption.swift in Sources */,
+				FF17B2D2227A589F0022AECE /* LIElementConverter.swift in Sources */,
 				FF437B6620D7CB83000D9666 /* LiFormatter.swift in Sources */,
 				FFFEC7DB1EA7698900F4210F /* VideoAttachment.swift in Sources */,
 				F12F58671EF20394008AE298 /* BlockquoteFormatter.swift in Sources */,

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Base/ElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Base/ElementConverter.swift
@@ -5,7 +5,7 @@ import UIKit
 ///
 public protocol ElementConverter {
     
-    typealias ContentSerializer = (_ elementNode: ElementNode, _ intrinsicRepresentation: NSAttributedString?, _ inheriting: [NSAttributedString.Key:Any]) -> NSAttributedString
+    typealias ContentSerializer = (_ elementNode: ElementNode, _ intrinsicRepresentation: NSAttributedString?, _ inheriting: [NSAttributedString.Key:Any], _ implicitRepresentationBeforeChildren: Bool) -> NSAttributedString
     
     /// Converts an instance of ElementNode into a NSAttributedString.
     ///

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/BRElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/BRElementConverter.swift
@@ -16,6 +16,6 @@ class BRElementConverter: ElementConverter {
         
         let intrinsicRepresentation = NSAttributedString(.lineSeparator, attributes: attributes)
         
-        return serialize(element, intrinsicRepresentation, attributes)
+        return serialize(element, intrinsicRepresentation, attributes, false)
     }
 }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/CiteElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/CiteElementConverter.swift
@@ -16,7 +16,7 @@ class CiteElementConverter: FormatterElementConverter {
         
         let childrenAttributes = attributes(for: element, inheriting: inheritedAttributes)
         
-        return serialize(element, nil, childrenAttributes)
+        return serialize(element, nil, childrenAttributes, false)
     }
     
     // MARK: - FormatterElementConverter

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigcaptionElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigcaptionElementConverter.swift
@@ -18,7 +18,7 @@ class FigcaptionElementConverter: ElementConverter {
         
         let attributes = self.attributes(for: element, inheriting: attributes)
         
-        return serialize(element, nil, attributes)
+        return serialize(element, nil, attributes, false)
     }
     
     private func attributes(for element: ElementNode, inheriting attributes: [NSAttributedString.Key: Any]) -> [NSAttributedString.Key: Any] {

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigureElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/FigureElementConverter.swift
@@ -16,7 +16,7 @@ class FigureElementConverter: ElementConverter {
        
         let attributes = self.attributes(for: element, inheriting: attributes)
         
-        return serialize(element, nil, attributes)
+        return serialize(element, nil, attributes, false)
     }
     
     private func attributes(for element: ElementNode, inheriting attributes: [NSAttributedString.Key: Any]) -> [NSAttributedString.Key: Any] {

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
@@ -113,7 +113,7 @@ class GenericElementConverter: ElementConverter {
         
         let childrenAttributes = attributes(for: element, inheriting: inheritedAttributes)
         
-        return serialize(element, nil, childrenAttributes)
+        return serialize(element, nil, childrenAttributes, false)
     }
 }
 

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/HRElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/HRElementConverter.swift
@@ -23,7 +23,7 @@ class HRElementConverter: AttachmentElementConverter {
         let attachment = self.attachment(for: element)
         
         let intrinsicRepresentation = NSAttributedString(attachment: attachment, attributes: attributes)
-        let serialization = serialize(element, intrinsicRepresentation, attributes)
+        let serialization = serialize(element, intrinsicRepresentation, attributes, false)
         
         return (attachment, serialization)
     }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/ImageElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/ImageElementConverter.swift
@@ -16,7 +16,7 @@ class ImageElementConverter: AttachmentElementConverter {
         
         let attachment = self.attachment(for: element)
         let intrinsicRepresentation = NSAttributedString(attachment: attachment, attributes: attributes)
-        let serialization = serialize(element, intrinsicRepresentation, attributes)
+        let serialization = serialize(element, intrinsicRepresentation, attributes, false)
         
         return (attachment, serialization)
     }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
@@ -17,7 +17,7 @@ class LIElementConverter: ElementConverter {
         var intrinsicRepresentation: NSAttributedString?
         let intrisicRepresentationBeforeChildren = !hasNonEmptyTextChildren(node: element) && hasNestedList(node: element)
         if intrisicRepresentationBeforeChildren {
-            intrinsicRepresentation = NSAttributedString(string: "\n", attributes: attributes)
+            intrinsicRepresentation = NSAttributedString(string: String(.paragraphSeparator), attributes: attributes)
         }        
 
         let elementRepresentation = HTMLElementRepresentation(element)

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
@@ -31,7 +31,7 @@ class LIElementConverter: ElementConverter {
 
     private func hasNonEmptyTextChildren(node: ElementNode) -> Bool {
         for node in node.children {
-            if let text = node as? TextNode, !text.contents.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).isEmpty {
+            if let text = node as? TextNode, !text.contents.trimmingCharacters(in: CharacterSet.whitespaces).isEmpty {
                 return true
             }
         }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
@@ -15,10 +15,11 @@ class LIElementConverter: ElementConverter {
         precondition(element.type == .li)
 
         var intrinsicRepresentation: NSAttributedString?
-        let intrisicRepresentationBeforeChildren = !hasNonEmptyTextChildren(node: element) && hasNestedList(node: element)
-        if intrisicRepresentationBeforeChildren {
-            intrinsicRepresentation = NSAttributedString(string: String(.paragraphSeparator), attributes: attributes)
-        }        
+        let intrisicRepresentationBeforeChildren = false
+//        let intrisicRepresentationBeforeChildren = !hasNonEmptyTextChildren(node: element) && hasNestedList(node: element)
+//        if intrisicRepresentationBeforeChildren {
+//            intrinsicRepresentation = NSAttributedString(string: String(.paragraphSeparator), attributes: attributes)
+//        }        
 
         let elementRepresentation = HTMLElementRepresentation(element)
         let representation = HTMLRepresentation(for: .element(elementRepresentation))

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
@@ -31,7 +31,7 @@ class LIElementConverter: ElementConverter {
 
     private func hasNonEmptyTextChildren(node: ElementNode) -> Bool {
         for node in node.children {
-            if let text = node as? TextNode, !text.contents.trimmingCharacters(in: CharacterSet.whitespaces).isEmpty {
+            if let text = node as? TextNode, !text.contents.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).isEmpty {
                 return true
             }
         }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
@@ -16,15 +16,15 @@ class LIElementConverter: ElementConverter {
 
         var intrinsicRepresentation: NSAttributedString?
         let intrisicRepresentationBeforeChildren = !hasNonEmptyTextChildren(node: element) && hasNestedList(node: element)
-        if intrisicRepresentationBeforeChildren {
-            intrinsicRepresentation = NSAttributedString(string: String(.paragraphSeparator), attributes: attributes)
-        }        
 
         let elementRepresentation = HTMLElementRepresentation(element)
         let representation = HTMLRepresentation(for: .element(elementRepresentation))
         let formatter = LiFormatter(placeholderAttributes: nil)
         let finalAttributes = formatter.apply(to: attributes, andStore: representation)
 
+        if intrisicRepresentationBeforeChildren {
+            intrinsicRepresentation = NSAttributedString(string: String(.paragraphSeparator), attributes: finalAttributes)
+        }
 
         return serialize(element, intrinsicRepresentation, finalAttributes, intrisicRepresentationBeforeChildren)
     }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
@@ -15,11 +15,10 @@ class LIElementConverter: ElementConverter {
         precondition(element.type == .li)
 
         var intrinsicRepresentation: NSAttributedString?
-        let intrisicRepresentationBeforeChildren = false
-//        let intrisicRepresentationBeforeChildren = !hasNonEmptyTextChildren(node: element) && hasNestedList(node: element)
-//        if intrisicRepresentationBeforeChildren {
-//            intrinsicRepresentation = NSAttributedString(string: String(.paragraphSeparator), attributes: attributes)
-//        }        
+        let intrisicRepresentationBeforeChildren = !hasNonEmptyTextChildren(node: element) && hasNestedList(node: element)
+        if intrisicRepresentationBeforeChildren {
+            intrinsicRepresentation = NSAttributedString(string: String(.paragraphSeparator), attributes: attributes)
+        }        
 
         let elementRepresentation = HTMLElementRepresentation(element)
         let representation = HTMLRepresentation(for: .element(elementRepresentation))
@@ -33,7 +32,7 @@ class LIElementConverter: ElementConverter {
     private func hasNonEmptyTextChildren(node: ElementNode) -> Bool {
         var result = false
         var whiteSpaces = CharacterSet.whitespacesAndNewlines
-        whiteSpaces.remove(charactersIn: String(.lineSeparator))
+        whiteSpaces.remove(charactersIn: String(.paragraphSeparator))
         for node in node.children {
             if let text = node as? TextNode, !text.contents.trimmingCharacters(in: whiteSpaces).isEmpty {
                 return true

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
@@ -15,7 +15,7 @@ class LIElementConverter: ElementConverter {
         precondition(element.type == .li)
 
         var intrinsicRepresentation: NSAttributedString?
-        let intrisicRepresentationBeforeChildren = !hasNonEmptyTextChildren(node: element)
+        let intrisicRepresentationBeforeChildren = !hasNonEmptyTextChildren(node: element) && hasNestedList(node: element)
         if intrisicRepresentationBeforeChildren {
             intrinsicRepresentation = NSAttributedString(string: "\n", attributes: attributes)
         }        
@@ -32,6 +32,15 @@ class LIElementConverter: ElementConverter {
     private func hasNonEmptyTextChildren(node: ElementNode) -> Bool {
         for node in node.children {
             if let text = node as? TextNode, !text.contents.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).isEmpty {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func hasNestedList(node: ElementNode) -> Bool {
+        for node in node.children {
+            if let element = node as? ElementNode, element.isNodeType(.ol) || element.isNodeType(.ul) {
                 return true
             }
         }

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
@@ -1,0 +1,40 @@
+import UIKit
+
+
+/// Converts `<li>` elements into a `String(.lineSeparator)`.
+///
+class LIElementConverter: ElementConverter {
+    
+    // MARK: - ElementConverter
+    
+    func convert(
+        _ element: ElementNode,
+        inheriting attributes: [NSAttributedString.Key: Any],
+        contentSerializer serialize: ContentSerializer) -> NSAttributedString {
+        
+        precondition(element.type == .li)
+
+        var intrinsicRepresentation: NSAttributedString?
+        let intrisicRepresentationBeforeChildren = !hasNonEmptyTextChildren(node: element)
+        if intrisicRepresentationBeforeChildren {
+            intrinsicRepresentation = NSAttributedString(string: "\n", attributes: attributes)
+        }        
+
+        let elementRepresentation = HTMLElementRepresentation(element)
+        let representation = HTMLRepresentation(for: .element(elementRepresentation))
+        let formatter = LiFormatter(placeholderAttributes: nil)
+        let finalAttributes = formatter.apply(to: attributes, andStore: representation)
+
+
+        return serialize(element, intrinsicRepresentation, finalAttributes, intrisicRepresentationBeforeChildren)
+    }
+
+    private func hasNonEmptyTextChildren(node: ElementNode) -> Bool {
+        for node in node.children {
+            if let text = node as? TextNode, !text.contents.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).isEmpty {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/LIElementConverter.swift
@@ -30,12 +30,18 @@ class LIElementConverter: ElementConverter {
     }
 
     private func hasNonEmptyTextChildren(node: ElementNode) -> Bool {
+        var result = false
+        var whiteSpaces = CharacterSet.whitespacesAndNewlines
+        whiteSpaces.remove(charactersIn: String(.lineSeparator))
         for node in node.children {
-            if let text = node as? TextNode, !text.contents.trimmingCharacters(in: CharacterSet.whitespaces).isEmpty {
+            if let text = node as? TextNode, !text.contents.trimmingCharacters(in: whiteSpaces).isEmpty {
                 return true
             }
+            if let element = node as? ElementNode, !element.isNodeType(.ol) && !element.isNodeType(.ul) {
+                result = result || hasNonEmptyTextChildren(node: element)
+            }
         }
-        return false
+        return result
     }
 
     private func hasNestedList(node: ElementNode) -> Bool {

--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/VideoElementConverter.swift
@@ -16,7 +16,7 @@ class VideoElementConverter: AttachmentElementConverter {
         
         let attachment = self.attachment(for: element)
         let intrinsicRepresentation = NSAttributedString(attachment: attachment, attributes: attributes)
-        let serialization = serialize(element, intrinsicRepresentation, attributes)
+        let serialization = serialize(element, intrinsicRepresentation, attributes, false)
         
         return (attachment, serialization)
     }

--- a/Aztec/Classes/Extensions/String+Paragraph.swift
+++ b/Aztec/Classes/Extensions/String+Paragraph.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - Paragraph Analysis Helpers
 //
-extension String {
+public extension String {
 
     /// This methods verifies if the receiver string contains a new paragraph at the specified index.
     ///

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -92,7 +92,7 @@ extension TextNode {
         // U+000A, which is non-breaking space.  We need to maintain it.
         //
         let whitespace = CharacterSet.whitespacesAndNewlines
-        let whitespaceToKeep = CharacterSet(charactersIn: String(.nonBreakingSpace))
+        let whitespaceToKeep = CharacterSet(charactersIn: String(.nonBreakingSpace)+String(.lineSeparator))
         let whitespaceToRemove = whitespace.subtracting(whitespaceToKeep)
         
         let trimmedText = text.trimmingCharacters(in: whitespaceToRemove)

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringSerializer.swift
@@ -19,7 +19,8 @@ class AttributedStringSerializer {
         .figure: FigureElementConverter(),
         .hr: HRElementConverter(),
         .img: ImageElementConverter(),
-        .video: VideoElementConverter()
+        .video: VideoElementConverter(),
+        .li: LIElementConverter()
     ]
     
     // MARK: - Attributes Converter
@@ -158,15 +159,19 @@ class AttributedStringSerializer {
     //
     private(set) lazy var genericElementConverter = GenericElementConverter()
     
-    lazy var contentSerializer: ElementConverter.ContentSerializer = { [unowned self] (elementNode, intrinsicRepresentation, attributes) in
+    lazy var contentSerializer: ElementConverter.ContentSerializer = { [unowned self] (elementNode, intrinsicRepresentation, attributes, intrinsicRepresentationBeforeChildren) in
         let content = NSMutableAttributedString()
-        
+
+        if let intrinsicRepresentation = intrinsicRepresentation, intrinsicRepresentationBeforeChildren {
+            content.append(intrinsicRepresentation)
+        }
+
         for child in elementNode.children {
             let nodeString = self.serialize(child, inheriting: attributes)
             content.append(nodeString)
         }
         
-        if let intrinsicRepresentation = intrinsicRepresentation {
+        if let intrinsicRepresentation = intrinsicRepresentation, !intrinsicRepresentationBeforeChildren {
             content.append(intrinsicRepresentation)
         }
         

--- a/AztecTests/New Group/ElementToAttributedString/GenericElementConverterTests.swift
+++ b/AztecTests/New Group/ElementToAttributedString/GenericElementConverterTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class GenericElementConverterTests: XCTestCase {
 
     let converter = GenericElementConverter()
-    let contentSerializer: ElementConverter.ContentSerializer = { elementNode, implicitRepresentation, attributes in
+    let contentSerializer: ElementConverter.ContentSerializer = { elementNode, implicitRepresentation, attributes, intrinsicRepresentationBeforeChildren in
         return NSAttributedString()
     }
 

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -480,4 +480,18 @@ class TextStorageTests: XCTestCase {
 
         XCTAssertEqual(html, outputHTML)
     }
+
+    func testListWithNestedLists() {
+        let initialHTML = "<ul><li>One</li><li><ul><li>Two</li></ul></li></ul>"
+
+        // Setup
+        let defaultAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                                .paragraphStyle: ParagraphStyle.default]
+
+        storage.setHTML(initialHTML, defaultAttributes: defaultAttributes)
+        let expectedResult = "One"+String(.paragraphSeparator)+String(.paragraphSeparator)+"Two"
+        let result = String(storage.mutableString)
+
+        XCTAssertEqual(expectedResult, result)
+    }
 }

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenblockConverter.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenblockConverter.swift
@@ -18,7 +18,7 @@ class GutenblockConverter: ElementConverter {
         
         let attributes = self.attributes(for: element, inheriting: attributes)
     
-        return serialize(element, nil, attributes)
+        return serialize(element, nil, attributes, false)
     }
     
     private func attributes(for element: ElementNode, inheriting attributes: [NSAttributedString.Key: Any]) -> [NSAttributedString.Key: Any] {

--- a/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenpackConverter.swift
+++ b/WordPressEditor/WordPressEditor/Classes/Plugins/WordPressPlugin/Gutenberg/GutenpackConverter.swift
@@ -27,7 +27,7 @@ public class GutenpackConverter: ElementConverter {
             
             let representation = NSAttributedString(attachment: attachment, attributes: attributes)
             
-            return serialize(element, representation, attributes)
+            return serialize(element, representation, attributes, false)
         }
 
         let blockContent = String(content[content.startIndex ..< content.index(before: content.endIndex)])
@@ -37,7 +37,7 @@ public class GutenpackConverter: ElementConverter {
         let attachment = GutenpackAttachment(name: blockName, content: blockContent)
         let representation = NSAttributedString(attachment: attachment, attributes: attributes)
         
-        return serialize(element, representation, attributes)
+        return serialize(element, representation, attributes, false)
     }
         
 }

--- a/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/GalleryShortcode/GalleryElementConverterTests.swift
+++ b/WordPressEditor/WordPressEditorTests/WordPressPlugin/Calypso/GalleryShortcode/GalleryElementConverterTests.swift
@@ -10,7 +10,7 @@ class GalleryElementConverterTests: XCTestCase {
         let attributes = [Attribute(name: "columns", value: .string("4"))]
         let element = ElementNode(type: .gallery, attributes: attributes)
         
-        let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes) -> NSAttributedString in
+        let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes, before) -> NSAttributedString in
             return NSAttributedString()
         }
         
@@ -24,7 +24,7 @@ class GalleryElementConverterTests: XCTestCase {
         let attributes = [Attribute(name: "iDs", value: .string("4, 2, 6,8"))]
         let element = ElementNode(type: .gallery, attributes: attributes)
         
-        let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes) -> NSAttributedString in
+        let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes, before) -> NSAttributedString in
             return NSAttributedString()
         }
         
@@ -43,7 +43,7 @@ class GalleryElementConverterTests: XCTestCase {
             let attributes = [Attribute(name: "orderby", value: .string(orderValue))]
             let element = ElementNode(type: .gallery, attributes: attributes)
             
-            let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes) -> NSAttributedString in
+            let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes, before) -> NSAttributedString in
                 return NSAttributedString()
             }
             
@@ -63,7 +63,7 @@ class GalleryElementConverterTests: XCTestCase {
             let attributes = [Attribute(name: "orderby", value: .string(orderByValue))]
             let element = ElementNode(type: .gallery, attributes: attributes)
             
-            let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes) -> NSAttributedString in
+            let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes, before) -> NSAttributedString in
                 return NSAttributedString()
             }
             
@@ -92,7 +92,7 @@ class GalleryElementConverterTests: XCTestCase {
                 let attributes = [columnsAttribute, idsAttribute, orderAttribute, orderByAttribute]
                 let element = ElementNode(type: .gallery, attributes: attributes)
                 
-                let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes) -> NSAttributedString in
+                let (gallery, _) = converter.convert(element, inheriting: [:]) { (elementNode, intrinsicRepresentation, attributes, intrinsicRepresentationBeforeChildren) -> NSAttributedString in
                     return NSAttributedString()
                 }
                 


### PR DESCRIPTION
Fixes #1180 

This PR addresses the issues reported on the ticket above by creating a dedicated LIConverter in order to check when to add a intrinsic representation for the <li> before or after the children.

The main logic here is that if the Li element has children elements that are nested lists and no text defined we need to add "\n" to the content in order for the marker to be shown.

To test:
 - If you set the HTML like this: 

```
<ul>
  <li>One</li>
  <li>
    <ul>
      <li>Two</li>
    </ul>
  </li>
</ul>
```

You should get something like this rendered:

<img width="147" alt="Screenshot 2019-05-01 at 12 27 52" src="https://user-images.githubusercontent.com/651601/57015470-df1ae580-6c0c-11e9-9768-af10731845c7.png">

Besides this test the remaining logic of lists should be retested:
 - Create lists
 - Indent element
 - Change styles
 - Remove list item
 - Add new list item