### PR TITLE
Creates isLoaded property

### DIFF
--- a/Aztec/Classes/TextKit/MediaAttachment.swift
+++ b/Aztec/Classes/TextKit/MediaAttachment.swift
@@ -45,6 +45,12 @@ open class MediaAttachment: NSTextAttachment {
         }
     }
 
+    /// Indicates if the media is loaded
+    ///
+    public var isLoaded: Bool {
+        return !needsNewAsset && !isFetchingImage
+    }
+
     /// Indicates if a new Asset should be retrieved, or we're current!.
     ///
     fileprivate var needsNewAsset = true

--- a/WordPressEditor/WordPressEditorTests/Extensions/MediaAttachmentWordPressTests.swift
+++ b/WordPressEditor/WordPressEditorTests/Extensions/MediaAttachmentWordPressTests.swift
@@ -29,4 +29,10 @@ class MediaAttachmentWordPressTests: XCTestCase {
         imageAttachment.extraAttributes[MediaAttachment.uploadKey] = nil
         XCTAssertEqual(imageAttachment.uploadID, nil)
     }
+
+    func testIsLoadedInitiallyReturnsFalse() {
+        let imageAttachment = MediaAttachment(identifier: "testing")
+
+        XCTAssertFalse(imageAttachment.isLoaded)
+    }
 }


### PR DESCRIPTION
Adds a property called `isLoaded` in `MediaAttachment`.

It returns `true` if the media is loaded, otherwise false.

To test:

The green build should be enough.

- [x] If it's feasible, I have added unit tests. 