### PR TITLE
Notify changes on TextView only on user events

### DIFF
--- a/Aztec/Classes/Extensions/UITextView+Delegate.swift
+++ b/Aztec/Classes/Extensions/UITextView+Delegate.swift
@@ -6,6 +6,9 @@ extension UITextView {
     /// Notifies the delegate of a text change.
     ///
     final func notifyTextViewDidChange() {
+        if let textView = self as? TextView, !textView.shouldNotifyOfNonUserChanges {
+            return
+        }
         delegate?.textViewDidChange?(self)
         NotificationCenter.default.post(name: UITextView.textDidChangeNotification, object: self)
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -176,7 +176,7 @@ open class TextView: UITextView {
 
     /// If this is true the text view will notify is delegate and notification system when changes happen by calls to methods like setHTML
     ///
-    open var shouldNotifyOfNonUserChanges = false
+    open var shouldNotifyOfNonUserChanges = true
 
     // MARK: - Customizable Input VC
     

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -173,6 +173,11 @@ open class TextView: UITextView {
     ///
     open var pasteboardDelegate: TextViewPasteboardDelegate = AztecTextViewPasteboardDelegate()
 
+
+    /// If this is true the text view will notify is delegate and notification system when changes happen by calls to methods like setHTML
+    ///
+    open var shouldNotifyOfNonUserChanges = false
+
     // MARK: - Customizable Input VC
     
     private var customInputViewController: UIInputViewController?


### PR DESCRIPTION
This changes introduces a flag to TextView to allow disabling notification of text changes that are cause because of code changes. For example when a setHTML is done by code, the TextView was sending a notification and evoking the delegate that a change in content happened.

This is special relevant on the Aztec wrapper to avoid a notification chain when setHTML is sent from the React/JS side and the component was immediately sending a notification of change back.

This will reduce the number of events being sent across the bridge from JS/Native and improved performance.

To test:
 - Check the demo app/content to see if everything works fine when flag is enabled
 - To check behaviour when flag in disabled you can use this PR in GB-mobile: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1144