### PR TITLE
Allow replacement of last empty line on Aztec

### DIFF
--- a/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
@@ -70,7 +70,7 @@ public class HTMLConverter {
     func replaceLastEmptyLine(in attributedString: NSAttributedString, with replacement: Character) -> NSAttributedString {
         var result = attributedString
         let string = attributedString.string
-        if string.isEmptyLineAtEndOfFile(at: string.count), !string.isEmpty, let location = string.location(before: attributedString.length) {
+        if !string.isEmpty, string.isEmptyLineAtEndOfFile(at: string.count), string.hasSuffix(String(.paragraphSeparator)), let location = string.location(before: attributedString.length) {
             let mutableString = NSMutableAttributedString(attributedString: attributedString)
             let attributes = mutableString.attributes(at: location, effectiveRange: nil)
             mutableString.replaceCharacters(in: NSRange(location: location, length: attributedString.length-location), with: NSAttributedString(string: String(replacement), attributes: attributes))

--- a/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
@@ -23,7 +23,7 @@ public class HTMLConverter {
 
     /// If a value is set the character set will be used to replace any last empty line created by the converter.
     ///
-    open var characterToReplaceLastEmtpyLine: Character?
+    open var characterToReplaceLastEmptyLine: Character?
 
     let htmlToTree = HTMLParser()
     
@@ -60,7 +60,7 @@ public class HTMLConverter {
         let defaultAttributes = defaultAttributes ?? [:]
         var attributedString = treeToAttributedString.serialize(rootNode, defaultAttributes: defaultAttributes)
 
-        if let characterToUse = characterToReplaceLastEmtpyLine {
+        if let characterToUse = characterToReplaceLastEmptyLine {
             attributedString = replaceLastEmptyLine(in: attributedString, with: characterToUse)
         }
         

--- a/Aztec/Classes/TextKit/TextStorage.swift
+++ b/Aztec/Classes/TextKit/TextStorage.swift
@@ -81,7 +81,7 @@ open class TextStorage: NSTextStorage {
     
     // MARK: - HTML Conversion
     
-    let htmlConverter = HTMLConverter()
+    public let htmlConverter = HTMLConverter()
     
     // MARK: - PluginManager
     

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -267,7 +267,7 @@ open class TextView: UITextView {
 
     // MARK: - TextKit Aztec Subclasses
 
-    var storage: TextStorage {
+    public var storage: TextStorage {
         return textStorage as! TextStorage
     }
 

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -494,4 +494,26 @@ class TextStorageTests: XCTestCase {
 
         XCTAssertEqual(expectedResult, result)
     }
+
+    func testEmptyListOutput() {
+        let initialHTML = "<ul><li></li></ul>"
+
+        // Setup
+        let defaultAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                                .paragraphStyle: ParagraphStyle.default]
+
+        storage.setHTML(initialHTML, defaultAttributes: defaultAttributes)
+        var expectedResult = String(.paragraphSeparator)
+        var result = String(storage.string)
+
+        XCTAssertEqual(expectedResult, result)
+
+        storage.htmlConverter.characterToReplaceLastEmtpyLine = Character(.zeroWidthSpace)
+
+        storage.setHTML(initialHTML, defaultAttributes: defaultAttributes)
+        expectedResult = String(.zeroWidthSpace)
+        result = String(storage.string)
+
+        XCTAssertEqual(expectedResult, result)
+    }
 }

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -508,7 +508,7 @@ class TextStorageTests: XCTestCase {
 
         XCTAssertEqual(expectedResult, result)
 
-        storage.htmlConverter.characterToReplaceLastEmtpyLine = Character(.zeroWidthSpace)
+        storage.htmlConverter.characterToReplaceLastEmptyLine = Character(.zeroWidthSpace)
 
         storage.setHTML(initialHTML, defaultAttributes: defaultAttributes)
         expectedResult = String(.zeroWidthSpace)

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -516,4 +516,26 @@ class TextStorageTests: XCTestCase {
 
         XCTAssertEqual(expectedResult, result)
     }
+
+    func testCiteOutput() {
+        let initialHTML = "<cite>Hello<br></cite>"
+
+        // Setup
+        let defaultAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                                .paragraphStyle: ParagraphStyle.default]
+
+        storage.setHTML(initialHTML, defaultAttributes: defaultAttributes)
+        var expectedResult = String("Hello")+String(.lineSeparator)
+        var result = String(storage.string)
+
+        XCTAssertEqual(expectedResult, result)
+
+        storage.htmlConverter.characterToReplaceLastEmptyLine = Character(.zeroWidthSpace)
+
+        storage.setHTML(initialHTML, defaultAttributes: defaultAttributes)
+        expectedResult = String("Hello")+String(.lineSeparator)
+        result = String(storage.string)
+
+        XCTAssertEqual(expectedResult, result)
+    }
 }


### PR DESCRIPTION
Allows the replacement of last empty lines inserted by the serialisers to be replaced to a specific character.

This is special important on handling HTML that consistent in single empty list elements or quote elements where the style needs to be applied to empty lines.

To test:
 - Just check if unit tests are running correctly
 - You can test the use of this feature using this GB-mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1129

