### PR TITLE
Fix copy paste

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -555,7 +555,11 @@ open class TextView: UITextView {
     // MARK: - Pasteboard Helpers
 
     internal func storeInPasteboard(encoded data: Data, pasteboard: UIPasteboard = UIPasteboard.general) {
-        pasteboard.setData(data, forPasteboardType: NSAttributedString.pastesboardUTI)
+        if pasteboard.numberOfItems > 0 {
+            pasteboard.items[0][NSAttributedString.pastesboardUTI] = data;
+        } else {
+            pasteboard.addItems([[NSAttributedString.pastesboardUTI: data]])
+        }
     }
 
     // MARK: - Intercept keyboard operations

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -2016,4 +2016,15 @@ class TextViewTests: XCTestCase {
 
         XCTAssertEqual(output, expected)
     }
+
+    // MARK: - Copy tests
+
+    func testCopyAndPasteToPlainText() {
+        let sourceTextView = TextViewStub(withHTML: "This is text with attributes: <strong>bold</strong>")
+
+        sourceTextView.selectedRange = NSRange(location: 0, length: sourceTextView.text.count)
+        sourceTextView.copy(nil)
+
+        XCTAssertEqual(UIPasteboard.general.string, "This is text with attributes: bold")
+    }
 }


### PR DESCRIPTION
Fixes #

This PR brings the fix for copy paste to develop.

To test:
 - Run the demo app
 - Copy some content from one of the demo content
 - Paste it in another app, for example Notes or Reminders
 - See that the content is pasted in plain text.

