### PR TITLE
Compatibility with both CocoaPods dynamic and static frameworks

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A830346228583B200798076 /* NSBundle+AztecBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A830345228583B200798076 /* NSBundle+AztecBundle.swift */; };
 		40359F261FD88A5F00B1C1D2 /* HRElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40359F251FD88A5F00B1C1D2 /* HRElementConverter.swift */; };
 		40359F281FD88A7900B1C1D2 /* BRElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40359F271FD88A7900B1C1D2 /* BRElementConverter.swift */; };
 		40A2986D1FD61B0C00AEDF3B /* ElementConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A2986C1FD61B0C00AEDF3B /* ElementConverter.swift */; };
@@ -272,6 +273,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1A830345228583B200798076 /* NSBundle+AztecBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSBundle+AztecBundle.swift"; sourceTree = "<group>"; };
 		40359F251FD88A5F00B1C1D2 /* HRElementConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HRElementConverter.swift; sourceTree = "<group>"; };
 		40359F271FD88A7900B1C1D2 /* BRElementConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BRElementConverter.swift; sourceTree = "<group>"; };
 		40A2986C1FD61B0C00AEDF3B /* ElementConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElementConverter.swift; sourceTree = "<group>"; };
@@ -733,6 +735,7 @@
 				F10BE6191EA7AE9D002E4625 /* NSAttributedString+ReplaceOcurrences.swift */,
 				F12328761FB638C6001E35EF /* NSAttributedStringKey+Aztec.swift */,
 				B574F4A31FB0CF3A0048F355 /* NSAttributedStringKey+Conversion.swift */,
+				1A830345228583B200798076 /* NSBundle+AztecBundle.swift */,
 				FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */,
 				F1584795203C9B4C00EE05A1 /* NSMutableAttributedString+ParagraphProperty.swift */,
 				F10BE6171EA7ADA6002E4625 /* NSMutableAttributedString+ReplaceOcurrences.swift */,
@@ -1576,6 +1579,7 @@
 				F15BA60D215159A600424120 /* ItalicStringAttributeConverter.swift in Sources */,
 				F1656FDC2152A00E009C7E3A /* ConditionalStringAttributeConverter.swift in Sources */,
 				599F25541D8BC9A1002871D6 /* TextView.swift in Sources */,
+				1A830346228583B200798076 /* NSBundle+AztecBundle.swift in Sources */,
 				F1E1D5801FEC44B30086B339 /* AttachmentElementConverter.swift in Sources */,
 				F1BDDDE520603C18000714E1 /* FigcaptionFormatter.swift in Sources */,
 				B524228D1F30C039002E7C6C /* HTMLDiv.swift in Sources */,

--- a/Aztec/Classes/Extensions/NSBundle+AztecBundle.swift
+++ b/Aztec/Classes/Extensions/NSBundle+AztecBundle.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension Bundle {
+    @objc public class var aztecBundle: Bundle {
+        let defaultBundle = Bundle(for: EditorView.self)
+        // If installed with CocoaPods, resources will be in WordPress-Aztec-iOS.bundle
+        if let bundleURL = defaultBundle.resourceURL,
+            let resourceBundle = Bundle(url: bundleURL.appendingPathComponent("WordPress-Aztec-iOS")) {
+            return resourceBundle
+        }
+        // Otherwise, the default bundle is used for resources
+        return defaultBundle
+    }
+}

--- a/Aztec/Classes/GUI/Assets.swift
+++ b/Aztec/Classes/GUI/Assets.swift
@@ -4,13 +4,13 @@ import UIKit
 class Assets {
 
     public static var playIcon: UIImage {
-        let bundle = Bundle(for: self)
+        let bundle = Bundle.aztecBundle
         let playImage = UIImage(named: "play", in: bundle, compatibleWith: nil)!
         return playImage
     }
 
     public static var imageIcon: UIImage {
-        let bundle = Bundle(for: self)
+        let bundle = Bundle.aztecBundle
         let playImage = UIImage(named: "image", in: bundle, compatibleWith: nil)!
         return playImage
     }

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -32,7 +32,11 @@ Pod::Spec.new do |s|
 
   s.module_name = "Aztec"
   s.source_files = 'Aztec/Classes/**/*'
-  s.resources = 'Aztec/Assets/**/*'
+  s.resource_bundles = {
+    'WordPress-Aztec-iOS': [
+      "Aztec/Assets/**/*"
+    ]
+  }
 
   s.xcconfig = {'OTHER_LDFLAGS' => '-lxml2',
   				'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'}


### PR DESCRIPTION
This makes the changes needed for the Aztec pod to be installed as a static or dynamic framework (with or without `use_frameworks!`). Currently, it does not work correctly when installed statically as the `.xcassets` file can conflict with the host app. The Editor pod already works fine (it doesn't have an `xcassets` file).

The changes are as follows:

- Use `resource_bundles` to move resources to `WordPress-Aztec-iOS.bundle`. This keeps the pod's resources separate from the main app.
- Replace all uses of `Bundle(for:..)` with the new `Bundle.aztecBundle` helper.

This will allow us to proceed with https://github.com/wordpress-mobile/WordPress-iOS/pull/11559.

To test:

- Run the example app and confirm it looks fine (the image place holder and video play button should be shown correctly).