### PR TITLE
CircleCI: Publish pods when the repo is tagged

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.32
+  ios: wordpress-mobile/ios@0.0.35
 
 workflows:
   test_and_validate:
@@ -30,3 +30,26 @@ workflows:
           podspec-path: WordPress-Editor-iOS.podspec
           # Updating specs is needed since WordPress-Editor-iOS depends on WordPress-Aztec-iOS
           update-specs-repo: true
+
+      - ios/publish-podspec:
+          name: Publish WordPress-Aztec-iOS to Trunk
+          xcode-version: "11.0"
+          podspec-path: WordPress-Aztec-iOS.podspec
+          post-to-slack: true
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+
+      - ios/publish-podspec:
+          name: Publish WordPress-Editor-iOS to Trunk
+          requires: [ "Publish WordPress-Aztec-iOS to Trunk" ]
+          xcode-version: "11.0"
+          podspec-path: WordPress-Editor-iOS.podspec
+          post-to-slack: true
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
### Description

Adding a CircleCI job that will run `pod trunk push` on the podspec whenever the repo is tagged. This is already in use and tested on WordPressAuthenticator.

### Testing Details

We can't really test this directly on the PR, but you can see it was tested here: https://github.com/wordpress-mobile/circleci-orbs/pull/38