### PR TITLE
Issue/1266 links with mix characters

### DIFF
--- a/Aztec/Classes/Libxml2/DOM/Data/Element.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/Element.swift
@@ -30,7 +30,7 @@ public struct Element: RawRepresentable, Hashable {
     public static var mergeableBlockLevelElements = Set<Element>([.blockquote, .div, .figure, .figcaption, .h1, .h2, .h3, .h4, .h5, .h6, .hr, .li, .ol, .ul, .p, .pre])
 
     /// List of style HTML elements that can be merged together when they are sibling to each other
-    public static var mergeableStyleElements = Set<Element>([.i, .em, .b, .strong, .strike, .u, .code, .cite])
+    public static var mergeableStyleElements = Set<Element>([.i, .em, .b, .strong, .strike, .u, .code, .cite, .a])
 
     /// List of block level elements that can be merged but only when they have a single children that is also mergeable
     ///

--- a/AztecTests/TextKit/TextViewTests.swift
+++ b/AztecTests/TextKit/TextViewTests.swift
@@ -2106,4 +2106,14 @@ class TextViewTests: XCTestCase {
         XCTAssertEqual(attributes[.foregroundColor] as! UIColor,UIColor.green)
     }
 
+    func testLinksWithMultipleCharactersNonLatinDontBreak() {
+        let textView = TextViewStub(withHTML: "<p><a href=\"www.worpdress.com\">WordPress 워드 프레스</a></p>")
+        let html = textView.getHTML()
+        XCTAssertEqual(html, "<p><a href=\"www.worpdress.com\">WordPress 워드 프레스</a></p>")
+
+        textView.setHTML("<p><a href=\"www.worpdress.com\">WordPress</a><a href=\"www.jetpack.com\">워드 프레스</a></p>")
+        let htmlTwoLinks = textView.getHTML()
+        XCTAssertEqual(htmlTwoLinks, "<p><a href=\"www.worpdress.com\">WordPress</a><a href=\"www.jetpack.com\">워드 프레스</a></p>")
+    }
+
 }


### PR DESCRIPTION
Fixes #1266 


To test:
 - Open the empty demo
 - Write this text: `WordPress 워드 프레스`
 - Add a link to the full text
 - Switch to HTML mode
 - Make sure the link is not broken in multiple links.

