### PR TITLE
Implement start and reversed in lists.

### DIFF
--- a/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
@@ -74,7 +74,7 @@ extension NSAttributedString {
     ///   - list: The list.
     ///   - location: The location of the item.
     ///
-    /// - Returns: Returns the total number of items within the list.
+    /// - Returns: Returns the total number of items within the list or NSNotFound if no list is available at location.
     ///
     func numberOfItems(in list: TextList,  at location: Int) -> Int {
         guard
@@ -102,7 +102,7 @@ extension NSAttributedString {
     ///   - list: The list.
     ///   - location: The location of the item.
     ///
-    /// - Returns: Returns the index within the list.
+    /// - Returns: Returns the index within the list or NSNotFound is no list is available at location.
     ///
     func itemNumber(in list: TextList, at location: Int) -> Int {
         guard

--- a/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
@@ -86,7 +86,7 @@ extension NSAttributedString {
         guard let rangeOfList = range(of:list, at: location) else {
             return NSNotFound
         }
-        var numberInList = 1
+        var numberInList = 0
         let paragraphRanges = self.paragraphRanges(intersecting: rangeOfList)
 
         for (_, enclosingRange) in paragraphRanges {

--- a/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
+++ b/Aztec/Classes/Extensions/NSAttributedString+Lists.swift
@@ -68,6 +68,34 @@ extension NSAttributedString {
         return resultRange
     }
 
+    /// Returns the number of  items of a list at the given location.
+    ///
+    /// - Parameters:
+    ///   - list: The list.
+    ///   - location: The location of the item.
+    ///
+    /// - Returns: Returns the total number of items within the list.
+    ///
+    func numberOfItems(in list: TextList,  at location: Int) -> Int {
+        guard
+            let paragraphStyle = attribute(.paragraphStyle, at: location, effectiveRange: nil) as? ParagraphStyle
+            else {
+                return NSNotFound
+        }
+        let listDepth = paragraphStyle.lists.count
+        guard let rangeOfList = range(of:list, at: location) else {
+            return NSNotFound
+        }
+        var numberInList = 0
+        let paragraphRanges = self.paragraphRanges(intersecting: rangeOfList)
+        for (_, enclosingRange) in paragraphRanges {
+            if let paragraphStyle = attribute(.paragraphStyle, at: enclosingRange.location, effectiveRange: nil) as? ParagraphStyle,
+               listDepth == paragraphStyle.lists.count {
+                numberInList += 1
+            }
+        }
+        return numberInList
+    }
     /// Returns the index of the item at the given location within the list.
     ///
     /// - Parameters:

--- a/Aztec/Classes/Libxml2/DOM/Data/AttributeType.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/AttributeType.swift
@@ -36,4 +36,6 @@ extension AttributeType {
     public static let src = AttributeType("src")
     public static let style = AttributeType("style")
     public static let target = AttributeType("target")
+    public static let reversed = AttributeType("reversed")
+    public static let start = AttributeType("start")
 }

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -765,6 +765,15 @@ private extension AttributedStringParser {
             listElement = element.toElementNode()
         } else {
             listElement = ElementNode(type: listType)
+            if list.style == .ordered {
+                if list.reversed {
+                    listElement.updateAttribute(named: "reversed", value: .none)
+                }
+
+                if list.start != 1 {
+                    listElement.updateAttribute(named: "start", value: .string("\(list.start)"))
+                }
+            }
         }
 
         return listElement

--- a/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/AttributedStringParser.swift
@@ -770,8 +770,8 @@ private extension AttributedStringParser {
                     listElement.updateAttribute(named: "reversed", value: .none)
                 }
 
-                if list.start != 1 {
-                    listElement.updateAttribute(named: "start", value: .string("\(list.start)"))
+                if let start = list.start {
+                    listElement.updateAttribute(named: "start", value: .string("\(start)"))
                 }
             }
         }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -211,10 +211,14 @@ private extension LayoutManager {
             let glyphRange = self.glyphRange(forCharacterRange: enclosingRange, actualCharacterRange: nil)
             let markerRect = rectForItem(range: glyphRange, origin: origin, paragraphStyle: paragraphStyle)
             var markerNumber = textStorage.itemNumber(in: list, at: enclosingRange.location)
+            var start = list.start ?? 1
             if list.reversed {
                 markerNumber = -markerNumber
+                if list.start == nil {
+                    start = textStorage.numberOfItems(in: list, at: enclosingRange.location)
+                }
             }
-            markerNumber += list.start
+            markerNumber += start
             
             drawItem(number: markerNumber, in: markerRect, from: list, using: paragraphStyle, at: enclosingRange.location)
         }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -210,8 +210,12 @@ private extension LayoutManager {
 
             let glyphRange = self.glyphRange(forCharacterRange: enclosingRange, actualCharacterRange: nil)
             let markerRect = rectForItem(range: glyphRange, origin: origin, paragraphStyle: paragraphStyle)
-            let markerNumber = textStorage.itemNumber(in: list, at: enclosingRange.location)
-
+            var markerNumber = textStorage.itemNumber(in: list, at: enclosingRange.location)
+            if list.reversed {
+                markerNumber = -markerNumber
+            }
+            markerNumber += list.start
+            
             drawItem(number: markerNumber, in: markerRect, from: list, using: paragraphStyle, at: enclosingRange.location)
         }
     }

--- a/Aztec/Classes/TextKit/ParagraphProperty/TextList.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/TextList.swift
@@ -24,7 +24,7 @@ open class TextList: ParagraphProperty {
 
     public let reversed: Bool
 
-    public let start: Int
+    public let start: Int?
 
     // MARK: - Properties
 
@@ -32,16 +32,19 @@ open class TextList: ParagraphProperty {
     ///
     let style: Style
 
-    init(style: Style, start: Int = 1, reversed: Bool = false, with representation: HTMLRepresentation? = nil) {
+    init(style: Style, start: Int? = nil, reversed: Bool = false, with representation: HTMLRepresentation? = nil) {
         self.style = style
 
         if let representation = representation, case let .element( html ) = representation.kind {
             self.reversed = html.attribute(ofType: .reversed) != nil
             
-            if let startAttribute = html.attribute(ofType: .start), case let .string( value ) = startAttribute.value, let start = Int(value) {
+            if let startAttribute = html.attribute(ofType: .start),
+                case let .string( value ) = startAttribute.value,
+                let start = Int(value)
+            {
                 self.start = start
             } else {
-                self.start = 1
+                self.start = nil
             }
         } else {
             self.start = start
@@ -61,7 +64,7 @@ open class TextList: ParagraphProperty {
             let decodedStart = aDecoder.decodeInteger(forKey: AttributeType.start.rawValue)
             start = decodedStart
         } else {
-            start = 1
+            start = nil
         }
 
         if aDecoder.containsValue(forKey: AttributeType.reversed.rawValue) {

--- a/Aztec/Classes/TextKit/ParagraphProperty/TextList.swift
+++ b/Aztec/Classes/TextKit/ParagraphProperty/TextList.swift
@@ -22,14 +22,31 @@ open class TextList: ParagraphProperty {
         }
     }
 
+    public let reversed: Bool
+
+    public let start: Int
+
     // MARK: - Properties
 
     /// Kind of List: Ordered / Unordered
     ///
     let style: Style
 
-    init(style: Style, with representation: HTMLRepresentation? = nil) {
+    init(style: Style, start: Int = 1, reversed: Bool = false, with representation: HTMLRepresentation? = nil) {
         self.style = style
+
+        if let representation = representation, case let .element( html ) = representation.kind {
+            self.reversed = html.attribute(ofType: .reversed) != nil
+            
+            if let startAttribute = html.attribute(ofType: .start), case let .string( value ) = startAttribute.value, let start = Int(value) {
+                self.start = start
+            } else {
+                self.start = 1
+            }
+        } else {
+            self.start = start
+            self.reversed = reversed
+        }
         super.init(with: representation)
     }
     
@@ -40,15 +57,31 @@ open class TextList: ParagraphProperty {
         } else {
             style = .ordered
         }
+        if aDecoder.containsValue(forKey: AttributeType.start.rawValue) {
+            let decodedStart = aDecoder.decodeInteger(forKey: AttributeType.start.rawValue)
+            start = decodedStart
+        } else {
+            start = 1
+        }
+
+        if aDecoder.containsValue(forKey: AttributeType.reversed.rawValue) {
+            let decodedReversed = aDecoder.decodeBool(forKey: AttributeType.reversed.rawValue)
+            reversed = decodedReversed
+        } else {
+            reversed = false
+        }
+
         super.init(coder: aDecoder)
     }
 
     public override func encode(with aCoder: NSCoder) {
         super.encode(with: aCoder)
         aCoder.encode(style.rawValue, forKey: String(describing: Style.self))
+        aCoder.encode(start, forKey: AttributeType.start.rawValue)
+        aCoder.encode(reversed, forKey: AttributeType.reversed.rawValue)
     }
 
     public static func ==(lhs: TextList, rhs: TextList) -> Bool {
-        return lhs.style == rhs.style 
+        return lhs.style == rhs.style && lhs.start == rhs.start && lhs.reversed == rhs.reversed
     }
 }

--- a/AztecTests/Formatters/TextListFormatterTests.swift
+++ b/AztecTests/Formatters/TextListFormatterTests.swift
@@ -33,8 +33,8 @@ class TextListFormatterTests: XCTestCase {
         XCTAssert(lists[2].style == .unordered)
         XCTAssert(lists[3].style == .ordered)
 
-        XCTAssert(list.itemNumber(in: lists[0], at: ranges[0].location) == 1)
-        XCTAssert(list.itemNumber(in: lists[3], at: ranges[3].location) == 1)
+        XCTAssert(list.itemNumber(in: lists[0], at: ranges[0].location) == 0)
+        XCTAssert(list.itemNumber(in: lists[3], at: ranges[3].location) == 0)
     }
 
     // Helpers #2:
@@ -64,7 +64,7 @@ class TextListFormatterTests: XCTestCase {
         }
 
         for (index, textList) in lists.enumerated() {
-            XCTAssert(list.itemNumber(in: textList, at: ranges[index].location) == index + 1)
+            XCTAssert(list.itemNumber(in: textList, at: ranges[index].location) == index)
         }
     }
 
@@ -92,7 +92,7 @@ class TextListFormatterTests: XCTestCase {
         XCTAssert(lists.count == 1)
 
         XCTAssert(lists[0].style == .ordered)
-        XCTAssert(string.itemNumber(in: lists[0], at: ranges[0].location) == 1)
+        XCTAssert(string.itemNumber(in: lists[0], at: ranges[0].location) == 0)
     }
 
 
@@ -152,7 +152,7 @@ class TextListFormatterTests: XCTestCase {
         }
 
         for (index, textList) in lists.enumerated() {
-            XCTAssertEqual(list.itemNumber(in: textList, at: ranges[index+1].location), index + 1)
+            XCTAssertEqual(list.itemNumber(in: textList, at: ranges[index+1].location), index)
         }
     }
 
@@ -185,7 +185,7 @@ class TextListFormatterTests: XCTestCase {
         XCTAssert(lists[2].style == .ordered)
         XCTAssert(lists[3].style == .unordered)
 
-        XCTAssert(list.itemNumber(in: lists[0], at: ranges[0].location) == 1)
+        XCTAssert(list.itemNumber(in: lists[0], at: ranges[0].location) == 0)
         XCTAssertEqual(list.itemNumber(in: lists[2], at: ranges[2].location), NSNotFound)
     }
 
@@ -246,9 +246,9 @@ class TextListFormatterTests: XCTestCase {
         XCTAssert(lists[2].style == .unordered)
         XCTAssert(lists[3].style == .ordered)
 
-        XCTAssert(list.itemNumber(in: lists[0], at: ranges[0].location) == 1)
-        XCTAssert(list.itemNumber(in: lists[1], at: ranges[1].location) == 2)
-        XCTAssert(list.itemNumber(in: lists[3], at: ranges[3].location) == 1)
+        XCTAssert(list.itemNumber(in: lists[0], at: ranges[0].location) == 0)
+        XCTAssert(list.itemNumber(in: lists[1], at: ranges[1].location) == 1)
+        XCTAssert(list.itemNumber(in: lists[3], at: ranges[3].location) == 0)
     }
 
 
@@ -280,9 +280,9 @@ class TextListFormatterTests: XCTestCase {
         XCTAssert(lists[3].style == .ordered)
         XCTAssert(lists[4].style == .ordered)
 
-        XCTAssert(list.itemNumber(in: lists[0], at: ranges[0].location) == 1)
-        XCTAssert(list.itemNumber(in: lists[1], at: ranges[1].location) == 2)
-        XCTAssert(list.itemNumber(in: lists[3], at: ranges[3].location) == 4)
+        XCTAssert(list.itemNumber(in: lists[0], at: ranges[0].location) == 0)
+        XCTAssert(list.itemNumber(in: lists[1], at: ranges[1].location) == 1)
+        XCTAssert(list.itemNumber(in: lists[3], at: ranges[3].location) == 3)
 
     }
 
@@ -318,7 +318,7 @@ class TextListFormatterTests: XCTestCase {
             XCTAssert(list!.style == .ordered)
 
 
-            XCTAssert(string.itemNumber(in: list!, at: range.location) == index + 1)
+            XCTAssert(string.itemNumber(in: list!, at: range.location) == index)
         }
     }
 
@@ -356,7 +356,7 @@ class TextListFormatterTests: XCTestCase {
             }
 
             XCTAssert(list.style == .ordered)
-            XCTAssert(string.itemNumber(in: list, at: range.location) == index+1)
+            XCTAssert(string.itemNumber(in: list, at: range.location) == index)
         }
     }
 
@@ -424,10 +424,9 @@ class TextListFormatterTests: XCTestCase {
 
         XCTAssert(items.count == 5)
 
-        XCTAssert(list.itemNumber(in: items[0], at: 0) == 1)
-        XCTAssert(list.itemNumber(in: items[0], at: 13)  == 2)
+        XCTAssert(list.itemNumber(in: items[0], at: 0) == 0)
+        XCTAssert(list.itemNumber(in: items[0], at: 13)  == 1)
     }
-
 
     // Verifies that the `present(in: at:)` helper effectively returns true, as needed.
     //

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -37,11 +37,25 @@ Code: <code>print("Hello world")</code>
     <li>Three</li>
 </ol>
 
+<h4>Start in 10 List:</h4>
+<ol start="10">
+    <li>Ten</li>
+    <li>Eleven</li>
+    <li>Twelve</li>
+</ol>
+
 <h4>Reversed List:</h4>
-<ol reversed start="10">
-    <li>One</li>
-    <li>Two</li>
+<ol reversed>
     <li>Three</li>
+    <li>Two</li>
+    <li>One</li>
+</ol>
+
+<h4>Reversed Start in 10 List:</h4>
+<ol reversed start="10">
+    <li>Ten</li>
+    <li>Nine</li>
+    <li>Eight</li>
 </ol>
 
 <h4>Nested lists:</h4>

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -37,6 +37,13 @@ Code: <code>print("Hello world")</code>
     <li>Three</li>
 </ol>
 
+<h4>Reversed List:</h4>
+<ol reversed start="10">
+    <li>One</li>
+    <li>Two</li>
+    <li>Three</li>
+</ol>
+
 <h4>Nested lists:</h4>
 
 <ol>


### PR DESCRIPTION
This PR adds visual support for the reversed and start properties in list.

It does three things:
 - Add to TextList paragraph attributes properties for reversed and start
 - Adds support for parsing of the attributes when reading the HTML
 - Adds support to show visually the attributes effect on display

![Simulator Screen Shot - iPhone 11 Pro Max - 2019-11-22 at 17 45 03](https://user-images.githubusercontent.com/651601/69448171-e859d400-0d4f-11ea-9028-6a82e15ca9cf.png)


To test:
 - Start the demo app
 - Check that all  lists are showed correctly, specially the new ones with reversed and start attributes.
 - Play around on HTML by changing the attributes of list to see if all is displayed correctly
- Test scenarios
 - Ordered list without start and reversed
 - Ordered list with reversed attribute: check if numbers are updated correctly has members are added
 - Ordered list with start attributed: check if numbers start on the correct number indicated
 - Ordered list with start and reversed: check if numbers are correct
 - In all cases delete lines and see if updates are done correctly.

