### PR TITLE
Merge Release/1.6.3 into master

### DIFF
--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.6.2'
+  s.version          = '1.6.3'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.6.2'
+  s.version          = '1.6.3'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Merge Release/1.6.3 into master.

Includes fix from https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1187
