### PR TITLE
Allow configuration of default fonts used in TextView

### DIFF
--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -235,6 +235,7 @@
 		FF61909E202481F4004BCD0A /* CodeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF61909D202481F4004BCD0A /* CodeFormatter.swift */; };
 		FF7A1C511E5651EA00C4C7C8 /* LineAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7A1C501E5651EA00C4C7C8 /* LineAttachment.swift */; };
 		FF7C89B01E3BC52F000472A8 /* NSAttributedString+FontTraits.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7C89AF1E3BC52F000472A8 /* NSAttributedString+FontTraits.swift */; };
+		FF7EAEC4234D253B007A26E0 /* FontProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7EAEC3234D253B007A26E0 /* FontProvider.swift */; };
 		FFA61E891DF18F3D00B71BF6 /* ParagraphStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */; };
 		FFA61EC21DF6C1C900B71BF6 /* NSAttributedString+Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */; };
 		FFB5D29720BEB21A0038DCFB /* CiteFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB5D29620BEB21A0038DCFB /* CiteFormatter.swift */; };
@@ -513,6 +514,7 @@
 		FF7A1C4A1E51F05700C4C7C8 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		FF7A1C501E5651EA00C4C7C8 /* LineAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineAttachment.swift; sourceTree = "<group>"; };
 		FF7C89AF1E3BC52F000472A8 /* NSAttributedString+FontTraits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+FontTraits.swift"; sourceTree = "<group>"; };
+		FF7EAEC3234D253B007A26E0 /* FontProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontProvider.swift; sourceTree = "<group>"; };
 		FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParagraphStyle.swift; sourceTree = "<group>"; };
 		FFA61EC11DF6C1C900B71BF6 /* NSAttributedString+Archive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Archive.swift"; sourceTree = "<group>"; };
 		FFB5D29620BEB21A0038DCFB /* CiteFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CiteFormatter.swift; sourceTree = "<group>"; };
@@ -804,6 +806,7 @@
 				FFA61E881DF18F3D00B71BF6 /* ParagraphStyle.swift */,
 				B5A99D831EBA073D00DED081 /* HTMLStorage.swift */,
 				F9982CF521877663001E606B /* TextViewPasteboardDelegate.swift */,
+				FF7EAEC3234D253B007A26E0 /* FontProvider.swift */,
 			);
 			path = TextKit;
 			sourceTree = "<group>";
@@ -1573,6 +1576,7 @@
 				F165D92A20C72EF500EAA6B0 /* Array+ShortcodeAttribute.swift in Sources */,
 				F165D92420C72C1000EAA6B0 /* ShortcodeAttributeSerializer.swift in Sources */,
 				F177FF751FB6404D00CBBE35 /* UILayoutPriority+Swift4.swift in Sources */,
+				FF7EAEC4234D253B007A26E0 /* FontProvider.swift in Sources */,
 				F1C05B9D1E37FA77007510EA /* String+CharacterName.swift in Sources */,
 				F1FF7D9F201A1D24007B0B32 /* Figcaption.swift in Sources */,
 				FF17B2D2227A589F0022AECE /* LIElementConverter.swift in Sources */,

--- a/Aztec.xcodeproj/project.pbxproj
+++ b/Aztec.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		FF24AC991F0146AF003CA91D /* Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF24AC981F0146AF003CA91D /* Assets.swift */; };
 		FF437B6420D7CB2D000D9666 /* HTMLLi.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF437B6320D7CB2D000D9666 /* HTMLLi.swift */; };
 		FF437B6620D7CB83000D9666 /* LiFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF437B6520D7CB83000D9666 /* LiFormatter.swift */; };
+		FF48CAC8234DD5D3007FFC79 /* NSMutableAttributedString+ReplaceAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF48CAC7234DD5D3007FFC79 /* NSMutableAttributedString+ReplaceAttributes.swift */; };
 		FF4E26601EA8DF1E005E8E42 /* ImageAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4E265F1EA8DF1E005E8E42 /* ImageAttachment.swift */; };
 		FF61909E202481F4004BCD0A /* CodeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF61909D202481F4004BCD0A /* CodeFormatter.swift */; };
 		FF7A1C511E5651EA00C4C7C8 /* LineAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7A1C501E5651EA00C4C7C8 /* LineAttachment.swift */; };
@@ -506,6 +507,7 @@
 		FF24AC981F0146AF003CA91D /* Assets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assets.swift; sourceTree = "<group>"; };
 		FF437B6320D7CB2D000D9666 /* HTMLLi.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLLi.swift; sourceTree = "<group>"; };
 		FF437B6520D7CB83000D9666 /* LiFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiFormatter.swift; sourceTree = "<group>"; };
+		FF48CAC7234DD5D3007FFC79 /* NSMutableAttributedString+ReplaceAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+ReplaceAttributes.swift"; sourceTree = "<group>"; };
 		FF4E265F1EA8DF1E005E8E42 /* ImageAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageAttachment.swift; sourceTree = "<group>"; };
 		FF5B98E21DC29D0C00571CA4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		FF5B98E41DC355B400571CA4 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
@@ -748,6 +750,7 @@
 				FFD0FEB61DAE59A700430586 /* NSLayoutManager+Attachments.swift */,
 				F1584795203C9B4C00EE05A1 /* NSMutableAttributedString+ParagraphProperty.swift */,
 				F10BE6171EA7ADA6002E4625 /* NSMutableAttributedString+ReplaceOcurrences.swift */,
+				FF48CAC7234DD5D3007FFC79 /* NSMutableAttributedString+ReplaceAttributes.swift */,
 				F18733C41DA096EE005AEB80 /* NSRange+Helpers.swift */,
 				FF20D6431EDC395E00294B78 /* NSTextingResult+Helpers.swift */,
 				F1C05B9C1E37FA77007510EA /* String+CharacterName.swift */,
@@ -1643,6 +1646,7 @@
 				599F25381D8BC9A1002871D6 /* InAttributesConverter.swift in Sources */,
 				B551A4A01E770B3800EE3A7F /* UIFont+Emoji.swift in Sources */,
 				F13E8AD820B71BAA007C9F8A /* PluginManager.swift in Sources */,
+				FF48CAC8234DD5D3007FFC79 /* NSMutableAttributedString+ReplaceAttributes.swift in Sources */,
 				F12F586E1EF20394008AE298 /* LinkFormatter.swift in Sources */,
 				F1584796203C9B4C00EE05A1 /* NSMutableAttributedString+ParagraphProperty.swift in Sources */,
 				F15BA6092151501300424120 /* BoldStringAttributeConverter.swift in Sources */,

--- a/Aztec/Classes/Extensions/NSMutableAttributedString+ReplaceAttributes.swift
+++ b/Aztec/Classes/Extensions/NSMutableAttributedString+ReplaceAttributes.swift
@@ -1,0 +1,21 @@
+import Foundation
+import UIKit
+
+public extension NSMutableAttributedString {
+
+    func replace(font: UIFont, with newFont: UIFont) {
+        let fullRange = NSRange(location: 0, length: self.length)
+
+        self.beginEditing()
+        self.enumerateAttributes(in: fullRange, options: []) { (attributes, subrange, stop) in
+            if let currentFont = attributes[.font] as? UIFont, currentFont.familyName == font.familyName {
+                var replacementFont = newFont
+                if let fontDescriptor = newFont.fontDescriptor.withSymbolicTraits(currentFont.fontDescriptor.symbolicTraits) {
+                    replacementFont = UIFont(descriptor: fontDescriptor, size: currentFont.pointSize)
+                }
+                self.addAttribute(.font, value: replacementFont, range: subrange)
+            }
+        }
+        self.endEditing()
+    }
+}

--- a/Aztec/Classes/Extensions/NSMutableAttributedString+ReplaceAttributes.swift
+++ b/Aztec/Classes/Extensions/NSMutableAttributedString+ReplaceAttributes.swift
@@ -3,19 +3,23 @@ import UIKit
 
 public extension NSMutableAttributedString {
 
+    /// Replace all instances of the .font attribute that belong to the same family for the new font, trying to keep the same symbolic traits
+    /// - Parameter font: the original font to be replaced
+    /// - Parameter newFont: the new font to use.
     func replace(font: UIFont, with newFont: UIFont) {
-        let fullRange = NSRange(location: 0, length: self.length)
+        let fullRange = NSRange(location: 0, length: length)
 
-        self.beginEditing()
-        self.enumerateAttributes(in: fullRange, options: []) { (attributes, subrange, stop) in
-            if let currentFont = attributes[.font] as? UIFont, currentFont.familyName == font.familyName {
-                var replacementFont = newFont
-                if let fontDescriptor = newFont.fontDescriptor.withSymbolicTraits(currentFont.fontDescriptor.symbolicTraits) {
-                    replacementFont = UIFont(descriptor: fontDescriptor, size: currentFont.pointSize)
-                }
-                self.addAttribute(.font, value: replacementFont, range: subrange)
+        beginEditing()
+        enumerateAttributes(in: fullRange, options: []) { (attributes, subrange, stop) in
+            guard let currentFont = attributes[.font] as? UIFont, currentFont.familyName == font.familyName else {
+                return
             }
+            var replacementFont = newFont
+            if let fontDescriptor = newFont.fontDescriptor.withSymbolicTraits(currentFont.fontDescriptor.symbolicTraits) {
+                replacementFont = UIFont(descriptor: fontDescriptor, size: currentFont.pointSize)
+            }
+            addAttribute(.font, value: replacementFont, range: subrange)
         }
-        self.endEditing()
+        endEditing()
     }
 }

--- a/Aztec/Classes/Formatters/Implementations/CodeFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/CodeFormatter.swift
@@ -12,15 +12,8 @@ class CodeFormatter: AttributeFormatter {
 
     // MARK: - Init
 
-    init(monospaceFont: UIFont = UIFont(descriptor:UIFontDescriptor(name: "Courier", size: 12), size:12), backgroundColor: UIColor = UIColor.lightGray) {
-        let font: UIFont
-
-        if #available(iOS 11.0, *) {
-            font = UIFontMetrics.default.scaledFont(for: monospaceFont)
-        } else {
-            font = monospaceFont
-        }
-        self.monospaceFont = font
+    init(monospaceFont: UIFont = FontProvider.shared.monospaceFont, backgroundColor: UIColor = UIColor.lightGray) {
+        self.monospaceFont = monospaceFont
         self.backgroundColor = backgroundColor
         self.htmlRepresentationKey = .codeHtmlRepresentation
     }

--- a/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/PreFormatter.swift
@@ -14,19 +14,10 @@ open class PreFormatter: ParagraphAttributeFormatter {
     ///
     let placeholderAttributes: [NSAttributedString.Key: Any]?
 
-
     /// Designated Initializer
     ///
-    init(monospaceFont: UIFont = UIFont(descriptor:UIFontDescriptor(name: "Courier", size: 12), size:12), placeholderAttributes: [NSAttributedString.Key : Any]? = nil) {
-        let font: UIFont
-
-        if #available(iOS 11.0, *) {
-            font = UIFontMetrics.default.scaledFont(for: monospaceFont)
-        } else {
-            font = monospaceFont
-        }
-
-        self.monospaceFont = font
+    init(monospaceFont: UIFont = FontProvider.shared.monospaceFont, placeholderAttributes: [NSAttributedString.Key : Any]? = nil) {
+        self.monospaceFont = monospaceFont
         self.placeholderAttributes = placeholderAttributes
     }
 

--- a/Aztec/Classes/TextKit/FontProvider.swift
+++ b/Aztec/Classes/TextKit/FontProvider.swift
@@ -1,0 +1,33 @@
+import Foundation
+import UIKit
+
+public class FontProvider {
+
+    private init() {
+
+    }
+
+    static var shared = FontProvider()
+
+    lazy var monospaceFont: UIFont = {
+        let baseFont = UIFont(descriptor:UIFontDescriptor(name: "Menlo", size: 14), size:14)
+        let font: UIFont
+        if #available(iOS 11.0, *) {
+            font = UIFontMetrics.default.scaledFont(for: baseFont)
+        } else {
+            font = baseFont
+        }
+        return font
+    }()
+
+    lazy var defaultFont: UIFont = {
+        let baseFont = UIFont.systemFont(ofSize: 14)
+        let font: UIFont
+        if #available(iOS 11.0, *) {
+            font = UIFontMetrics.default.scaledFont(for: baseFont)
+        } else {
+            font = baseFont
+        }
+        return font
+    }()
+}

--- a/Aztec/Classes/TextKit/FontProvider.swift
+++ b/Aztec/Classes/TextKit/FontProvider.swift
@@ -7,7 +7,7 @@ public class FontProvider {
 
     }
 
-    static var shared = FontProvider()
+    public static var shared = FontProvider()
 
     public lazy var monospaceFont: UIFont = {
         let baseFont = UIFont(descriptor:UIFontDescriptor(name: "Menlo", size: 14), size:14)

--- a/Aztec/Classes/TextKit/FontProvider.swift
+++ b/Aztec/Classes/TextKit/FontProvider.swift
@@ -9,7 +9,7 @@ public class FontProvider {
 
     static var shared = FontProvider()
 
-    lazy var monospaceFont: UIFont = {
+    public lazy var monospaceFont: UIFont = {
         let baseFont = UIFont(descriptor:UIFontDescriptor(name: "Menlo", size: 14), size:14)
         let font: UIFont
         if #available(iOS 11.0, *) {
@@ -20,7 +20,7 @@ public class FontProvider {
         return font
     }()
 
-    lazy var defaultFont: UIFont = {
+    public lazy var defaultFont: UIFont = {
         let baseFont = UIFont.systemFont(ofSize: 14)
         let font: UIFont
         if #available(iOS 11.0, *) {

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -317,7 +317,11 @@ private extension LayoutManager {
         traits.remove(.traitBold)
         traits.remove(.traitItalic)
 
-        let descriptor = font.fontDescriptor.withSymbolicTraits(traits)
-        return UIFont(descriptor: descriptor!, size: font.pointSize)
+        if let descriptor = font.fontDescriptor.withSymbolicTraits(traits) {
+            return UIFont(descriptor: descriptor, size: font.pointSize)
+        } else {
+            // Don't touch the font if we cannot remove the symbolic traits.
+            return font
+        }
     }
 }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -226,6 +226,8 @@ open class TextView: UITextView {
 
     // MARK: - Properties: UI Defaults
 
+    /// The font to use to render any HTML that doesn't specify an explicit font.
+    /// If this is changed all the instances that use this font will be updated to the new one.
     public var defaultFont: UIFont {
         didSet {
             textStorage.replace(font: oldValue, with: defaultFont)
@@ -359,6 +361,10 @@ open class TextView: UITextView {
 
     // MARK: - Init & deinit
 
+    /// Creates a Text View using the provided parameters as a base for HTML rendering.
+    /// - Parameter defaultFont: The font to use to render the elements if no specific font is set by the HTML.
+    /// - Parameter defaultParagraphStyle: The default paragraph style if no explicit attributes are defined in HTML
+    /// - Parameter defaultMissingImage: The image to use if the view is not able to render an image specified in the HTML.
     @objc public init(
         defaultFont: UIFont,
         defaultParagraphStyle: ParagraphStyle = ParagraphStyle.default,
@@ -385,7 +391,7 @@ open class TextView: UITextView {
     }
 
     required public init?(coder aDecoder: NSCoder) {
-        self.defaultFont = FontProvider.shared.defaultFont
+        defaultFont = FontProvider.shared.defaultFont
         defaultParagraphStyle = ParagraphStyle.default
         defaultMissingImage = Assets.imageIcon
         

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -226,7 +226,26 @@ open class TextView: UITextView {
 
     // MARK: - Properties: UI Defaults
 
-    public let defaultFont: UIFont
+    public var monospaceFont: UIFont = UIFont(descriptor:UIFontDescriptor(name: "Courier", size: 12), size:12)
+
+    public var defaultFont: UIFont {
+        didSet {
+            refreshFont(oldFont: oldValue, newFont: defaultFont)
+        }
+    }
+
+    private func refreshFont(oldFont: UIFont, newFont: UIFont) {
+        let fullRange = NSRange(location: 0, length: textStorage.length)
+
+        textStorage.beginEditing()
+        textStorage.enumerateAttributes(in: fullRange, options: []) { (attributes, subrange, stop) in
+            if let currentFont = attributes[.font] as? UIFont, currentFont == oldFont {
+                textStorage.addAttribute(.font, value: newFont, range: subrange)
+            }
+        }
+        textStorage.endEditing()
+    }
+
     public let defaultParagraphStyle: ParagraphStyle
     var defaultMissingImage: UIImage
     

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -397,13 +397,7 @@ open class TextView: UITextView {
     }
 
     required public init?(coder aDecoder: NSCoder) {
-        let font = UIFont.systemFont(ofSize: 14)
-        if #available(iOS 11.0, *) {
-            self.defaultFont = UIFontMetrics.default.scaledFont(for: font)
-        } else {
-            self.defaultFont = font
-        }
-
+        self.defaultFont = FontProvider.shared.defaultFont
         defaultParagraphStyle = ParagraphStyle.default
         defaultMissingImage = Assets.imageIcon
         

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -228,20 +228,8 @@ open class TextView: UITextView {
 
     public var defaultFont: UIFont {
         didSet {
-            refreshFont(oldFont: oldValue, newFont: defaultFont)
+            textStorage.replace(font: oldValue, with: defaultFont)
         }
-    }
-
-    private func refreshFont(oldFont: UIFont, newFont: UIFont) {
-        let fullRange = NSRange(location: 0, length: textStorage.length)
-
-        textStorage.beginEditing()
-        textStorage.enumerateAttributes(in: fullRange, options: []) { (attributes, subrange, stop) in
-            if let currentFont = attributes[.font] as? UIFont, currentFont == oldFont {
-                textStorage.addAttribute(.font, value: newFont, range: subrange)
-            }
-        }
-        textStorage.endEditing()
     }
 
     public let defaultParagraphStyle: ParagraphStyle

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -226,8 +226,6 @@ open class TextView: UITextView {
 
     // MARK: - Properties: UI Defaults
 
-    public var monospaceFont: UIFont = UIFont(descriptor:UIFontDescriptor(name: "Courier", size: 12), size:12)
-
     public var defaultFont: UIFont {
         didSet {
             refreshFont(oldFont: oldValue, newFont: defaultFont)
@@ -257,23 +255,6 @@ open class TextView: UITextView {
         if let color = textColor {
             attributes[.foregroundColor] = color
         }
-        return attributes
-    }
-    
-    /// This closure will be executed whenever the `TextView` needs to set the base style for
-    /// a caption.  Override this to customize the caption styling.
-    ///
-    public lazy var captionStyler: ([NSAttributedString.Key:Any]) -> [NSAttributedString.Key:Any] = { [weak self] attributes in
-        guard let `self` = self else {
-            return attributes
-        }
-        
-        let font = self.defaultFont.withSize(10)
-        
-        var attributes = attributes
-        attributes[.font] = font
-        attributes[.foregroundColor] = UIColor.darkGray
-        
         return attributes
     }
     

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -1673,7 +1673,7 @@ class TextViewTests: XCTestCase {
 
         textView.insertText("😘")
         let currentTypingFont = textView.typingAttributes[.font] as! UIFont
-        XCTAssertEqual(currentTypingFont, font, "Font should be set to default")
+        XCTAssertEqual(currentTypingFont.fontDescriptor, font.fontDescriptor, "Font should be set to default")
     }
 
 

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -195,9 +195,13 @@ class EditorDemoController: UIViewController {
         } else {
             html = ""
         }
-        
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(changeFont))
         editorView.setHTML(html)
         editorView.becomeFirstResponder()
+    }
+
+    @objc func changeFont() {
+        editorView.richTextView.defaultFont = UIFont.preferredFont(forTextStyle: .callout)
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
This PR brings to TextView the following:

 - The possibility to replace the defaultFont being used after the TextView is created
 - Introduction of a FontProvider to allow configuration of fonts being used in the system
 - Configuration of the default font being used for monospace 

To test:
 - Run the sample app
 - Check the demo content
 - There is new button on the top right (+) press it and see if the default font changes in all the demo content.

