### PR TITLE
[Dark Mode] Expose editor html storage as property

### DIFF
--- a/Aztec/Classes/EditorView/EditorView.swift
+++ b/Aztec/Classes/EditorView/EditorView.swift
@@ -6,12 +6,14 @@ import UIKit
 public class EditorView: UIView {
     public let htmlTextView: UITextView
     public let richTextView: TextView
+    public let htmlStorage: HTMLStorage
     
     // MARK: - Encoding / Decoding
     
     static let htmlTextViewKey = "Aztec.EditorView.htmlTextView"
     static let richTextViewKey = "Aztec.EditorView.richTextView"
-    
+    static let htmlStorageKey = "Aztec.EditorView.htmlStorage"
+
     // MARK: - Content Insets
     
     public var contentInset: UIEdgeInsets {
@@ -95,12 +97,14 @@ public class EditorView: UIView {
     
     public required init?(coder aDecoder: NSCoder) {
         guard let htmlTextView = aDecoder.decodeObject(forKey: EditorView.htmlTextViewKey) as? UITextView,
-            let richTextView = aDecoder.decodeObject(forKey: EditorView.richTextViewKey) as? TextView else {
+            let richTextView = aDecoder.decodeObject(forKey: EditorView.richTextViewKey) as? TextView,
+            let htmlStorage = aDecoder.decodeObject(forKey: EditorView.htmlStorageKey) as? HTMLStorage else {
                 return nil
         }
         
         self.htmlTextView = htmlTextView
         self.richTextView = richTextView
+        self.htmlStorage = htmlStorage
         
         if #available(iOS 11, *) {
             htmlTextView.smartInsertDeleteType = .no
@@ -117,10 +121,11 @@ public class EditorView: UIView {
         let storage = HTMLStorage(defaultFont: defaultHTMLFont)
         let layoutManager = NSLayoutManager()
         let container = NSTextContainer()
-        
+
         storage.addLayoutManager(layoutManager)
         layoutManager.addTextContainer(container)
-        
+
+        self.htmlStorage = storage
         self.htmlTextView = UITextView(frame: .zero, textContainer: container)
         self.richTextView = TextView(defaultFont: defaultFont, defaultParagraphStyle: defaultParagraphStyle, defaultMissingImage: defaultMissingImage)
         

--- a/Aztec/Classes/EditorView/EditorView.swift
+++ b/Aztec/Classes/EditorView/EditorView.swift
@@ -6,13 +6,17 @@ import UIKit
 public class EditorView: UIView {
     public let htmlTextView: UITextView
     public let richTextView: TextView
-    public let htmlStorage: HTMLStorage
+    public var htmlStorage: HTMLStorage {
+        guard let htmlStorage = htmlTextView.textStorage as? HTMLStorage else {
+            fatalError("If this happens, something is very off on the init config")
+        }
+        return htmlStorage
+    }
     
     // MARK: - Encoding / Decoding
     
     static let htmlTextViewKey = "Aztec.EditorView.htmlTextView"
     static let richTextViewKey = "Aztec.EditorView.richTextView"
-    static let htmlStorageKey = "Aztec.EditorView.htmlStorage"
 
     // MARK: - Content Insets
     
@@ -97,14 +101,12 @@ public class EditorView: UIView {
     
     public required init?(coder aDecoder: NSCoder) {
         guard let htmlTextView = aDecoder.decodeObject(forKey: EditorView.htmlTextViewKey) as? UITextView,
-            let richTextView = aDecoder.decodeObject(forKey: EditorView.richTextViewKey) as? TextView,
-            let htmlStorage = aDecoder.decodeObject(forKey: EditorView.htmlStorageKey) as? HTMLStorage else {
+            let richTextView = aDecoder.decodeObject(forKey: EditorView.richTextViewKey) as? TextView else {
                 return nil
         }
         
         self.htmlTextView = htmlTextView
         self.richTextView = richTextView
-        self.htmlStorage = htmlStorage
         
         if #available(iOS 11, *) {
             htmlTextView.smartInsertDeleteType = .no
@@ -125,7 +127,6 @@ public class EditorView: UIView {
         storage.addLayoutManager(layoutManager)
         layoutManager.addTextContainer(container)
 
-        self.htmlStorage = storage
         self.htmlTextView = UITextView(frame: .zero, textContainer: container)
         self.richTextView = TextView(defaultFont: defaultFont, defaultParagraphStyle: defaultParagraphStyle, defaultMissingImage: defaultMissingImage)
         

--- a/Aztec/Classes/TextKit/HTMLStorage.swift
+++ b/Aztec/Classes/TextKit/HTMLStorage.swift
@@ -15,6 +15,10 @@ open class HTMLStorage: NSTextStorage {
     ///
     open var font: UIFont
 
+    /// Color to be applied over HTML text
+    ///
+    open var textColor = Styles.defaultTextColor
+
     /// Color to be applied over HTML Comments
     ///
     open var commentColor = Styles.defaultCommentColor
@@ -124,7 +128,7 @@ private extension HTMLStorage {
     func colorizeHTML() {
         let fullStringRange = rangeOfEntireString
 
-        removeAttribute(.foregroundColor, range: fullStringRange)
+        addAttribute(.foregroundColor, value: textColor, range: fullStringRange)
         addAttribute(.font, value: font, range: fullStringRange)
 
         let tags = RegExes.html.matches(in: string, options: [], range: fullStringRange)
@@ -164,6 +168,7 @@ extension HTMLStorage {
     /// Default Styles
     ///
     public struct Styles {
+        static let defaultTextColor = UIColor.black
         static let defaultCommentColor = UIColor.lightGray
         static let defaultTagColor = UIColor(red: 0x00/255.0, green: 0x75/255.0, blue: 0xB6/255.0, alpha: 0xFF/255.0)
         static let defaultQuotedColor = UIColor(red: 0x6E/255.0, green: 0x96/255.0, blue: 0xB1/255.0, alpha: 0xFF/255.0)

--- a/AztecTests/EditorView/EditorViewTests.swift
+++ b/AztecTests/EditorView/EditorViewTests.swift
@@ -80,4 +80,24 @@ class EditorViewTests: XCTestCase {
         XCTAssertEqual(editorView.editingMode, .richText)
         XCTAssertEqual(editorView.activeView, editorView.richTextView)
     }
+    
+    func testHTMLStorageTextColor() {
+        let font = UIFont.systemFont(ofSize: 14)
+        let editorView = Aztec.EditorView(
+            defaultFont: font,
+            defaultHTMLFont: font,
+            defaultParagraphStyle: ParagraphStyle(),
+            defaultMissingImage: UIImage())
+        
+        XCTAssertEqual(editorView.htmlStorage.textColor, HTMLStorage.Styles.defaultTextColor)
+        
+        editorView.htmlStorage.textColor = .red
+        editorView.richTextView.text = "Hello World"
+        editorView.toggleEditingMode()
+
+        let textColor = editorView.htmlStorage.attribute(.foregroundColor, at: 3, effectiveRange: nil) as! UIColor
+        
+        XCTAssertEqual(editorView.htmlStorage.textColor, UIColor.red)
+        XCTAssertEqual(textColor, UIColor.red)
+    }
 }

--- a/AztecTests/TextKit/HTMLStorageTests.swift
+++ b/AztecTests/TextKit/HTMLStorageTests.swift
@@ -63,4 +63,22 @@ class HTMLStorageTests: XCTestCase {
         XCTAssertEqual(openingTagColor, HTMLStorage.Styles.defaultTagColor)
         XCTAssertEqual(closingTagColor, HTMLStorage.Styles.defaultTagColor)
     }
+    
+    func testSetTextColor() {
+        let font = UIFont.boldSystemFont(ofSize: 12)
+        let storage = HTMLStorage(defaultFont: font)
+        let initialString = "Hello there"
+        
+        storage.insert(NSAttributedString(string: initialString), at: 0)
+        
+        XCTAssertEqual(storage.string, initialString)
+        XCTAssertEqual(storage.textColor, HTMLStorage.Styles.defaultTextColor)
+
+        storage.textColor = .red
+        storage.replaceCharacters(in: NSRange(location: 0, length: 4), with: NSAttributedString(string: "Hello world"))
+        
+        let textColor = storage.attribute(.foregroundColor, at: 0, effectiveRange: nil) as! UIColor
+
+        XCTAssertEqual(textColor, UIColor.red)
+    }
 }

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.9.0'
+  s.version          = '1.9.0-beta.1'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.8.1'
+  s.version          = '1.9.0-beta.1'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.9.0-beta.1'
+  s.version          = '1.9.0'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.9.0'
+  s.version          = '1.9.0-beta.1'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.8.1'
+  s.version          = '1.9.0-beta.1'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.9.0-beta.1'
+  s.version          = '1.9.0'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Refs. [WPiOS #12462](https://github.com/wordpress-mobile/WordPress-iOS/pull/12462)

This PR exposes the Editor html storage as let property in order to customize its colors due to the introduction of DarkMode. This is required for implementing dark mode in [WPiOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/12462).

## To test:
• Run the Unit Tests
• Run [WPiOS #12462](https://github.com/wordpress-mobile/WordPress-iOS/pull/12462)

