### PR TITLE
CircleCI: Use --include-podspecs when validating WordPress-Editor-iOS podspec to avoid publishing problems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@0.0.35
+  ios: wordpress-mobile/ios@dev:cocoapods-addtional-options
 
 workflows:
   test_and_validate:
@@ -28,8 +28,8 @@ workflows:
           name: Validate WordPress-Editor-iOS.podspec
           xcode-version: "11.0"
           podspec-path: WordPress-Editor-iOS.podspec
-          # Updating specs is needed since WordPress-Editor-iOS depends on WordPress-Aztec-iOS
-          update-specs-repo: true
+          # Reference WordPress-Aztec-iOS.podspec locally so we don't have to get it from the specs repo
+          additional-parameters: --include-podspecs=WordPress-Aztec-iOS.podspec
 
       - ios/publish-podspec:
           name: Publish WordPress-Aztec-iOS to Trunk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # This uses the iOS Orb located at https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@dev:cocoapods-addtional-options
+  ios: wordpress-mobile/ios@0.0.36
 
 workflows:
   test_and_validate:


### PR DESCRIPTION
This requires https://github.com/wordpress-mobile/circleci-orbs/pull/40 to be merged.

We have a problem with the CocoaPod publishing workflow for Aztec-iOS. `WordPress-Aztec-iOS.podspec` is a dependency of `WordPress-Editor-iOS.podspec`. This means that when the version numbers in the podspecs are bumped prior to making a new release, CI fails to validate `WordPress-Editor-iOS.podspec`  because it can't find the new version of `WordPress-Aztec-iOS`.

The solution is to make use of a reasonably recent addition to CocoaPods (https://github.com/CocoaPods/CocoaPods/pull/8536) which allows us to include local podspecs during validation and avoid searching the specs repo for `WordPress-Aztec-iOS`.

## To test:

### CI

- See that CI is still green when validating against the local podspec.

### Test locally

1. Bump the version number in `WordPress-Aztec-iOS.podspec` and `WordPress-Editor-iOS.podspec` to something not yet released (e.g. `1.2.0`) but don't commit your changes.
2. Run `bundle exec pod lib lint WordPress-Editor-iOS.podspec --include-podspecs=WordPress-Aztec-iOS.podspec` and see that validation passes even though this version isn't released yet.