### PR TITLE
Fix typo in NSBundle path

### DIFF
--- a/Aztec/Classes/Extensions/NSBundle+AztecBundle.swift
+++ b/Aztec/Classes/Extensions/NSBundle+AztecBundle.swift
@@ -5,7 +5,7 @@ extension Bundle {
         let defaultBundle = Bundle(for: EditorView.self)
         // If installed with CocoaPods, resources will be in WordPress-Aztec-iOS.bundle
         if let bundleURL = defaultBundle.resourceURL,
-            let resourceBundle = Bundle(url: bundleURL.appendingPathComponent("WordPress-Aztec-iOS")) {
+            let resourceBundle = Bundle(url: bundleURL.appendingPathComponent("WordPress-Aztec-iOS.bundle")) {
             return resourceBundle
         }
         // Otherwise, the default bundle is used for resources


### PR DESCRIPTION
@SergioEstevao spotted an issue with my changes in https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1182 when Aztec is integrated in WPiOS as a static framework.

It turns out there was a slight typo in the bundle helper. it works correctly now.

To test:

- Point WPiOS to this branch.
- Test that a post with a video loads correctly (it shows the play button).
