### PR TITLE
Make sure that standalone block elements are kept.

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/ElementNode.swift
@@ -255,7 +255,7 @@ public class ElementNode: Node {
     /// - Returns: Returns `true` if it can be the last one, false otherwise.
     ///
     func canBeLastInTree() -> Bool {
-        return hasAttributes() || type == .li
+        return hasAttributes() || isBlockLevel()
     }
 
     /// Find out if this is a block-level element.


### PR DESCRIPTION
Related #1157 

This PR is related to the issue above, but it implements a more generic approach where all block-level elements are kept even when they are empty and the only ones in the content.


To test:
 - Open the empty demo app
 - Switch to HTML and insert the following: ```<blockquote></blockquote>```
 - Switch to Visual mode
 - See if the blockquote element is displayed, you should see an empty quote
 - Switch to HTML mode, and check the HTML is still there


