### PR TITLE
Make default HTML elements to represent striketrough to be s

### DIFF
--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -899,7 +899,7 @@ private extension AttributedStringParser {
             return representationElement.toElementNode()
         }
 
-        return ElementNode(type: .strike)
+        return ElementNode(type: .s)
     }
 
     /// Extracts all of the Code Elements contained within a collection of Attributes.

--- a/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
+++ b/AztecTests/NSAttributedString/Conversions/AttributedStringParserTests.swift
@@ -134,7 +134,7 @@ class AttributedStringParserTests: XCTestCase {
             XCTFail()
             return
         }
-        XCTAssertEqual(strike.name, Element.strike.rawValue)
+        XCTAssertEqual(strike.name, Element.s.rawValue)
         XCTAssertEqual(strike.children.count, 1)
 
         guard let text = strike.children.first as? TextNode else {


### PR DESCRIPTION
Make the implementation of the strikethrough formatting to use the `<s>` element by default.

This will help with GB compatibility.

To test:
 - Start the demo app
 - Open an empty demo
 - Select the option Strikethrough on the toolbar
 - type some words
 - Switch to HTML
 - Make sure `<s>` was used.
 - Switch to a demo with content
 - Check on the demo content if the Strikethrough elements activate the toolbar.

