### PR TITLE
Set default text color when text color is changed.

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -256,6 +256,17 @@ open class TextView: UITextView {
         }        
     }()
 
+    open override var textColor: UIColor? {
+        set {
+            super.textColor = newValue
+            defaultTextColor = newValue
+        }
+
+        get {
+            return super.textColor
+        }
+    }
+
     // MARK: - Plugin Loading
     
     var pluginManager: PluginManager {


### PR DESCRIPTION
Fixes: #1040 

Makes sure that when textColor is changed explicitely the defaultTextColor for HTML is updated accordingly.

To test:
 - Change the value of textColor in EditorDemoController line 181
 - Run the demo app
 - Check that the color is applied to all text where no color is set in HTML
 - Check that copy/paste without formatting from other apps get the color set in textColor

