### PR TITLE
Make underline action use a span and css by default.

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/UnderlineFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/UnderlineFormatter.swift
@@ -8,3 +8,15 @@ class UnderlineFormatter: StandardAttributeFormatter {
                    htmlRepresentationKey: .underlineHtmlRepresentation)
     }
 }
+
+class SpanUnderlineFormatter: UnderlineFormatter {
+
+    override func apply(to attributes: [NSAttributedString.Key : Any], andStore representation: HTMLRepresentation?) -> [NSAttributedString.Key : Any] {
+
+        let cssAttribute = CSSAttribute.underline
+        let underlineStyleAttribute = Attribute(type: .style, value: .inlineCss([cssAttribute]))
+        let spanRepresentation = HTMLElementRepresentation(ElementNode.init(type: .span, attributes: [underlineStyleAttribute], children: []))
+
+        return super.apply(to: attributes, andStore: HTMLRepresentation(for: .element(spanRepresentation)))        
+    }
+}

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -747,7 +747,7 @@ open class TextView: UITextView {
     private static let formatterMap: [FormattingIdentifier: AttributeFormatter] = [
         .bold: BoldFormatter(),
         .italic: ItalicFormatter(),
-        .underline: UnderlineFormatter(),
+        .underline: SpanUnderlineFormatter(),
         .strikethrough: StrikethroughFormatter(),
         .link: LinkFormatter(),
         .orderedlist: TextListFormatter(style: .ordered),
@@ -935,7 +935,7 @@ open class TextView: UITextView {
     /// - Parameter range: The NSRange to edit.
     ///
     open func toggleUnderline(range: NSRange) {
-        let formatter = UnderlineFormatter()
+        let formatter = SpanUnderlineFormatter()
         toggle(formatter: formatter, atRange: range)
     }
 


### PR DESCRIPTION
Fixes #1212 


To test:
 - Open the demo app
 - Select empty content
 - write some text
 - Apply the underline style with the toolbar
 - Switch to HTML and check that the HTML uses the ```<span style="text-decoration: underline">``` element.
 - Repeat but now apply the style using the shortcut menu by selecting the text and then tapping the BIU option in the context menu.

