### PR TITLE
Allow customisation of format bar colors

### DIFF
--- a/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
+++ b/Aztec/Classes/GUI/FormatBar/FormatBarItem.swift
@@ -14,7 +14,7 @@ open class FormatBarItem: UIButton {
 
     /// Tint Color to be applied whenever the button is selected
     ///
-    var selectedTintColor: UIColor? {
+    open var selectedTintColor: UIColor? {
         didSet {
             updateTintColor()
         }
@@ -23,7 +23,7 @@ open class FormatBarItem: UIButton {
 
     /// Tint Color to be applied whenever the button is highlighted
     ///
-    var highlightedTintColor: UIColor? {
+    open var highlightedTintColor: UIColor? {
         didSet {
             updateTintColor()
         }
@@ -32,7 +32,7 @@ open class FormatBarItem: UIButton {
 
     /// Tint Color to be applied whenever the button is disabled
     ///
-    var disabledTintColor: UIColor? {
+    open var disabledTintColor: UIColor? {
         didSet {
             updateTintColor()
         }
@@ -41,7 +41,7 @@ open class FormatBarItem: UIButton {
 
     /// Tint Color to be applied to the "Normal" State
     ///
-    var normalTintColor: UIColor? {
+    open var normalTintColor: UIColor? {
         didSet {
             updateTintColor()
         }

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.7.0'
+  s.version          = '1.7.1-beta.1'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.8.0'
+  s.version          = '1.8.1'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.7.0'
+  s.version          = '1.7.1-beta.1'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.8.0'
+  s.version          = '1.8.1'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
This PR exposes the color properties for `FormatBarItem`. This is required for implementing dark mode in WPiOS. You can test it with this WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12373