### PR TITLE
Issue/refactor demo app

### DIFF
--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */; };
 		FFC41BDE20DBC7BA004DFB4D /* video.html in Resources */ = {isa = PBXBuildFile; fileRef = FFC41BDD20DBC7BA004DFB4D /* video.html */; };
 		FFFA53D023C4A64200829A43 /* MediaInsertionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFA53CF23C4A64200829A43 /* MediaInsertionHelper.swift */; };
+		FFFA53D523C4AD0B00829A43 /* TextViewAttachmentDelegateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFA53D423C4AD0B00829A43 /* TextViewAttachmentDelegateProvider.swift */; };
+		FFFA53D723C4C43700829A43 /* UIImage+SaveTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFA53D623C4C43700829A43 /* UIImage+SaveTo.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -162,6 +164,8 @@
 		FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AttachmentDetailsViewController.storyboard; sourceTree = "<group>"; };
 		FFC41BDD20DBC7BA004DFB4D /* video.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = video.html; sourceTree = "<group>"; };
 		FFFA53CF23C4A64200829A43 /* MediaInsertionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaInsertionHelper.swift; sourceTree = "<group>"; };
+		FFFA53D423C4AD0B00829A43 /* TextViewAttachmentDelegateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewAttachmentDelegateProvider.swift; sourceTree = "<group>"; };
+		FFFA53D623C4C43700829A43 /* UIImage+SaveTo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+SaveTo.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -257,7 +261,9 @@
 				FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */,
 				607FACD71AFB9204008FA782 /* ViewController.swift */,
 				E63EF92A1D36A60B00B5BA4B /* EditorDemoController.swift */,
+				FFFA53D423C4AD0B00829A43 /* TextViewAttachmentDelegateProvider.swift */,
 				FFFA53CF23C4A64200829A43 /* MediaInsertionHelper.swift */,
+				FFFA53D623C4C43700829A43 /* UIImage+SaveTo.swift */,
 				B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */,
 				607FACD91AFB9204008FA782 /* Main.storyboard */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
@@ -476,8 +482,10 @@
 			files = (
 				FFFA53D023C4A64200829A43 /* MediaInsertionHelper.swift in Sources */,
 				B5DB1C371EC630E10005E623 /* UnknownEditorViewController.swift in Sources */,
+				FFFA53D523C4AD0B00829A43 /* TextViewAttachmentDelegateProvider.swift in Sources */,
 				599F25701D8BCF57002871D6 /* AppDelegate.swift in Sources */,
 				59D2873B1D8C599B00B99C80 /* AttachmentDetailsViewController.swift in Sources */,
+				FFFA53D723C4C43700829A43 /* UIImage+SaveTo.swift in Sources */,
 				E63EF92B1D36A60B00B5BA4B /* EditorDemoController.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
 			);

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -43,7 +43,7 @@
 		FF629DC9223BC418004C4106 /* videoShortcodes.html in Resources */ = {isa = PBXBuildFile; fileRef = FF629DC8223BC418004C4106 /* videoShortcodes.html */; };
 		FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */; };
 		FFC41BDE20DBC7BA004DFB4D /* video.html in Resources */ = {isa = PBXBuildFile; fileRef = FFC41BDD20DBC7BA004DFB4D /* video.html */; };
-		FFFA53D023C4A64200829A43 /* MediaInsertionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFA53CF23C4A64200829A43 /* MediaInsertionHelper.swift */; };
+		FFFA53D023C4A64200829A43 /* MediaInserter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFA53CF23C4A64200829A43 /* MediaInserter.swift */; };
 		FFFA53D523C4AD0B00829A43 /* TextViewAttachmentDelegateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFA53D423C4AD0B00829A43 /* TextViewAttachmentDelegateProvider.swift */; };
 		FFFA53D723C4C43700829A43 /* UIImage+SaveTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFA53D623C4C43700829A43 /* UIImage+SaveTo.swift */; };
 /* End PBXBuildFile section */
@@ -163,7 +163,7 @@
 		FF629DC8223BC418004C4106 /* videoShortcodes.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = videoShortcodes.html; sourceTree = "<group>"; };
 		FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AttachmentDetailsViewController.storyboard; sourceTree = "<group>"; };
 		FFC41BDD20DBC7BA004DFB4D /* video.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = video.html; sourceTree = "<group>"; };
-		FFFA53CF23C4A64200829A43 /* MediaInsertionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaInsertionHelper.swift; sourceTree = "<group>"; };
+		FFFA53CF23C4A64200829A43 /* MediaInserter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaInserter.swift; sourceTree = "<group>"; };
 		FFFA53D423C4AD0B00829A43 /* TextViewAttachmentDelegateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewAttachmentDelegateProvider.swift; sourceTree = "<group>"; };
 		FFFA53D623C4C43700829A43 /* UIImage+SaveTo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+SaveTo.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -262,7 +262,7 @@
 				607FACD71AFB9204008FA782 /* ViewController.swift */,
 				E63EF92A1D36A60B00B5BA4B /* EditorDemoController.swift */,
 				FFFA53D423C4AD0B00829A43 /* TextViewAttachmentDelegateProvider.swift */,
-				FFFA53CF23C4A64200829A43 /* MediaInsertionHelper.swift */,
+				FFFA53CF23C4A64200829A43 /* MediaInserter.swift */,
 				FFFA53D623C4C43700829A43 /* UIImage+SaveTo.swift */,
 				B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */,
 				607FACD91AFB9204008FA782 /* Main.storyboard */,
@@ -480,7 +480,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FFFA53D023C4A64200829A43 /* MediaInsertionHelper.swift in Sources */,
+				FFFA53D023C4A64200829A43 /* MediaInserter.swift in Sources */,
 				B5DB1C371EC630E10005E623 /* UnknownEditorViewController.swift in Sources */,
 				FFFA53D523C4AD0B00829A43 /* TextViewAttachmentDelegateProvider.swift in Sources */,
 				599F25701D8BCF57002871D6 /* AppDelegate.swift in Sources */,

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		FF629DC9223BC418004C4106 /* videoShortcodes.html in Resources */ = {isa = PBXBuildFile; fileRef = FF629DC8223BC418004C4106 /* videoShortcodes.html */; };
 		FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */; };
 		FFC41BDE20DBC7BA004DFB4D /* video.html in Resources */ = {isa = PBXBuildFile; fileRef = FFC41BDD20DBC7BA004DFB4D /* video.html */; };
+		FFFA53D023C4A64200829A43 /* MediaInsertionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFA53CF23C4A64200829A43 /* MediaInsertionHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -160,6 +161,7 @@
 		FF629DC8223BC418004C4106 /* videoShortcodes.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = videoShortcodes.html; sourceTree = "<group>"; };
 		FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AttachmentDetailsViewController.storyboard; sourceTree = "<group>"; };
 		FFC41BDD20DBC7BA004DFB4D /* video.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = video.html; sourceTree = "<group>"; };
+		FFFA53CF23C4A64200829A43 /* MediaInsertionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaInsertionHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -255,6 +257,7 @@
 				FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */,
 				607FACD71AFB9204008FA782 /* ViewController.swift */,
 				E63EF92A1D36A60B00B5BA4B /* EditorDemoController.swift */,
+				FFFA53CF23C4A64200829A43 /* MediaInsertionHelper.swift */,
 				B5DB1C361EC630E10005E623 /* UnknownEditorViewController.swift */,
 				607FACD91AFB9204008FA782 /* Main.storyboard */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
@@ -471,6 +474,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FFFA53D023C4A64200829A43 /* MediaInsertionHelper.swift in Sources */,
 				B5DB1C371EC630E10005E623 /* UnknownEditorViewController.swift in Sources */,
 				599F25701D8BCF57002871D6 /* AppDelegate.swift in Sources */,
 				59D2873B1D8C599B00B99C80 /* AttachmentDetailsViewController.swift in Sources */,

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -24,8 +24,8 @@ class EditorDemoController: UIViewController {
         }
     }
 
-    fileprivate(set) lazy var mediaInsertionHelper: MediaInsertionHelper = {
-        return MediaInsertionHelper(textView: self.richTextView, attachmentTextAttributes: Constants.mediaMessageAttributes)
+    fileprivate(set) lazy var mediaInserter: MediaInserter = {
+        return MediaInserter(textView: self.richTextView, attachmentTextAttributes: Constants.mediaMessageAttributes)
     }()
 
     fileprivate(set) lazy var textViewAttachmentDelegate: TextViewAttachmentDelegate = {
@@ -1084,13 +1084,13 @@ let info = convertFromUIImagePickerControllerInfoKeyDictionary(info)
             }
 
             // Insert Image + Reclaim Focus
-            mediaInsertionHelper.insertImage(image)
+            mediaInserter.insertImage(image)
 
         case typeMovie:
             guard let videoURL = info[convertFromUIImagePickerControllerInfoKey(UIImagePickerController.InfoKey.mediaURL)] as? URL else {
                 return
             }
-            mediaInsertionHelper.insertVideo(videoURL)
+            mediaInserter.insertVideo(videoURL)
         default:
             print("Media type not supported: \(mediaType)")
         }

--- a/Example/Example/MediaInserter.swift
+++ b/Example/Example/MediaInserter.swift
@@ -4,7 +4,7 @@ import Aztec
 import AVFoundation
 import Gridicons
 
-class MediaInsertionHelper
+class MediaInserter
 {
     fileprivate var mediaErrorMode = false
 
@@ -36,7 +36,7 @@ class MediaInsertionHelper
         let progress = Progress(parent: nil, userInfo: [MediaProgressKey.mediaID: imageID])
         progress.totalUnitCount = 100
 
-        Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(MediaInsertionHelper.timerFireMethod(_:)), userInfo: progress, repeats: true)
+        Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(MediaInserter.timerFireMethod(_:)), userInfo: progress, repeats: true)
     }
 
     func insertVideo(_ videoURL: URL) {
@@ -53,7 +53,7 @@ class MediaInsertionHelper
         let progress = Progress(parent: nil, userInfo: [MediaProgressKey.mediaID: mediaID, MediaProgressKey.videoURL:videoURL])
         progress.totalUnitCount = 100
 
-        Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(MediaInsertionHelper.timerFireMethod(_:)), userInfo: progress, repeats: true)
+        Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(MediaInserter.timerFireMethod(_:)), userInfo: progress, repeats: true)
     }
 
     @objc func timerFireMethod(_ timer: Timer) {

--- a/Example/Example/MediaInserter.swift
+++ b/Example/Example/MediaInserter.swift
@@ -77,7 +77,7 @@ class MediaInserter
             timer.invalidate()
             attachment.progress = nil
             if let videoAttachment = attachment as? VideoAttachment, let videoURL = progress.userInfo[MediaProgressKey.videoURL] as? URL {
-                videoAttachment.updateURL(videoURL)
+                videoAttachment.updateURL(videoURL, refreshAsset: false)
             }
         }
         richTextView.refresh(attachment, overlayUpdateOnly: true)

--- a/Example/Example/MediaInsertionHelper.swift
+++ b/Example/Example/MediaInsertionHelper.swift
@@ -1,0 +1,102 @@
+import Foundation
+import UIKit
+import Aztec
+import AVFoundation
+import Gridicons
+
+class MediaInsertionHelper
+{
+    fileprivate var mediaErrorMode = false
+
+    struct MediaProgressKey {
+        static let mediaID = ProgressUserInfoKey("mediaID")
+        static let videoURL = ProgressUserInfoKey("videoURL")
+    }
+    
+    let richTextView: TextView
+
+    var mediaMessageAttributes: [NSAttributedString.Key: Any]
+
+    init(textView: TextView, messageAttributes: [NSAttributedString.Key: Any]) {
+        self.richTextView = textView
+        self.mediaMessageAttributes = messageAttributes
+    }
+
+    func saveToDisk(image: UIImage) -> URL {
+        let fileName = "\(ProcessInfo.processInfo.globallyUniqueString)_file.jpg"
+
+        guard let data = image.jpegData(compressionQuality: 0.9) else {
+            fatalError("Could not conert image to JPEG.")
+        }
+
+        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
+
+        guard (try? data.write(to: fileURL, options: [.atomic])) != nil else {
+            fatalError("Could not write the image to disk.")
+        }
+
+        return fileURL
+    }
+
+    func insertImage(_ image: UIImage) {
+
+        let fileURL = saveToDisk(image: image)
+
+        let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange, sourceURL: fileURL, placeHolderImage: image)
+        attachment.size = .full
+        attachment.alignment = ImageAttachment.Alignment.none
+        if let attachmentRange = richTextView.textStorage.ranges(forAttachment: attachment).first {
+            richTextView.setLink(fileURL, inRange: attachmentRange)
+        }
+        let imageID = attachment.identifier
+        let progress = Progress(parent: nil, userInfo: [MediaProgressKey.mediaID: imageID])
+        progress.totalUnitCount = 100
+
+        Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(MediaInsertionHelper.timerFireMethod(_:)), userInfo: progress, repeats: true)
+    }
+
+    func insertVideo(_ videoURL: URL) {
+        let asset = AVURLAsset(url: videoURL, options: nil)
+        let imgGenerator = AVAssetImageGenerator(asset: asset)
+        imgGenerator.appliesPreferredTrackTransform = true
+        guard let cgImage = try? imgGenerator.copyCGImage(at: CMTimeMake(value: 0, timescale: 1), actualTime: nil) else {
+            return
+        }
+        let posterImage = UIImage(cgImage: cgImage)
+        let posterURL = saveToDisk(image: posterImage)
+        let attachment = richTextView.replaceWithVideo(at: richTextView.selectedRange, sourceURL: URL(string:"placeholder://")!, posterURL: posterURL, placeHolderImage: posterImage)
+        let mediaID = attachment.identifier
+        let progress = Progress(parent: nil, userInfo: [MediaProgressKey.mediaID: mediaID, MediaProgressKey.videoURL:videoURL])
+        progress.totalUnitCount = 100
+
+        Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(MediaInsertionHelper.timerFireMethod(_:)), userInfo: progress, repeats: true)
+    }
+
+    @objc func timerFireMethod(_ timer: Timer) {
+        guard let progress = timer.userInfo as? Progress,
+              let imageId = progress.userInfo[MediaProgressKey.mediaID] as? String,
+              let attachment = richTextView.attachment(withId: imageId)
+        else {
+            timer.invalidate()
+            return
+        }
+        progress.completedUnitCount += 1
+
+        attachment.progress = progress.fractionCompleted
+        if mediaErrorMode && progress.fractionCompleted >= 0.25 {
+            timer.invalidate()
+            let message = NSAttributedString(string: "Upload failed!", attributes: mediaMessageAttributes)
+            attachment.message = message
+            attachment.overlayImage = Gridicon.iconOfType(.refresh)
+        }
+        if progress.fractionCompleted >= 1 {
+            timer.invalidate()
+            attachment.progress = nil
+            if let videoAttachment = attachment as? VideoAttachment, let videoURL = progress.userInfo[MediaProgressKey.videoURL] as? URL {
+                videoAttachment.updateURL(videoURL)
+            }
+        }
+        richTextView.refresh(attachment, overlayUpdateOnly: true)
+    }
+
+}

--- a/Example/Example/TextViewAttachmentDelegateProvider.swift
+++ b/Example/Example/TextViewAttachmentDelegateProvider.swift
@@ -1,0 +1,327 @@
+import Foundation
+import Aztec
+import UIKit
+import Gridicons
+import AVFoundation
+import AVKit
+
+class TextViewAttachmentDelegateProvider: NSObject, TextViewAttachmentDelegate {
+
+    fileprivate var currentSelectedAttachment: MediaAttachment?
+    let baseController: UIViewController
+    let attachmentTextAttributes: [NSAttributedString.Key: Any]
+
+    init(baseController: UIViewController, attachmentTextAttributes: [NSAttributedString.Key: Any]) {
+        self.baseController = baseController
+        self.attachmentTextAttributes = attachmentTextAttributes
+    }
+
+    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
+
+        switch attachment {
+        case let videoAttachment as VideoAttachment:
+            guard let posterURL = videoAttachment.posterURL else {
+                // Let's get a frame from the video directly
+                if let videoURL = videoAttachment.mediaURL {
+                    exportPreviewImageForVideo(atURL: videoURL, onCompletion: success, onError: failure)
+                } else {
+                    exportPreviewImageForVideo(atURL: url, onCompletion: success, onError: failure)
+                }
+                return
+            }
+            downloadImage(from: posterURL, success: success, onFailure: failure)
+        case let imageAttachment as ImageAttachment:
+            if let imageURL = imageAttachment.url {
+                downloadImage(from: imageURL, success: success, onFailure: failure)
+            }
+        default:
+            failure()
+        }
+    }
+
+    func textView(_ textView: TextView, placeholderFor attachment: NSTextAttachment) -> UIImage {
+        return placeholderImage(for: attachment)
+    }
+
+    func placeholderImage(for attachment: NSTextAttachment) -> UIImage {
+        let imageSize = CGSize(width:64, height:64)
+        var placeholderImage: UIImage
+        switch attachment {
+        case _ as ImageAttachment:
+            placeholderImage = Gridicon.iconOfType(.image, withSize: imageSize)
+        case _ as VideoAttachment:
+            placeholderImage = Gridicon.iconOfType(.video, withSize: imageSize)
+        default:
+            placeholderImage = Gridicon.iconOfType(.attachment, withSize: imageSize)
+        }
+        if #available(iOS 13.0, *) {
+            placeholderImage = placeholderImage.withTintColor(.label)
+        }
+        return placeholderImage
+    }
+
+    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL? {
+        guard let image = imageAttachment.image else {
+            return nil
+        }
+
+        return image.saveToTemporaryFile()
+    }
+
+    func textView(_ textView: TextView, deletedAttachment attachment: MediaAttachment) {
+        print("Attachment \(attachment.identifier) removed.\n")
+    }
+
+    func textView(_ textView: TextView, selected attachment: NSTextAttachment, atPosition position: CGPoint) {
+        switch attachment {
+        case let attachment as HTMLAttachment:
+            displayUnknownHtmlEditor(for: attachment, in: textView)
+        case let attachment as MediaAttachment:
+            selected(in: textView, textAttachment: attachment, atPosition: position)
+        default:
+            break
+        }
+    }
+
+    func textView(_ textView: TextView, deselected attachment: NSTextAttachment, atPosition position: CGPoint) {
+        deselected(in: textView, textAttachment: attachment, atPosition: position)
+    }
+
+    fileprivate func resetMediaAttachmentOverlay(_ mediaAttachment: MediaAttachment) {
+        mediaAttachment.overlayImage = nil
+        mediaAttachment.message = nil
+    }
+
+    func selected(in textView: TextView, textAttachment attachment: MediaAttachment, atPosition position: CGPoint) {
+        if (currentSelectedAttachment == attachment) {
+            displayActions(in: textView, forAttachment: attachment, position: position)
+        } else {
+            if let selectedAttachment = currentSelectedAttachment {
+                resetMediaAttachmentOverlay(selectedAttachment)
+                textView.refresh(selectedAttachment)
+            }
+
+            // and mark the newly tapped attachment
+            if attachment.message == nil {
+                let message = NSLocalizedString("Options", comment: "Options to show when tapping on a media object on the post/page editor.")
+                attachment.message = NSAttributedString(string: message, attributes: attachmentTextAttributes)
+            }
+            attachment.overlayImage = Gridicon.iconOfType(.pencil, withSize: CGSize(width: 32.0, height: 32.0)).withRenderingMode(.alwaysTemplate)
+            textView.refresh(attachment)
+            currentSelectedAttachment = attachment
+        }
+    }
+
+    func deselected(in textView: TextView,textAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
+        currentSelectedAttachment = nil
+        if let mediaAttachment = attachment as? MediaAttachment {
+            resetMediaAttachmentOverlay(mediaAttachment)
+            textView.refresh(mediaAttachment)
+        }
+    }
+
+    func displayVideoPlayer(for videoURL: URL) {
+        let asset = AVURLAsset(url: videoURL)
+        let controller = AVPlayerViewController()
+        let playerItem = AVPlayerItem(asset: asset)
+        let player = AVPlayer(playerItem: playerItem)
+        controller.showsPlaybackControls = true
+        controller.player = player
+        player.play()
+        baseController.present(controller, animated:true, completion: nil)
+    }
+}
+
+// MARK: - Media fetch methods
+//
+private extension TextViewAttachmentDelegateProvider {
+
+    func exportPreviewImageForVideo(atURL url: URL, onCompletion: @escaping (UIImage) -> (), onError: @escaping () -> ()) {
+        DispatchQueue.global(qos: .background).async {
+            let asset = AVURLAsset(url: url)
+            guard asset.isExportable else {
+                onError()
+                return
+            }
+            let generator = AVAssetImageGenerator(asset: asset)
+            generator.appliesPreferredTrackTransform = true
+            generator.generateCGImagesAsynchronously(forTimes: [NSValue(time: CMTimeMake(value: 2, timescale: 1))],
+                                                     completionHandler: { (time, cgImage, actualTime, result, error) in
+                                                        guard let cgImage = cgImage else {
+                                                            DispatchQueue.main.async {
+                                                                onError()
+                                                            }
+                                                            return
+                                                        }
+                                                        let image = UIImage(cgImage: cgImage)
+                                                        DispatchQueue.main.async {
+                                                            onCompletion(image)
+                                                        }
+            })
+        }
+    }
+
+    func downloadImage(from url: URL, success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
+        let task = URLSession.shared.dataTask(with: url) { [weak self] (data, _, error) in
+            DispatchQueue.main.async {
+                guard self != nil else {
+                    return
+                }
+
+                guard error == nil, let data = data, let image = UIImage(data: data, scale: UIScreen.main.scale) else {
+                    failure()
+                    return
+                }
+
+                success(image)
+            }
+        }
+
+        task.resume()
+    }
+}
+
+// MARK: - Media attachments actions
+//
+extension TextViewAttachmentDelegateProvider {
+    
+    func displayActions(in textView: TextView, forAttachment attachment: MediaAttachment, position: CGPoint) {
+        let mediaID = attachment.identifier
+        let title: String = NSLocalizedString("Media Options", comment: "Title for action sheet with media options.")
+        let message: String? = nil
+        let alertController = UIAlertController(title: title, message:message, preferredStyle: .actionSheet)
+        let dismissAction = UIAlertAction(title: NSLocalizedString("Dismiss", comment: "User action to dismiss media options."),
+                                          style: .cancel,
+                                          handler: { [weak self] (action) in
+                                            self?.resetMediaAttachmentOverlay(attachment)
+                                            textView.refresh(attachment)
+        }
+        )
+        alertController.addAction(dismissAction)
+
+        let removeAction = UIAlertAction(title: NSLocalizedString("Remove Media", comment: "User action to remove media."),
+                                         style: .destructive,
+                                         handler: { (action) in
+                                            textView.remove(attachmentID: mediaID)
+        })
+        alertController.addAction(removeAction)
+
+        if let imageAttachment = attachment as? ImageAttachment {
+            let detailsAction = UIAlertAction(title:NSLocalizedString("Media Details", comment: "User action to change media details."),
+                                              style: .default,
+                                              handler: { [weak self] (action) in
+                                                self?.displayDetailsForAttachment(in: textView, imageAttachment, position: position)
+            })
+            alertController.addAction(detailsAction)
+        } else if let videoAttachment = attachment as? VideoAttachment, let videoURL = videoAttachment.mediaURL {
+            let detailsAction = UIAlertAction(title:NSLocalizedString("Play Video", comment: "User action to play video."),
+                                              style: .default,
+                                              handler: { [weak self] (action) in
+                                                self?.displayVideoPlayer(for: videoURL)
+            })
+            alertController.addAction(detailsAction)
+        }
+
+        alertController.title = title
+        alertController.message = message
+        alertController.popoverPresentationController?.sourceView = textView
+        alertController.popoverPresentationController?.sourceRect = CGRect(origin: position, size: CGSize(width: 1, height: 1))
+        alertController.popoverPresentationController?.permittedArrowDirections = .any
+        baseController.present(alertController, animated:true, completion: nil)
+    }
+
+    func displayDetailsForAttachment(in textView: TextView, _ attachment: ImageAttachment, position:CGPoint) {
+
+        let caption = textView.caption(for: attachment)
+        let detailsViewController = AttachmentDetailsViewController.controller(for: attachment, with: caption)
+
+        let linkInfo = textView.linkInfo(for: attachment)
+        let linkRange = linkInfo?.range
+        let linkUpdateRange = linkRange ?? textView.textStorage.ranges(forAttachment: attachment).first!
+
+        if let linkURL = linkInfo?.url {
+            detailsViewController.linkURL = linkURL
+        }
+
+        detailsViewController.onUpdate = { (alignment, size, srcURL, linkURL, alt, caption) in
+
+            let attachment = textView.edit(attachment) { attachment in
+                if let alt = alt {
+                    attachment.extraAttributes["alt"] = .string(alt)
+                }
+
+                attachment.alignment = alignment
+                attachment.size = size
+                attachment.updateURL(srcURL)
+            }
+
+            if let caption = caption, caption.length > 0 {
+                textView.replaceCaption(for: attachment, with: caption)
+            } else {
+                textView.removeCaption(for: attachment)
+            }
+
+            if let newLinkURL = linkURL {
+                textView.setLink(newLinkURL, inRange: linkUpdateRange)
+            } else if linkURL != nil {
+                textView.removeLink(inRange: linkUpdateRange)
+            }
+        }
+
+        let selectedRange = textView.selectedRange
+
+        detailsViewController.onDismiss = {
+            textView.becomeFirstResponder()
+            textView.selectedRange = selectedRange
+        }
+
+        let navigationController = UINavigationController(rootViewController: detailsViewController)
+        baseController.present(navigationController, animated: true, completion: nil)
+    }
+}
+
+// MARK: - Unknown HTML
+//
+private extension TextViewAttachmentDelegateProvider {
+
+    func displayUnknownHtmlEditor(for attachment: HTMLAttachment, in textView: TextView) {
+        let targetVC = UnknownEditorViewController(attachment: attachment)
+        targetVC.onDidSave = { [weak self] html in
+            textView.edit(attachment) { updated in
+                updated.rawHTML = html
+            }
+
+            self?.baseController.dismiss(animated: true, completion: nil)
+        }
+
+        targetVC.onDidCancel = { [weak self] in
+            self?.baseController.dismiss(animated: true, completion: nil)
+        }
+
+        let navigationController = UINavigationController(rootViewController: targetVC)
+        displayAsPopover(viewController: navigationController)
+    }
+
+    func displayAsPopover(viewController: UIViewController) {
+        viewController.modalPresentationStyle = .popover
+        viewController.preferredContentSize = baseController.view.frame.size
+
+        let presentationController = viewController.popoverPresentationController
+        presentationController?.sourceView = baseController.view
+        presentationController?.delegate = self
+
+        baseController.present(viewController, animated: true, completion: nil)
+    }
+}
+
+// MARK: - UIPopoverPresentationControllerDelegate
+//
+extension TextViewAttachmentDelegateProvider: UIPopoverPresentationControllerDelegate {
+
+    func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
+        return .none
+    }
+
+    func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
+    }
+}

--- a/Example/Example/TextViewAttachmentDelegateProvider.swift
+++ b/Example/Example/TextViewAttachmentDelegateProvider.swift
@@ -302,8 +302,7 @@ private extension TextViewAttachmentDelegateProvider {
         displayAsPopover(viewController: navigationController)
     }
 
-    func displayAsPopover(viewController: UIViewController) {
-        viewController.modalPresentationStyle = .popover
+    func displayAsPopover(viewController: UIViewController) {        
         viewController.preferredContentSize = baseController.view.frame.size
 
         let presentationController = viewController.popoverPresentationController

--- a/Example/Example/UIImage+SaveTo.swift
+++ b/Example/Example/UIImage+SaveTo.swift
@@ -1,0 +1,21 @@
+import Foundation
+import UIKit
+
+extension UIImage {
+
+    func saveToTemporaryFile() -> URL {
+        let fileName = "\(ProcessInfo.processInfo.globallyUniqueString)_file.jpg"
+
+        guard let data = self.jpegData(compressionQuality: 0.9) else {
+            fatalError("Could not conert image to JPEG.")
+        }
+
+        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
+
+        guard (try? data.write(to: fileURL, options: [.atomic])) != nil else {
+            fatalError("Could not write the image to disk.")
+        }
+
+        return fileURL
+    }
+}


### PR DESCRIPTION
Addresses #1224 

This is a first step on simplifying the EditorDemoController, by breaking it in smaller classes.
On this PR we mainly focus around the attachment handling by creating two classes:
 - MediaInserter: to do the actions to insert media object in the TextView
 - TextViewAttachmentDelegateProvider: to provide all the delegate methods and actions around the attachment handling on TextView

To test:
 - Check the demo app and see that all media bevahiour is correct:
  - insert Image
  - insert Video
  - Tap on Image/Video and see if the actions show correctly.
  - Tap on unknown HTML and see if the actions show correctly.

