### PR TITLE
Issue/make metrics configurable

### DIFF
--- a/Aztec/Classes/Constants/Metrics.swift
+++ b/Aztec/Classes/Constants/Metrics.swift
@@ -4,12 +4,12 @@ import Foundation
 /// A collection of constants and metrics shared between the Aztec importer
 /// and the editor.
 ///
-enum Metrics {
+public enum Metrics {
 
-    static let defaultIndentation = CGFloat(12)
-    static let maxIndentation = CGFloat(200)    
-    static let listTextIndentation = CGFloat(16)
-    static let tabStepInterval = 8
-    static let tabStepCount = 12
-    static let paragraphSpacing = CGFloat(6)
+    public static var defaultIndentation = CGFloat(12)
+    public static var maxIndentation = CGFloat(200)
+    public static var listTextIndentation = CGFloat(16)
+    public static var tabStepInterval = 8
+    public static var tabStepCount = 12
+    public static var paragraphSpacing = CGFloat(6)
 }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -283,7 +283,7 @@ private extension LayoutManager {
         var resultAttributes = attributes
         var indent: CGFloat = 0
         if let style = attributes[.paragraphStyle] as? ParagraphStyle {
-            indent = style.listIndent + Metrics.listTextIndentation
+            indent = style.listIndent + Metrics.listTextIndentation - (Metrics.listTextIndentation / 4)
         }
 
         resultAttributes[.paragraphStyle] = markerParagraphStyle(indent: indent)

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -172,6 +172,7 @@ class EditorDemoController: UIViewController {
         view.addSubview(titlePlaceholderLabel)
         view.addSubview(separatorView)
         Aztec.Metrics.listTextIndentation = 24
+        editorView.richTextView.textContainer.lineFragmentPadding = 0
         // color setup
         if #available(iOS 13.0, *) {
             view.backgroundColor = UIColor.systemBackground

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -171,6 +171,7 @@ class EditorDemoController: UIViewController {
         view.addSubview(titleTextView)
         view.addSubview(titlePlaceholderLabel)
         view.addSubview(separatorView)
+        Aztec.Metrics.listTextIndentation = 24
         // color setup
         if #available(iOS 13.0, *) {
             view.backgroundColor = UIColor.systemBackground


### PR DESCRIPTION
Makes paragraph indentation metrics to be configurable externally.

It also improves list indentation for markers to be based on total list indentation.


To test:
 - Just make sure the demo app builds and works correctly.

