### PR TITLE
Fix copy/paste of attributed string from app without support for dark/light mode

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -647,7 +647,7 @@ open class TextView: UITextView {
         evaluateRemovalOfSingleLineParagraphAttributesAfterSelectionChange()
         ensureRemovalOfParagraphAttributesWhenPressingBackspaceAndEmptyingTheDocument()
         ensureCursorRedraw(afterEditing: deletedString.string)
-
+        recalculateTypingAttributes()
         notifyTextViewDidChange()
     }
 
@@ -1247,6 +1247,7 @@ open class TextView: UITextView {
     private func recalculateTypingAttributes(at location: Int) {
         
         guard storage.length > 0 else {
+            typingAttributes = defaultAttributes
             return
         }
         

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -249,13 +249,11 @@ open class TextView: UITextView {
     }
 
     open lazy var defaultTextColor: UIColor? = {
-        let color: UIColor
         if #available(iOS 13.0, *) {
-            color = UIColor.label
+            return UIColor.label
         } else {
-            color = UIColor.darkText
-        }
-        return color
+            return UIColor.darkText
+        }        
     }()
 
     // MARK: - Plugin Loading

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -248,16 +248,16 @@ open class TextView: UITextView {
         return attributes
     }
 
-    open var defaultTextColor: UIColor?
+    open lazy var defaultTextColor: UIColor? = {
+        let color: UIColor
+        if #available(iOS 13.0, *) {
+            color = UIColor.label
+        } else {
+            color = UIColor.darkText
+        }
+        return color
+    }()
 
-    override open var textColor: UIColor? {
-        get {
-            return super.textColor
-        }
-        set {
-            super.textColor = newValue            
-        }
-    }
     // MARK: - Plugin Loading
     
     var pluginManager: PluginManager {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -242,12 +242,22 @@ open class TextView: UITextView {
             .font: defaultFont,
             .paragraphStyle: defaultParagraphStyle,
         ]
-        if let color = textColor {
+        if let color = defaultTextColor {
             attributes[.foregroundColor] = color
         }
         return attributes
     }
-    
+
+    open var defaultTextColor: UIColor?
+
+    override open var textColor: UIColor? {
+        get {
+            return super.textColor
+        }
+        set {
+            super.textColor = newValue            
+        }
+    }
     // MARK: - Plugin Loading
     
     var pluginManager: PluginManager {

--- a/Aztec/Classes/TextKit/TextViewPasteboardDelegate.swift
+++ b/Aztec/Classes/TextKit/TextViewPasteboardDelegate.swift
@@ -58,7 +58,7 @@ open class AztecTextViewPasteboardDelegate: TextViewPasteboardDelegate {
         guard let string = UIPasteboard.general.attributedString() else {
             return false
         }
-
+        string.loadLazyAttachments()
         let selectedRange = textView.selectedRange
         let storage = textView.storage
 
@@ -69,15 +69,30 @@ open class AztecTextViewPasteboardDelegate: TextViewPasteboardDelegate {
             textView?.undoTextReplacement(of: originalText, finalRange: finalRange)
         })
 
-        string.loadLazyAttachments()
+        let colorCorrectedString = fixColors(in: string, using: textView.textColor)
 
-        storage.replaceCharacters(in: selectedRange, with: string)
+        storage.replaceCharacters(in: selectedRange, with: colorCorrectedString)
         textView.notifyTextViewDidChange()
 
         let newSelectedRange = NSRange(location: selectedRange.location + string.length, length: 0)
         textView.selectedRange = newSelectedRange
 
         return true
+    }
+
+    private func fixColors(in string: NSAttributedString, using baseColor: UIColor?) -> NSAttributedString {
+        guard #available(iOS 13.0, *) else {
+            return string
+        }
+        let colorToUse = baseColor ?? UIColor.label
+
+        let newString = NSMutableAttributedString(attributedString: string)
+        newString.enumerateAttributes(in: newString.rangeOfEntireString, options: []) { (attributes, range, stop) in
+            if attributes[.foregroundColor] == nil {
+                newString.setAttributes([.foregroundColor: colorToUse], range: range)
+            }
+        }
+        return newString
     }
 
     /// Tries to paste raw text from the clipboard, replacing the selected range.

--- a/Aztec/Classes/TextKit/TextViewPasteboardDelegate.swift
+++ b/Aztec/Classes/TextKit/TextViewPasteboardDelegate.swift
@@ -69,7 +69,7 @@ open class AztecTextViewPasteboardDelegate: TextViewPasteboardDelegate {
             textView?.undoTextReplacement(of: originalText, finalRange: finalRange)
         })
 
-        let colorCorrectedString = fixColors(in: string, using: textView.textColor)
+        let colorCorrectedString = fixColors(in: string, using: textView.defaultTextColor)
 
         storage.replaceCharacters(in: selectedRange, with: colorCorrectedString)
         textView.notifyTextViewDidChange()

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -2078,6 +2078,7 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(UIPasteboard.general.html(), "<p><strong>bol</strong></p>")
     }
 
+    /// Check if pasting attributed text without color, the color is set to default color
     func testPasteAttributedText() {
         let sourceAttributedText = NSAttributedString(string: "Hello world")
         var pasteItems = [String:Any]()
@@ -2093,6 +2094,16 @@ class TextViewTests: XCTestCase {
 
         XCTAssertEqual(attributes[.foregroundColor] as! UIColor, UIColor.red)
         XCTAssertEqual(textView.text, "Hello world")
+    }
+
+    /// Check that deleting all text resets the typying attributes to the default attributes
+    func testDeleteAllTextSetTypyingAttributesToDefault() {
+        let textView = TextViewStub(withHTML: "<p style=\"color:0xFF0000\">Hello world</p>")
+        textView.defaultTextColor = UIColor.green
+        textView.selectedRange = textView.attributedText!.rangeOfEntireString
+        textView.deleteBackward()
+        let attributes = textView.typingAttributes
+        XCTAssertEqual(attributes[.foregroundColor] as! UIColor,UIColor.green)
     }
 
 }

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -2078,4 +2078,21 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(UIPasteboard.general.html(), "<p><strong>bol</strong></p>")
     }
 
+    func testPasteAttributedText() {
+        let sourceAttributedText = NSAttributedString(string: "Hello world")
+        var pasteItems = [String:Any]()
+        pasteItems[kUTTypePlainText as String] = try! sourceAttributedText.data(from: sourceAttributedText.rangeOfEntireString, documentAttributes: [.documentType: DocumentType.plain])
+        UIPasteboard.general.setItems([pasteItems], options: [:])
+        let textView = TextViewStub(withHTML: "")
+        textView.defaultTextColor = UIColor.red
+        textView.paste(nil)
+
+        let attributedString = textView.attributedText!
+
+        let attributes = attributedString.attributes(at: 0, effectiveRange: nil)
+
+        XCTAssertEqual(attributes[.foregroundColor] as! UIColor, UIColor.red)
+        XCTAssertEqual(textView.text, "Hello world")
+    }
+
 }

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -65,7 +65,7 @@ class EditorDemoController: UIViewController {
     
     private func setupHTMLTextView(_ textView: UITextView) {
         let accessibilityLabel = NSLocalizedString("HTML Content", comment: "Post HTML content")
-        self.configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
+        self.configureDefaultProperties(htmlTextView: textView, accessibilityLabel: accessibilityLabel)
         
         textView.isHidden = true
         textView.delegate = self
@@ -325,7 +325,22 @@ class EditorDemoController: UIViewController {
     }
 
 
-    private func configureDefaultProperties(for textView: UITextView, accessibilityLabel: String) {
+    private func configureDefaultProperties(for textView: TextView, accessibilityLabel: String) {
+        textView.accessibilityLabel = accessibilityLabel
+        textView.font = Constants.defaultContentFont
+        textView.keyboardDismissMode = .interactive
+        if #available(iOS 13.0, *) {
+            textView.textColor = UIColor.label
+            textView.defaultTextColor = UIColor.label
+        } else {
+            // Fallback on earlier versions
+            textView.textColor = UIColor(red: 0x1A/255.0, green: 0x1A/255.0, blue: 0x1A/255.0, alpha: 1)
+            textView.defaultTextColor = UIColor(red: 0x1A/255.0, green: 0x1A/255.0, blue: 0x1A/255.0, alpha: 1)
+        }
+        textView.linkTextAttributes = [.foregroundColor: UIColor(red: 0x01 / 255.0, green: 0x60 / 255.0, blue: 0x87 / 255.0, alpha: 1), NSAttributedString.Key.underlineStyle: NSNumber(value: NSUnderlineStyle.single.rawValue)]
+    }
+
+    private func configureDefaultProperties(htmlTextView textView: UITextView, accessibilityLabel: String) {
         textView.accessibilityLabel = accessibilityLabel
         textView.font = Constants.defaultContentFont
         textView.keyboardDismissMode = .interactive


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-iOS/issues/12688

This PR implements three fixes to sort issues around text color:
 - When copy/paste attributed string it makes sure that text color is set to default color if no color is set
 - It also make sure that when all text is deleted the typing attributes are reset to default attributes that include the default color
 - Make sure that the defaultColor is used for default attributes where converting from HTML mode.

To test:
 - Copy paste text from other apps. Examples: Notes app, Tumblr in post edit mode, inside different sections of Aztec
 - Open the demo app, put the cursor over the text with the red color, switch to HTML mode, and switch back to visual. Check that text is displayed in the correct color.
 - Open the demo app, select all the text and delete it. Start to type check that the text shows with the default attributes and not with the attributes of the last selection.

@maxme do you want these fixes to land on release 13.7 of WPiOS (currently frozen) or the next one 13.8?
