### PR TITLE
Recalculate typing attributes on alignment update

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -339,6 +339,12 @@ open class TextView: UITextView {
         }
     }
 
+    override open var textAlignment: NSTextAlignment {
+        didSet {
+            recalculateTypingAttributes()
+        }
+    }
+
 
     /// This property returns the Attributes associated to the Extra Line Fragment.
     ///

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -341,7 +341,9 @@ open class TextView: UITextView {
 
     override open var textAlignment: NSTextAlignment {
         didSet {
-            recalculateTypingAttributes()
+            if (textAlignment != oldValue) {
+                recalculateTypingAttributes()
+            }
         }
     }
 


### PR DESCRIPTION
## Description

I am proposing this change to address an issue I observed when implementing [alignment controls for paragraph blocks in gutenberg](https://github.com/wordpress-mobile/gutenberg-mobile/issues/1266). In particular, I observed that updating the alignment on empty views caused a number of display issues where either the cursor or the placeholder text (or both) would fail to reflect the selected alignment. More detail on these issues is discussed in the "Outstanding Issue #3: iOS Empty Views" section of [the gutenberg paragraph alignment PR's description](https://github.com/WordPress/gutenberg/pull/17577).

Before | After
--- | ---
![ios-align-before mov](https://user-images.githubusercontent.com/4656348/67223526-6fd4c000-f3fd-11e9-8c90-4f7df0f84df1.gif) |  ![ios-align-after mov](https://user-images.githubusercontent.com/4656348/67223364-24baad00-f3fd-11e9-8857-6218119ef8e2.gif)


### How I arrived at this fix

In essence, the issue seems to be that the display of the views is not consistently being updated when the alignment field is updated. I tried calling either `setNeedsLayout()` or `setNeedsDisplay()` [when the alignment is being updated](https://github.com/wordpress-mobile/gutenberg-mobile/blob/develop/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift#L37) and they improved the behavior, but did not fully address it. While exploring a different fix I discovered that calling `recalculateTypingAttributes()` when the alignment is updated does seem to address all of the issues. 

### Why this might _not_ be the best fix

I do not fully understand the reasons that this fixes the issues I was observing, so there may be a better fix.

An additional reason for caution with respect to this fix is that there is [a comment](https://github.com/wordpress-mobile/AztecEditor-iOS/blob/bd0548894c9af281b3f250444f198641e9d86832/Aztec/Classes/TextKit/TextView.swift#L1226) warning against unnecessarily calling `recalculateTypingAttributes`:

> Only call this method when sure that the typingAttributes need to be recalculated.  Keep in mind that recalculating the typingAttributes in the wrong moment can cause trouble (for example reverting a decision by the user to turn a style off).

A final reason for caution with this approach is that I have found that _in debug builds_ it seems like it might be a bit easier for me to encounter [this focus loop issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/953) with this fix in place when I was testing changing alignment between various paragraph blocks. I am not convinced it is easier to recreate, however, and I was not able to recreate the focus loop issue on a release build.

For these reasons, I encourage a _very_ critical review of this PR.

## Testing

In addition to smoke testing the Aztec Editor itself, you can test that this change fixes the handling of alignment changes in either the gutenberg-mobile demo app or WPiOS:

1. Check out and build either 
    1. gutenberg-mobile demo app: commit [4281bdf6f82d113eb27f67a827ed42de78200b7c](https://github.com/wordpress-mobile/gutenberg-mobile/commit/4281bdf6f82d113eb27f67a827ed42de78200b7c); or 
    2. WPiOS: commit [8fb7796bde969e4d7b181b7beb8e69814b893bfd](https://github.com/wordpress-mobile/WordPress-iOS/commit/8fb7796bde969e4d7b181b7beb8e69814b893bfd).
2. Create an empty paragraph block
3. Update alignment on empty paragraph block
4.  Observe the cursor and placeholder text update position to reflect the selected alignment
4. Begin typing text
5. Observe that the cursor and text continue to reflect the selected alignment (i.e., they do bounces back to the default (left) alignment



