### PR TITLE
Issue/fix crash on toggle quotes

### DIFF
--- a/Aztec/Classes/Extensions/NSMutableAttributedString+ReplaceOcurrences.swift
+++ b/Aztec/Classes/Extensions/NSMutableAttributedString+ReplaceOcurrences.swift
@@ -32,17 +32,19 @@ extension NSMutableAttributedString {
 
         assert(!replacementString.contains(stringToFind),
                "Allowing the replacement string to contain the original string would result in a ininite loop.")
-
-        let swiftUTF16Range = string.utf16.range(from: range)
+        let rangeDifference = (replacementString as NSString).length - (stringToFind as NSString).length
+        var swiftUTF16Range = string.utf16.range(from: range)
         var swiftRange = string.range(from: swiftUTF16Range)
-
         while let matchRange = string.range(of: stringToFind, options: [], range: swiftRange, locale: nil) {
             let matchNSRange = string.utf16NSRange(from: matchRange)
 
             replaceCharacters(in: matchNSRange, with: replacementString)
             
             // Since the new string may invalidate the initial swift range, we want to update it.
-            swiftRange = swiftRange.lowerBound ..< string.index(matchRange.lowerBound, offsetBy: replacementString.count)
+            // And because the string that backs the NSAttributeString will change after the replace we need to recalculate the index from scratch
+            let updatedRange = range.extendedRight(by: rangeDifference)
+            swiftUTF16Range = string.utf16.range(from: updatedRange)
+            swiftRange = string.range(from: swiftUTF16Range)
         }
     }
 }

--- a/AztecTests/Extensions/NSMutableAttributedStringReplaceOcurrencesTests.swift
+++ b/AztecTests/Extensions/NSMutableAttributedStringReplaceOcurrencesTests.swift
@@ -88,4 +88,14 @@ class NSMutableAttributedStringReplaceOcurrencesTests: XCTestCase {
 
         XCTAssertEqual(newAttrString, NSAttributedString(string: "🌎💚💚😬💚🌎"))
     }
+
+    /// Tests that replacing ocurrences on the end of a range work correctly
+    ///
+    func testReplaceOcurrencesThatAreOnEndOfRange() {
+        let attrString = NSAttributedString(string: "Hello"+String(.paragraphSeparator)+"Amazing"+String(.paragraphSeparator)+"World"+String(.paragraphSeparator))
+        let newAttrString = NSMutableAttributedString(attributedString: attrString)
+        newAttrString.replaceOcurrences(of: String(.paragraphSeparator), with: String(.lineFeed), within: NSRange(location:6, length: 8))
+
+        XCTAssertEqual(newAttrString, NSAttributedString(string: "Hello"+String(.paragraphSeparator)+"Amazing"+String(.lineFeed)+"World"+String(.paragraphSeparator)))
+    }
 }

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1254,6 +1254,22 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(textView.text, Constants.sampleText0 + Constants.sampleText1 + String(.lineFeed) + String(.lineFeed))
     }
 
+    /// Verifies that toggling a Blockquote paragraph in the middle of paragraph does not crash system.    
+    ///
+    func testTogglingBlockquoteOnMiddleOfRangeDoesNotCrash() {
+        let initialQuote = """
+            <blockquote><strong>Quote One</strong></blockquote>
+            <blockquote><strong>Quote Two</strong></blockquote>
+            <blockquote><strong>Quote Three</strong></blockquote>
+        """
+        let textView = TextViewStub(withHTML: initialQuote)
+
+        textView.selectedTextRange = textView.textRange(from: textView.endOfDocument, to: textView.endOfDocument)
+        textView.toggleBlockquote(range: NSRange(location: 11, length: 0))
+
+        XCTAssertEqual(textView.text, "Quote One" + String(.paragraphSeparator)+"Quote Two"+String(.lineFeed)+"Quote Three")
+    }
+
 
     // MARK: - Pre
 


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-iOS/issues/11948

This issues fixes a crash on the app when toggling a blockquote in the middle of the following HTML

```
<blockquote><strong>Quote One</strong></blockquote>
<blockquote><strong>Quote Two</strong></blockquote>
<blockquote><strong>Quote Three</strong></blockquote>
```

The crash was happening inside the method 
```func replaceOcurrences(of stringToFind: String, with replacementString: String, within range: NSRange) {```

When I first try to unit test the original method using a vanilla NSMutableAttributedString everything was running correctly. Then I remembered that our implementation of TextStorage while it uses an NSMutableString it has special handling for the string property.
This was the reason that the range was getting invalid, after the first replacement was made and then caused a crash on the second tentative to math the occurrence.
The bug was fixed by making sure the range where we are trying to match is completely recalculated after a replacement.

To test:
 - Start the empty demo in the Calypso/Gutenberg
 - Copy paste the HTML above
 - Tap on the line with `Quote Two`
 - Tap on Toggle Blockquote icon on the toolbar
 - Check that app doesn't crash

