### PR TITLE
Make available method to extract HTML from a string.

### DIFF
--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -369,6 +369,10 @@ open class TextStorage: NSTextStorage {
     open func getHTML(prettify: Bool = false, range: NSRange) -> String {
         return htmlConverter.html(from: self.attributedSubstring(from: range), prettify: prettify)
     }
+
+    open func getHTML(prettify: Bool = false, from attributedString: NSAttributedString) -> String {
+        return htmlConverter.html(from: attributedString, prettify: prettify)
+    }
     
     func setHTML(_ html: String, defaultAttributes: [NSAttributedString.Key: Any]) {
         let originalLength = length


### PR DESCRIPTION
This PR just makes another method available to the outside to retrieve HTML from any attributed string.

To test:
 - There is no change in the logic of aztec in any way so no tests needed.
 - You can test the use of this method using this GB-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1097
