### PR TITLE
Making popovert presentation background color dynamic

### DIFF
--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.10.0'
+  s.version          = '1.10.1'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.9.0'
+  s.version          = '1.9.1-beta.1'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.9.1-beta.1'
+  s.version          = '1.9.1'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.9.0'
+  s.version          = '1.9.1-beta.1'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.10.0'
+  s.version          = '1.10.1'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.9.1-beta.1'
+  s.version          = '1.9.1'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPressEditor/WordPressEditor/Classes/ViewControllers/OptionsTableViewController/OptionsTablePresenter.swift
+++ b/WordPressEditor/WordPressEditor/Classes/ViewControllers/OptionsTableViewController/OptionsTablePresenter.swift
@@ -58,7 +58,7 @@ public class OptionsTablePresenter: NSObject {
         optionsViewController.popoverPresentationController?.permittedArrowDirections = [.down]
         optionsViewController.popoverPresentationController?.sourceView = barItem
         optionsViewController.popoverPresentationController?.sourceRect = barItem.bounds
-        optionsViewController.popoverPresentationController?.backgroundColor = .white
+        optionsViewController.popoverPresentationController?.backgroundColor = optionsViewController.cellBackgroundColor
         optionsViewController.popoverPresentationController?.delegate = self
         
         presentingViewController.present(optionsViewController, animated: true, completion: completion)


### PR DESCRIPTION
This allows to have a dark popovert presentation background color on Dark Mode.

In this way we fix a small glitch that appears when we have a black tableView background with a white `UIVisualEffectContentView`.

![Aztec-fix](https://user-images.githubusercontent.com/9772967/66111534-5ba15e00-e5c9-11e9-8efd-4e62a401d209.png)

To test:
- Checkout and follow the instructions on https://github.com/wordpress-mobile/WordPress-iOS/pull/12616

