### PR TITLE
Issue/1086 blockquote multilevel support

### DIFF
--- a/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
+++ b/Aztec/Classes/Converters/ElementsToAttributedString/Implementations/GenericElementConverter.swift
@@ -15,7 +15,7 @@ class GenericElementConverter: ElementConverter {
     
     // MARK: - Built-in formatter instances
     
-    lazy var blockquoteFormatter = BlockquoteFormatter()
+    lazy var blockquoteFormatter = BlockquoteFormatter(increaseDepth: true)
     lazy var boldFormatter = BoldFormatter()
     lazy var divFormatter = HTMLDivFormatter()
     lazy var h1Formatter = HeaderFormatter(headerLevel: .h1)

--- a/Aztec/Classes/Formatters/Implementations/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/BlockquoteFormatter.swift
@@ -10,11 +10,15 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
     ///
     let placeholderAttributes: [NSAttributedString.Key: Any]?
 
+    /// Tells if the formatter is increasing the depth of a list or simple changing the current one if any
+    let increaseDepth: Bool
+
 
     /// Designated Initializer
     ///
-    init(placeholderAttributes: [NSAttributedString.Key: Any]? = nil) {
+    init(placeholderAttributes: [NSAttributedString.Key: Any]? = nil, increaseDepth: Bool = false) {
         self.placeholderAttributes = placeholderAttributes
+        self.increaseDepth = increaseDepth
     }
 
 
@@ -26,11 +30,18 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
         if let paragraphStyle = attributes[.paragraphStyle] as? NSParagraphStyle {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
         }
-
-        newParagraphStyle.appendProperty(Blockquote(with: representation))
+        
+        let newQuote = Blockquote(with: representation)
+        
+        if newParagraphStyle.blockquotes.isEmpty || increaseDepth {
+            newParagraphStyle.insertProperty(newQuote, afterLastOfType: Blockquote.self)
+        } else {
+            newParagraphStyle.replaceProperty(ofType: Blockquote.self, with: newQuote)
+        }
 
         var resultingAttributes = attributes
         resultingAttributes[.paragraphStyle] = newParagraphStyle
+        
         return resultingAttributes
     }
 
@@ -55,5 +66,10 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
             return false
         }
         return !style.blockquotes.isEmpty
+    }
+    
+    static func blockquotes(in attributes: [NSAttributedString.Key: Any]) -> [Blockquote] {
+        let style = attributes[.paragraphStyle] as? ParagraphStyle
+        return style?.blockquotes ?? []
     }
 }

--- a/Aztec/Classes/Formatters/Implementations/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/BlockquoteFormatter.swift
@@ -12,6 +12,9 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
 
     /// Tells if the formatter is increasing the depth of a list or simple changing the current one if any
     let increaseDepth: Bool
+    
+    /// Next color
+    var nextTextColor: UIColor?
 
 
     /// Designated Initializer
@@ -41,6 +44,7 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
 
         var resultingAttributes = attributes
         resultingAttributes[.paragraphStyle] = newParagraphStyle
+        resultingAttributes[.foregroundColor] = nextTextColor
         
         return resultingAttributes
     }
@@ -58,6 +62,13 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
 
         var resultingAttributes = attributes
         resultingAttributes[.paragraphStyle] = newParagraphStyle
+        
+        resultingAttributes.removeValue(forKey: .foregroundColor)
+
+        if let defaultAttributes = self.placeholderAttributes {
+            resultingAttributes[.foregroundColor] = defaultAttributes[.foregroundColor]
+        }
+        
         return resultingAttributes
     }
 

--- a/Aztec/Classes/Formatters/Implementations/BlockquoteFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/BlockquoteFormatter.swift
@@ -13,9 +13,6 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
     /// Tells if the formatter is increasing the depth of a list or simple changing the current one if any
     let increaseDepth: Bool
     
-    /// Next color
-    var nextTextColor: UIColor?
-
 
     /// Designated Initializer
     ///
@@ -44,7 +41,6 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
 
         var resultingAttributes = attributes
         resultingAttributes[.paragraphStyle] = newParagraphStyle
-        resultingAttributes[.foregroundColor] = nextTextColor
         
         return resultingAttributes
     }
@@ -62,13 +58,7 @@ class BlockquoteFormatter: ParagraphAttributeFormatter {
 
         var resultingAttributes = attributes
         resultingAttributes[.paragraphStyle] = newParagraphStyle
-        
-        resultingAttributes.removeValue(forKey: .foregroundColor)
-
-        if let defaultAttributes = self.placeholderAttributes {
-            resultingAttributes[.foregroundColor] = defaultAttributes[.foregroundColor]
-        }
-        
+                
         return resultingAttributes
     }
 

--- a/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
@@ -35,6 +35,7 @@ class TextListFormatter: ParagraphAttributeFormatter {
         }
 
         let newList = TextList(style: self.listStyle, with: representation)
+        
         if newParagraphStyle.lists.isEmpty || increaseDepth {
             newParagraphStyle.insertProperty(newList, afterLastOfType: HTMLLi.self)
         } else {

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -70,16 +70,19 @@ private extension LayoutManager {
             let blockquoteGlyphRange = glyphRange(forCharacterRange: range, actualCharacterRange: nil)
 
             enumerateLineFragments(forGlyphRange: blockquoteGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
+                
+                let startIndent = paragraphStyle.blockquoteIndent
+
                 let lineRange = self.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
                 let lineCharacters = textStorage.attributedSubstring(from: lineRange).string
                 let lineEndsParagraph = lineCharacters.isEndOfParagraph(before: lineCharacters.endIndex)
-                let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: 0.0, lineEndsParagraph: lineEndsParagraph)
+                let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: startIndent, lineEndsParagraph: lineEndsParagraph)
 
                 self.drawBlockquoteBackground(in: blockquoteRect.integral, with: context)
                 
-                let nestDepth = paragraphStyle.blockquoteDepth
+                let nestDepth = paragraphStyle.blockquoteNestDepth
                 for index in 0...nestDepth {
-                  let indent = CGFloat(index) * Metrics.listTextIndentation
+                  let indent = startIndent + CGFloat(index) * Metrics.listTextIndentation
 
                   let nestRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: indent, lineEndsParagraph: lineEndsParagraph)
 

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -140,26 +140,24 @@ private extension LayoutManager {
     }
     
     private func drawBlockquoteBorder(in rect: CGRect, with context: CGContext, at depth: Int) {
-        
         let quoteCount = blockquoteBorderColors.count
         let index = min(depth, quoteCount-1)
         
-        if blockquoteBorderColors.indices.contains(index) {
-            let borderColor = blockquoteBorderColors[index]
-            let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
-            borderColor.setFill()
-            context.fill(borderRect)
-        }
-
+        guard index < quoteCount else {return}
+        
+        let borderColor = blockquoteBorderColors[index]
+        let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
+        borderColor.setFill()
+        context.fill(borderRect)
     }
 
     /// Draws a single Blockquote Line Fragment, in the specified Rectangle, using a given Graphics Context.
     ///
     private func drawBlockquoteBackground(in rect: CGRect, with context: CGContext) {
-        if let blockquoteBackgroundColor = blockquoteBackgroundColor {
-            blockquoteBackgroundColor.setFill()
-            context.fill(rect)
-        }
+        guard let color = blockquoteBackgroundColor else {return}
+        
+        color.setFill()
+        context.fill(rect)
     }
 }
 

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -10,12 +10,14 @@ class LayoutManager: NSLayoutManager {
     /// Blockquote's Left Border Color
     /// Include 3 nested values
     
-    var blockquoteBorderColor = [0 : UIColor(hexString: "66D6FF")!,
-                                1 : UIColor(hexString: "5198E8")!,
-                                2 : UIColor(hexString: "597CFF")!]
+    var blockquoteBorderColor = [0 : UIColor(hexString: "9252FF")!,
+                                1 : UIColor(hexString: "5A4AE8")!,
+                                2 : UIColor(hexString: "5D77FE")!,
+                                3 : UIColor(hexString: "4A8EE8")!,
+                                4 : UIColor(hexString: "52CAFF")!]
     
-    /// Update this accordingly to the dictionary above
-    static let quoteMaxDepth: Int = 2
+    /// Update this accordingly to the highest index value in the dictionary above
+    static let quoteMaxDepth: Int = 4
 
 
     /// Blockquote's Background Color

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -17,7 +17,7 @@ class LayoutManager: NSLayoutManager {
                                 4 : UIColor(hexString: "52CAFF")!]
     
     /// Update this accordingly to the highest index value in the dictionary above
-    static let quoteMaxDepth: Int = 4
+    var quoteMaxDepth: Int = 4
 
 
     /// Blockquote's Background Color
@@ -147,7 +147,7 @@ private extension LayoutManager {
     
     private func drawNestedBlockquote(in rect: CGRect, with context: CGContext, at depth: Int) {
         
-        let index = depth > LayoutManager.quoteMaxDepth ? LayoutManager.quoteMaxDepth : depth
+        let index = depth > quoteMaxDepth ? quoteMaxDepth : depth
 
         if let blockquoteBorderColor = blockquoteBorderColor[index] {
             let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -76,7 +76,9 @@ private extension LayoutManager {
                 let lineEndsParagraph = lineCharacters.isEndOfParagraph(before: lineCharacters.endIndex)
                 let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: blockquoteIndent, lineEndsParagraph: lineEndsParagraph)
 
-                self.drawBlockquote(in: blockquoteRect.integral, with: context)
+                self.drawBlockquoteBackground(in: blockquoteRect.integral, with: context)
+                self.drawBlockquoteBorder(in: blockquoteRect.integral, with: context, at: 0)
+
                 
                 //nested blockquote
                 let nestDepth = paragraphStyle.blockquoteNestedIndent.depth
@@ -86,7 +88,7 @@ private extension LayoutManager {
                     
                     let nestRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: indent, lineEndsParagraph: lineEndsParagraph)
                     
-                    self.drawNestedBlockquote(in: nestRect.integral, with: context, at: index)
+                    self.drawBlockquoteBorder(in: nestRect.integral, with: context, at: index)
                 }
                 
             
@@ -107,7 +109,8 @@ private extension LayoutManager {
         let extraIndent = paragraphStyle.blockquoteIndent
         let extraRect = blockquoteRect(origin: origin, lineRect: extraLineFragmentRect, blockquoteIndent: extraIndent, lineEndsParagraph: false)
 
-        drawBlockquote(in: extraRect.integral, with: context)
+        drawBlockquoteBackground(in: extraRect.integral, with: context)
+        drawBlockquoteBorder(in: extraRect.integral, with: context, at: 0)
     }
 
 
@@ -140,10 +143,10 @@ private extension LayoutManager {
         return blockquoteRect
     }
     
-    private func drawNestedBlockquote(in rect: CGRect, with context: CGContext, at depth: Int) {
+    private func drawBlockquoteBorder(in rect: CGRect, with context: CGContext, at depth: Int) {
         
         let quoteCount = blockquoteBorderColors.count
-        let index = depth < quoteCount ? depth : quoteCount-1
+        let index = min(depth, quoteCount-1)
         
         if blockquoteBorderColors.indices.contains(index) {
             let borderColor = blockquoteBorderColors[index]
@@ -156,17 +159,10 @@ private extension LayoutManager {
 
     /// Draws a single Blockquote Line Fragment, in the specified Rectangle, using a given Graphics Context.
     ///
-    private func drawBlockquote(in rect: CGRect, with context: CGContext) {
+    private func drawBlockquoteBackground(in rect: CGRect, with context: CGContext) {
         if let blockquoteBackgroundColor = blockquoteBackgroundColor {
             blockquoteBackgroundColor.setFill()
             context.fill(rect)
-
-        }
-
-        if let borderColor = blockquoteBorderColors.first {
-            let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
-            borderColor.setFill()
-            context.fill(borderRect)
         }
     }
 }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -141,7 +141,9 @@ private extension LayoutManager {
         let quoteCount = blockquoteBorderColors.count
         let index = min(depth, quoteCount-1)
         
-        guard index < quoteCount else {return}
+        guard quoteCount > 0 && index < quoteCount else {
+            return            
+        }
         
         let borderColor = blockquoteBorderColors[index]
         let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -73,6 +73,19 @@ private extension LayoutManager {
                 let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: blockquoteIndent, lineEndsParagraph: lineEndsParagraph)
 
                 self.drawBlockquote(in: blockquoteRect.integral, with: context)
+                
+                //nested blockquote
+                let nestDepth = paragraphStyle.blockquoteNestedIndent.depth
+                guard nestDepth >= 1 else {return}
+                for index in 1...nestDepth {
+                    let indent = CGFloat(index) * Metrics.listTextIndentation
+                    
+                    let nestRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: indent, lineEndsParagraph: lineEndsParagraph)
+                    
+                    self.drawBlockquote(in: nestRect.integral, with: context)
+                }
+                
+            
             }
         }
 

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -8,12 +8,14 @@ import QuartzCore
 class LayoutManager: NSLayoutManager {
 
     /// Blockquote's Left Border Color
-    ///
-    var blockquoteBorderColor: UIColor? = UIColor(red: 0.52, green: 0.65, blue: 0.73, alpha: 1.0)
+    /// Include 3 nested values
     
-    var blockquoteBorderColor1: UIColor? = UIColor(red: 0.62, green: 0.75, blue: 0.83, alpha: 1.0)
-
-    var blockquoteBorderColor2: UIColor? = UIColor(red: 0.72, green: 0.85, blue: 0.93, alpha: 1.0)
+    var blockquoteBorderColor = [0 : UIColor(hexString: "66D6FF")!,
+                                1 : UIColor(hexString: "5198E8")!,
+                                2 : UIColor(hexString: "597CFF")!]
+    
+    /// Update this accordingly to the dictionary above
+    static let quoteMaxDepth: Int = 2
 
 
     /// Blockquote's Background Color
@@ -143,39 +145,12 @@ private extension LayoutManager {
     
     private func drawNestedBlockquote(in rect: CGRect, with context: CGContext, at depth: Int) {
         
-        switch depth {
-        case 0:
-            if let blockquoteBorderColor = blockquoteBorderColor {
-                let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
-                blockquoteBorderColor.setFill()
-                context.fill(borderRect)
-                
-            }
-            
-        case 1:
-            if let blockquoteBorderColor = blockquoteBorderColor1 {
-                let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
-                blockquoteBorderColor.setFill()
-                context.fill(borderRect)
-                
-            }
-            
-        case 2:
-            if let blockquoteBorderColor = blockquoteBorderColor2 {
-                let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
-                blockquoteBorderColor.setFill()
-                context.fill(borderRect)
-                
-            }
-            
-        default:
-            if let blockquoteBorderColor = blockquoteBorderColor2 {
-                let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
-                blockquoteBorderColor.setFill()
-                context.fill(borderRect)
-    
-            }
-            
+        let index = depth > LayoutManager.quoteMaxDepth ? LayoutManager.quoteMaxDepth : depth
+
+        if let blockquoteBorderColor = blockquoteBorderColor[index] {
+            let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
+            blockquoteBorderColor.setFill()
+            context.fill(borderRect)
         }
 
     }
@@ -189,7 +164,7 @@ private extension LayoutManager {
 
         }
 
-        if let blockquoteBorderColor = blockquoteBorderColor {
+        if let blockquoteBorderColor = blockquoteBorderColor[0] {
             let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
             blockquoteBorderColor.setFill()
             context.fill(borderRect)

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -66,19 +66,18 @@ private extension LayoutManager {
             guard let paragraphStyle = object as? ParagraphStyle, !paragraphStyle.blockquotes.isEmpty else {
                 return
             }
-            
-            let blockquoteIndent = paragraphStyle.blockquoteIndent
+                        
             let blockquoteGlyphRange = glyphRange(forCharacterRange: range, actualCharacterRange: nil)
 
             enumerateLineFragments(forGlyphRange: blockquoteGlyphRange) { (rect, usedRect, textContainer, glyphRange, stop) in
                 let lineRange = self.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
                 let lineCharacters = textStorage.attributedSubstring(from: lineRange).string
                 let lineEndsParagraph = lineCharacters.isEndOfParagraph(before: lineCharacters.endIndex)
-                let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: blockquoteIndent, lineEndsParagraph: lineEndsParagraph)
+                let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: 0.0, lineEndsParagraph: lineEndsParagraph)
 
                 self.drawBlockquoteBackground(in: blockquoteRect.integral, with: context)
                 
-                let nestDepth = paragraphStyle.blockquoteNestedIndent.depth
+                let nestDepth = paragraphStyle.blockquoteDepth
                 for index in 0...nestDepth {
                   let indent = CGFloat(index) * Metrics.listTextIndentation
 

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -10,15 +10,11 @@ class LayoutManager: NSLayoutManager {
     /// Blockquote's Left Border Color
     /// Include 3 nested values
     
-    var blockquoteBorderColor = [0 : UIColor(hexString: "9252FF")!,
-                                1 : UIColor(hexString: "5A4AE8")!,
-                                2 : UIColor(hexString: "5D77FE")!,
-                                3 : UIColor(hexString: "4A8EE8")!,
-                                4 : UIColor(hexString: "52CAFF")!]
-    
-    /// Update this accordingly to the highest index value in the dictionary above
-    var quoteMaxDepth: Int = 4
-
+    var blockquoteBorderColors = [UIColor(hexString: "9252FF")!,
+                                UIColor(hexString: "5A4AE8")!,
+                                UIColor(hexString: "5D77FE")!,
+                                UIColor(hexString: "4A8EE8")!,
+                                UIColor(hexString: "52CAFF")!]
 
     /// Blockquote's Background Color
     ///
@@ -147,11 +143,13 @@ private extension LayoutManager {
     
     private func drawNestedBlockquote(in rect: CGRect, with context: CGContext, at depth: Int) {
         
-        let index = depth > quoteMaxDepth ? quoteMaxDepth : depth
-
-        if let blockquoteBorderColor = blockquoteBorderColor[index] {
+        let quoteCount = blockquoteBorderColors.count
+        let index = depth < quoteCount ? depth : quoteCount-1
+        
+        if blockquoteBorderColors.indices.contains(index) {
+            let borderColor = blockquoteBorderColors[index]
             let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
-            blockquoteBorderColor.setFill()
+            borderColor.setFill()
             context.fill(borderRect)
         }
 
@@ -166,9 +164,9 @@ private extension LayoutManager {
 
         }
 
-        if let blockquoteBorderColor = blockquoteBorderColor[0] {
+        if let borderColor = blockquoteBorderColors.first {
             let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
-            blockquoteBorderColor.setFill()
+            borderColor.setFill()
             context.fill(borderRect)
         }
     }

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -10,6 +10,11 @@ class LayoutManager: NSLayoutManager {
     /// Blockquote's Left Border Color
     ///
     var blockquoteBorderColor: UIColor? = UIColor(red: 0.52, green: 0.65, blue: 0.73, alpha: 1.0)
+    
+    var blockquoteBorderColor1: UIColor? = UIColor(red: 0.62, green: 0.75, blue: 0.83, alpha: 1.0)
+
+    var blockquoteBorderColor2: UIColor? = UIColor(red: 0.72, green: 0.85, blue: 0.93, alpha: 1.0)
+
 
     /// Blockquote's Background Color
     ///
@@ -62,7 +67,7 @@ private extension LayoutManager {
             guard let paragraphStyle = object as? ParagraphStyle, !paragraphStyle.blockquotes.isEmpty else {
                 return
             }
-
+            
             let blockquoteIndent = paragraphStyle.blockquoteIndent
             let blockquoteGlyphRange = glyphRange(forCharacterRange: range, actualCharacterRange: nil)
 
@@ -82,7 +87,7 @@ private extension LayoutManager {
                     
                     let nestRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: indent, lineEndsParagraph: lineEndsParagraph)
                     
-                    self.drawBlockquote(in: nestRect.integral, with: context)
+                    self.drawNestedBlockquote(in: nestRect.integral, with: context, at: index)
                 }
                 
             
@@ -134,6 +139,45 @@ private extension LayoutManager {
         }
 
         return blockquoteRect
+    }
+    
+    private func drawNestedBlockquote(in rect: CGRect, with context: CGContext, at depth: Int) {
+        
+        switch depth {
+        case 0:
+            if let blockquoteBorderColor = blockquoteBorderColor {
+                let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
+                blockquoteBorderColor.setFill()
+                context.fill(borderRect)
+                
+            }
+            
+        case 1:
+            if let blockquoteBorderColor = blockquoteBorderColor1 {
+                let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
+                blockquoteBorderColor.setFill()
+                context.fill(borderRect)
+                
+            }
+            
+        case 2:
+            if let blockquoteBorderColor = blockquoteBorderColor2 {
+                let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
+                blockquoteBorderColor.setFill()
+                context.fill(borderRect)
+                
+            }
+            
+        default:
+            if let blockquoteBorderColor = blockquoteBorderColor2 {
+                let borderRect = CGRect(origin: rect.origin, size: CGSize(width: blockquoteBorderWidth, height: rect.height))
+                blockquoteBorderColor.setFill()
+                context.fill(borderRect)
+    
+            }
+            
+        }
+
     }
 
     /// Draws a single Blockquote Line Fragment, in the specified Rectangle, using a given Graphics Context.

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -9,11 +9,7 @@ class LayoutManager: NSLayoutManager {
 
     /// Blockquote's Left Border Color
     /// Set the array with how many colors you like, they appear in the order they are set in the array.
-    var blockquoteBorderColors = [UIColor(hexString: "9252FF")!,
-                                UIColor(hexString: "5A4AE8")!,
-                                UIColor(hexString: "5D77FE")!,
-                                UIColor(hexString: "4A8EE8")!,
-                                UIColor(hexString: "52CAFF")!]
+    var blockquoteBorderColors = [UIColor.systemGray]
 
     /// Blockquote's Background Color
     ///

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -8,8 +8,7 @@ import QuartzCore
 class LayoutManager: NSLayoutManager {
 
     /// Blockquote's Left Border Color
-    /// Include 3 nested values
-    
+    /// Set the array with how many colors you like, they appear in the order they are set in the array.
     var blockquoteBorderColors = [UIColor(hexString: "9252FF")!,
                                 UIColor(hexString: "5A4AE8")!,
                                 UIColor(hexString: "5D77FE")!,

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -77,18 +77,14 @@ private extension LayoutManager {
                 let blockquoteRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: blockquoteIndent, lineEndsParagraph: lineEndsParagraph)
 
                 self.drawBlockquoteBackground(in: blockquoteRect.integral, with: context)
-                self.drawBlockquoteBorder(in: blockquoteRect.integral, with: context, at: 0)
-
                 
-                //nested blockquote
                 let nestDepth = paragraphStyle.blockquoteNestedIndent.depth
-                guard nestDepth >= 1 else {return}
-                for index in 1...nestDepth {
-                    let indent = CGFloat(index) * Metrics.listTextIndentation
-                    
-                    let nestRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: indent, lineEndsParagraph: lineEndsParagraph)
-                    
-                    self.drawBlockquoteBorder(in: nestRect.integral, with: context, at: index)
+                for index in 0...nestDepth {
+                  let indent = CGFloat(index) * Metrics.listTextIndentation
+
+                  let nestRect = self.blockquoteRect(origin: origin, lineRect: rect, blockquoteIndent: indent, lineEndsParagraph: lineEndsParagraph)
+
+                  self.drawBlockquoteBorder(in: nestRect.integral, with: context, at: index)
                 }
                 
             

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -176,17 +176,30 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
         }
     }
     
-    /// The amount of indent for the nested blockquote of the paragraph if any.
-    ///
+    /// The level of indent to start the blockquote of the paragraph. Includes list indentation.
+    /// Handles whether blockquote is outside or insdie of a list.
     public var blockquoteIndent: CGFloat {
-        return CGFloat(blockquoteDepth) * Metrics.listTextIndentation
-    }
-    
-    /// The level of depth for the nested blockquote of the paragraph if any.
-    ///
-    public var blockquoteDepth: Int {
         let listAndBlockquotes = properties.filter({ property in
             return property is Blockquote || property is TextList
+        })
+        if listAndBlockquotes.first is Blockquote {
+            return 0
+        }
+        var depth = 0
+        for position in (0..<listAndBlockquotes.count).reversed() {
+            if listAndBlockquotes[position] is Blockquote {
+                depth = position
+                break
+            }
+        }
+        return CGFloat(depth) * Metrics.listTextIndentation
+    }
+    
+    /// The level of depth for the nested blockquote of the paragraph. Excludes list indentation.
+    ///
+    public var blockquoteNestDepth: Int {
+        let listAndBlockquotes = properties.filter({ property in
+            return property is Blockquote
         })
         var depth = 0
         for position in (0..<listAndBlockquotes.count).reversed() {

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -175,26 +175,16 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
             super.tailIndent = newValue
         }
     }
-
-    /// The amount of indent for the blockquote of the paragraph if any.
-    ///
-    public var blockquoteIndent: CGFloat {
-        let blockquoteIndex = properties.filter({ property in
-            return property is Blockquote || property is TextList
-        }).firstIndex(where: { property in
-            return property is Blockquote
-        })
-
-        guard let depth = blockquoteIndex else {
-            return 0
-        }
-
-        return CGFloat(depth) * Metrics.listTextIndentation
-    }
     
     /// The amount of indent for the nested blockquote of the paragraph if any.
     ///
-    public var blockquoteNestedIndent: (depth: Int, indent: CGFloat) {
+    public var blockquoteIndent: CGFloat {
+        return CGFloat(blockquoteDepth) * Metrics.listTextIndentation
+    }
+    
+    /// The level of depth for the nested blockquote of the paragraph if any.
+    ///
+    public var blockquoteDepth: Int {
         let listAndBlockquotes = properties.filter({ property in
             return property is Blockquote || property is TextList
         })
@@ -205,8 +195,7 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
                 break
             }
         }
-        let indent = CGFloat(depth) * Metrics.listTextIndentation
-        return (depth, indent)
+        return depth
     }
 
     /// The amount of indent for the list of the paragraph if any.

--- a/Aztec/Classes/TextKit/ParagraphStyle.swift
+++ b/Aztec/Classes/TextKit/ParagraphStyle.swift
@@ -191,6 +191,23 @@ open class ParagraphStyle: NSMutableParagraphStyle, CustomReflectable {
 
         return CGFloat(depth) * Metrics.listTextIndentation
     }
+    
+    /// The amount of indent for the nested blockquote of the paragraph if any.
+    ///
+    public var blockquoteNestedIndent: (depth: Int, indent: CGFloat) {
+        let listAndBlockquotes = properties.filter({ property in
+            return property is Blockquote || property is TextList
+        })
+        var depth = 0
+        for position in (0..<listAndBlockquotes.count).reversed() {
+            if listAndBlockquotes[position] is Blockquote {
+                depth = position
+                break
+            }
+        }
+        let indent = CGFloat(depth) * Metrics.listTextIndentation
+        return (depth, indent)
+    }
 
     /// The amount of indent for the list of the paragraph if any.
     ///

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -296,6 +296,24 @@ open class TextView: UITextView {
         }
     }
 
+    @objc dynamic public var blockquoteBorderColorNested1: UIColor? {
+        get {
+            return layout.blockquoteBorderColor1
+        }
+        set {
+            layout.blockquoteBorderColor1 = newValue
+        }
+    }
+    
+    @objc dynamic public var blockquoteBorderColorNested2: UIColor? {
+        get {
+            return layout.blockquoteBorderColor2
+        }
+        set {
+            layout.blockquoteBorderColor2 = newValue
+        }
+    }
+    
     /// Blockquote Blocks Background Color.
     ///
     @objc dynamic public var blockquoteBackgroundColor: UIColor? {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -2103,6 +2103,7 @@ private extension TextView {
         }
         
         typingAttributes[.paragraphStyle] = paragraphStyleWithoutProperties(from: paragraphStyle)
+        typingAttributes[.foregroundColor] = defaultTextColor
     }
     
     private func removeParagraphPropertiesFromParagraph(spanning range: NSRange) {
@@ -2114,6 +2115,7 @@ private extension TextView {
         }
         
         attributes[.paragraphStyle] = paragraphStyleWithoutProperties(from: paragraphStyle)
+        attributes[.foregroundColor] = defaultTextColor
         
         storage.setAttributes(attributes, range: range)
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -651,7 +651,7 @@ open class TextView: UITextView {
     }
     
     // MARK: Blockquote helpers
-    private func getTextColorForQuoteDepth(_ depth: Int) -> (prev: UIColor, next: UIColor) {
+    private func getTextColorForQuoteDepth(_ depth: Int, toggle: Bool = false) -> (prev: UIColor, next: UIColor) {
         
         //prev color
         let originalColor = defaultAttributes[.foregroundColor] as! UIColor
@@ -668,7 +668,8 @@ open class TextView: UITextView {
         let index = depth > LayoutManager.quoteMaxDepth ? LayoutManager.quoteMaxDepth : depth
 
         let nextIndex = index+1 > LayoutManager.quoteMaxDepth ? LayoutManager.quoteMaxDepth : index+1
-        let nextColor = layout.blockquoteBorderColor[nextIndex]!
+        // when index is 0 could be quotes off or quotes on first level, toggle bool helps us know if we are toggling it on or indenting to next level and act accordingly
+        let nextColor = toggle ? layout.blockquoteBorderColor[index]! : layout.blockquoteBorderColor[nextIndex]!
         
         return (prevColor, nextColor)
     }
@@ -1113,10 +1114,11 @@ open class TextView: UITextView {
         var originalQuoteAttributes = typingAttributes
         originalQuoteAttributes.removeValue(forKey: .foregroundColor)
         
-        let textColor = getTextColorForQuoteDepth(currentDepth)
+        let textColor = getTextColorForQuoteDepth(currentDepth, toggle: true)
         originalQuoteAttributes[.foregroundColor] = textColor.prev
         
         let formatter = BlockquoteFormatter(placeholderAttributes: originalQuoteAttributes)
+        //use the first color when toggling on
         formatter.nextTextColor = textColor.next
         
         toggle(formatter: formatter, atRange: range)

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -227,8 +227,8 @@ open class TextView: UITextView {
     // MARK: - Properties: Blockquotes
     
     /// The max levels of quote indentation allowed
-    /// Set to 9 for iPhone sized screen, 24 for other devices
-    var maximumBlockquoteIndentationLevels = UIDevice.current.userInterfaceIdiom == .phone ? 9 : 24
+    /// Default is 9
+    public var maximumBlockquoteIndentationLevels = 9
 
     // MARK: - Properties: UI Defaults
 

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -314,6 +314,24 @@ open class TextView: UITextView {
         }
     }
     
+    @objc dynamic public var blockquoteBorderColorNested3: UIColor {
+        get {
+            return layout.blockquoteBorderColor[3]!
+        }
+        set {
+            layout.blockquoteBorderColor[3] = newValue
+        }
+    }
+    
+    @objc dynamic public var blockquoteBorderColorNested4: UIColor {
+        get {
+            return layout.blockquoteBorderColor[4]!
+        }
+        set {
+            layout.blockquoteBorderColor[4] = newValue
+        }
+    }
+    
     /// Blockquote Blocks Background Color.
     ///
     @objc dynamic public var blockquoteBackgroundColor: UIColor? {

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -226,7 +226,9 @@ open class TextView: UITextView {
     
     // MARK: - Properties: Blockquotes
     
-    var maximumBlockquoteIndentationLevels = 9
+    /// The max levels of quote indentation allowed
+    /// Set to 9 for iPhone sized screen, 24 for other devices
+    var maximumBlockquoteIndentationLevels = UIDevice.current.userInterfaceIdiom == .phone ? 9 : 24
 
     // MARK: - Properties: UI Defaults
 
@@ -285,66 +287,15 @@ open class TextView: UITextView {
 
     // MARK: - Apparance Properties
 
-    /// Blockquote max depth, enter 1 - 5, default is 5
-    @objc dynamic public var blockquoteMaxDepth: Int {
-        get {
-            return layout.quoteMaxDepth + 1
-        }
-        set {
-            if newValue < 0 {
-                layout.quoteMaxDepth = 0
-            } else if newValue <= 5 {
-                layout.quoteMaxDepth = newValue - 1
-            } else {
-                layout.quoteMaxDepth = 4
-            }
-        }
-    }
     
-    /// Blockquote Blocks Border Color.
+    /// Blockquote Blocks Border and Text Colors
     ///
-    @objc dynamic public var blockquoteBorderColor: UIColor {
+    @objc dynamic public var blockquoteBorderColors: [UIColor] {
         get {
-            return layout.blockquoteBorderColor[0]!
+            return layout.blockquoteBorderColors
         }
         set {
-            layout.blockquoteBorderColor[0] = newValue
-        }
-    }
-
-    @objc dynamic public var blockquoteBorderColorNested1: UIColor {
-        get {
-            return layout.blockquoteBorderColor[1]!
-        }
-        set {
-            layout.blockquoteBorderColor[1] = newValue
-        }
-    }
-    
-    @objc dynamic public var blockquoteBorderColorNested2: UIColor {
-        get {
-            return layout.blockquoteBorderColor[2]!
-        }
-        set {
-            layout.blockquoteBorderColor[2] = newValue
-        }
-    }
-    
-    @objc dynamic public var blockquoteBorderColorNested3: UIColor {
-        get {
-            return layout.blockquoteBorderColor[3]!
-        }
-        set {
-            layout.blockquoteBorderColor[3] = newValue
-        }
-    }
-    
-    @objc dynamic public var blockquoteBorderColorNested4: UIColor {
-        get {
-            return layout.blockquoteBorderColor[4]!
-        }
-        set {
-            layout.blockquoteBorderColor[4] = newValue
+            layout.blockquoteBorderColors = newValue
         }
     }
     
@@ -687,23 +638,27 @@ open class TextView: UITextView {
     // MARK: Blockquote helpers
     private func getTextColorForQuoteDepth(_ depth: Int, toggle: Bool = false) -> (prev: UIColor, next: UIColor) {
         
+        let quoteCount = layout.blockquoteBorderColors.count
+        
         //prev color
         let originalColor = defaultAttributes[.foregroundColor] as! UIColor
         let prevColor: UIColor
-        if depth - 1 < 0 {
+        let prevIndex = depth - 1
+        
+        if prevIndex < 0 {
             prevColor = originalColor
-        } else if depth - 1 >= layout.quoteMaxDepth {
-            prevColor = layout.blockquoteBorderColor[layout.quoteMaxDepth]!
+        } else if prevIndex < quoteCount {
+            prevColor = layout.blockquoteBorderColors[prevIndex]
         } else {
-            prevColor = layout.blockquoteBorderColor[depth-1]!
+            prevColor = layout.blockquoteBorderColors[quoteCount-1]
         }
         
         //next color
-        let index = depth > layout.quoteMaxDepth ? layout.quoteMaxDepth : depth
+        let index = depth < quoteCount ? depth : quoteCount-1
 
-        let nextIndex = index+1 > layout.quoteMaxDepth ? layout.quoteMaxDepth : index+1
+        let nextIndex = index+1 < quoteCount ? index+1 : quoteCount-1
         // when index is 0 could be quotes off or quotes on first level, toggle bool helps us know if we are toggling it on or indenting to next level and act accordingly
-        let nextColor = toggle ? layout.blockquoteBorderColor[index]! : layout.blockquoteBorderColor[nextIndex]!
+        let nextColor = toggle ? layout.blockquoteBorderColors[index] : layout.blockquoteBorderColors[nextIndex]
         
         return (prevColor, nextColor)
     }

--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -285,6 +285,22 @@ open class TextView: UITextView {
 
     // MARK: - Apparance Properties
 
+    /// Blockquote max depth, enter 1 - 5, default is 5
+    @objc dynamic public var blockquoteMaxDepth: Int {
+        get {
+            return layout.quoteMaxDepth + 1
+        }
+        set {
+            if newValue < 0 {
+                layout.quoteMaxDepth = 0
+            } else if newValue <= 5 {
+                layout.quoteMaxDepth = newValue - 1
+            } else {
+                layout.quoteMaxDepth = 4
+            }
+        }
+    }
+    
     /// Blockquote Blocks Border Color.
     ///
     @objc dynamic public var blockquoteBorderColor: UIColor {
@@ -676,16 +692,16 @@ open class TextView: UITextView {
         let prevColor: UIColor
         if depth - 1 < 0 {
             prevColor = originalColor
-        } else if depth - 1 >= LayoutManager.quoteMaxDepth {
-            prevColor = layout.blockquoteBorderColor[LayoutManager.quoteMaxDepth]!
+        } else if depth - 1 >= layout.quoteMaxDepth {
+            prevColor = layout.blockquoteBorderColor[layout.quoteMaxDepth]!
         } else {
             prevColor = layout.blockquoteBorderColor[depth-1]!
         }
         
         //next color
-        let index = depth > LayoutManager.quoteMaxDepth ? LayoutManager.quoteMaxDepth : depth
+        let index = depth > layout.quoteMaxDepth ? layout.quoteMaxDepth : depth
 
-        let nextIndex = index+1 > LayoutManager.quoteMaxDepth ? LayoutManager.quoteMaxDepth : index+1
+        let nextIndex = index+1 > layout.quoteMaxDepth ? layout.quoteMaxDepth : index+1
         // when index is 0 could be quotes off or quotes on first level, toggle bool helps us know if we are toggling it on or indenting to next level and act accordingly
         let nextColor = toggle ? layout.blockquoteBorderColor[index]! : layout.blockquoteBorderColor[nextIndex]!
         

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -181,7 +181,7 @@ class EditorDemoController: UIViewController {
             editorView.richTextView.textColor = UIColor.label
             editorView.richTextView.blockquoteBackgroundColor = UIColor.secondarySystemBackground
             editorView.richTextView.preBackgroundColor = UIColor.secondarySystemBackground
-            editorView.richTextView.blockquoteBorderColors = [.red, .blue, .green]
+            editorView.richTextView.blockquoteBorderColors = [.secondarySystemFill, .systemTeal, .systemBlue]
             var attributes = editorView.richTextView.linkTextAttributes
             attributes?[.foregroundColor] =  UIColor.link
         } else {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -181,7 +181,7 @@ class EditorDemoController: UIViewController {
             editorView.richTextView.textColor = UIColor.label
             editorView.richTextView.blockquoteBackgroundColor = UIColor.secondarySystemBackground
             editorView.richTextView.preBackgroundColor = UIColor.secondarySystemBackground
-            editorView.richTextView.blockquoteBorderColor = UIColor.secondarySystemFill
+            editorView.richTextView.blockquoteBorderColors = [.red, .blue, .green]
             var attributes = editorView.richTextView.linkTextAttributes
             attributes?[.foregroundColor] =  UIColor.link
         } else {


### PR DESCRIPTION
Fixes #1086 

To test: new array method of tracking nested colors and next / previous index logic cleaned up to be more readable

replaces PR #1252 

**Original PR Description**

To test: try tabbing and shift tabbing to go through nested quotes

**Features:**

supports up to 9 levels of indentation, arbitrary, could be more, but seemed enough
supports from 1 to 5 levels of colored quotes, editable by user of the API, default is 5
style can be made to look like apple mail app or other mail apps by removing background color and customizing colors

<img width="584" alt="Screen Shot 2019-12-09 at 7 56 50 PM" src="https://user-images.githubusercontent.com/10858053/70672305-9e1f9080-1c33-11ea-9934-ec6ad5d00321.png">


**Known issue:**
when pasting quotes from either internally or externally such as a mail client, the text color doesn't change properly. Something with the tryPastingHTML method and replace not correctly getting color for new string. Would appreciate help fixing this.