### PR TITLE
Allow configuration of text color

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -226,11 +226,13 @@ open class TextView: UITextView {
     var defaultMissingImage: UIImage
     
     fileprivate var defaultAttributes: [NSAttributedString.Key: Any] {
-        let attributes: [NSAttributedString.Key: Any] = [
+        var attributes: [NSAttributedString.Key: Any] = [
             .font: defaultFont,
-            .paragraphStyle: defaultParagraphStyle
+            .paragraphStyle: defaultParagraphStyle,
         ]
-
+        if let color = textColor {
+            attributes[.foregroundColor] = color
+        }
         return attributes
     }
     

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -324,7 +324,8 @@ class EditorDemoController: UIViewController {
         textView.accessibilityLabel = accessibilityLabel
         textView.font = Constants.defaultContentFont
         textView.keyboardDismissMode = .interactive
-        textView.textColor = UIColor.darkText
+        textView.textColor = UIColor(red: 0x1A/255.0, green: 0x1A/255.0, blue: 0x1A/255.0, alpha: 1)
+        textView.linkTextAttributes = [.foregroundColor: UIColor(red: 0x01 / 255.0, green: 0x60 / 255.0, blue: 0x87 / 255.0, alpha: 1), NSAttributedString.Key.underlineStyle: NSNumber(value: NSUnderlineStyle.single.rawValue)]
     }
 
     private func registerAttachmentImageProviders() {


### PR DESCRIPTION
This PR allows the configuration of the textColor to affect the default color being used on the editor.

To test:
 - Run the demo app
 - Check if the textColor applied is being used.
 - Try to change the color on the EditorDemoController class to see if the changes have effect.

