### PR TITLE
Add html to pasteboard when doing copy or cut.

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -365,6 +365,10 @@ open class TextStorage: NSTextStorage {
     open func getHTML(prettify: Bool = false) -> String {
         return htmlConverter.html(from: self, prettify: prettify)
     }
+
+    open func getHTML(prettify: Bool = false, range: NSRange) -> String {
+        return htmlConverter.html(from: self.attributedSubstring(from: range), prettify: prettify)
+    }
     
     func setHTML(_ html: String, defaultAttributes: [NSAttributedString.Key: Any]) {
         let originalLength = length

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -1,6 +1,6 @@
 import UIKit
 import Foundation
-
+import CoreServices
 
 // MARK: - TextViewAttachmentDelegate
 //
@@ -458,16 +458,20 @@ open class TextView: UITextView {
 
     open override func cut(_ sender: Any?) {
         let data = storage.attributedSubstring(from: selectedRange).archivedData()
+        let html = storage.getHTML(range: selectedRange)
         super.cut(sender)
 
         storeInPasteboard(encoded: data)
+        storeInPasteboard(html: html)
     }
 
     open override func copy(_ sender: Any?) {
         let data = storage.attributedSubstring(from: selectedRange).archivedData()
+        let html = storage.getHTML(range: selectedRange)
         super.copy(sender)
 
         storeInPasteboard(encoded: data)
+        storeInPasteboard(html: html)
     }
 
     open override func paste(_ sender: Any?) {
@@ -559,6 +563,14 @@ open class TextView: UITextView {
             pasteboard.items[0][NSAttributedString.pastesboardUTI] = data;
         } else {
             pasteboard.addItems([[NSAttributedString.pastesboardUTI: data]])
+        }
+    }
+
+    internal func storeInPasteboard(html: String, pasteboard: UIPasteboard = UIPasteboard.general) {
+        if pasteboard.numberOfItems > 0 {
+            pasteboard.items[0][kUTTypeHTML as String] = html;
+        } else {
+            pasteboard.addItems([[kUTTypeHTML as String: html]])
         }
     }
 

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -2017,7 +2017,7 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(output, expected)
     }
 
-    // MARK: - Copy tests
+    // MARK: - Copy/Paste tests
 
     func testCopyAndPasteToPlainText() {
         let sourceTextView = TextViewStub(withHTML: "This is text with attributes: <strong>bold</strong>")
@@ -2027,4 +2027,32 @@ class TextViewTests: XCTestCase {
 
         XCTAssertEqual(UIPasteboard.general.string, "This is text with attributes: bold")
     }
+
+    func testCopyHTML() {
+        let sourceTextView = TextViewStub(withHTML: "<p>This is text with attributes: <strong>bold</strong> and <italic>italic</italic></p>")
+
+        sourceTextView.selectedRange = NSRange(location: 0, length: sourceTextView.text.count)
+        sourceTextView.copy(nil)
+
+        XCTAssertEqual(UIPasteboard.general.html(), "<p>This is text with attributes: <strong>bold</strong> and <italic>italic</italic></p>")
+    }
+
+    func testCutHTML() {
+        let sourceTextView = TextViewStub(withHTML: "<p>This is text with attributes: <strong>bold</strong> and <italic>italic</italic></p>")
+
+        sourceTextView.selectedRange = NSRange(location: 0, length: sourceTextView.text.count)
+        sourceTextView.cut(nil)
+
+        XCTAssertEqual(UIPasteboard.general.html(), "<p>This is text with attributes: <strong>bold</strong> and <italic>italic</italic></p>")
+    }
+
+    func testCopyPartialHTML() {
+        let sourceTextView = TextViewStub(withHTML: "<p><strong>bold</strong> and <italic>italic</italic></p>")
+
+        sourceTextView.selectedRange = NSRange(location: 0, length: 3)
+        sourceTextView.copy(nil)
+
+        XCTAssertEqual(UIPasteboard.general.html(), "<p><strong>bol</strong></p>")
+    }
+
 }


### PR DESCRIPTION
This PR implements copy/cut of HTML out of Aztec TextView.

This is done by getting the HTML of the selected range and then adding it to the pasteboard.

To test:
 - On the demo content copy or cut a selection that has HTML attributes (bold, italic, etc..)
 - Paste it on another app that supports it. For example ~Pages~ GB web on Safari
 - See that it was properly pasted.

