### PR TITLE
Fix drawing of underlines when they have a nbsp and span to the end of a line.

### DIFF
--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -201,7 +201,6 @@ private extension LayoutManager {
     }
 }
 
-
 // MARK: - Lists Helpers
 //
 private extension LayoutManager {
@@ -360,3 +359,16 @@ private extension LayoutManager {
         }
     }
 }
+
+extension LayoutManager {
+
+    override func underlineGlyphRange(_ glyphRange: NSRange, underlineType underlineVal: NSUnderlineStyle, lineFragmentRect lineRect: CGRect, lineFragmentGlyphRange lineGlyphRange: NSRange, containerOrigin: CGPoint) {
+
+        var updatedGlyphRange = glyphRange
+        if glyphRange.endLocation == lineGlyphRange.endLocation {
+            updatedGlyphRange = NSRange(location: glyphRange.location, length: glyphRange.length - 1)
+        }
+        drawUnderline(forGlyphRange: updatedGlyphRange, underlineType: underlineVal, baselineOffset: 0, lineFragmentRect: lineRect, lineFragmentGlyphRange: lineGlyphRange, containerOrigin: containerOrigin)
+    }
+}
+

--- a/Example/AztecExample.xcodeproj/project.pbxproj
+++ b/Example/AztecExample.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		F1D3610B20929F0200B4E7A5 /* WordPressEditor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1D3610420929E6D00B4E7A5 /* WordPressEditor.framework */; };
 		FF149F4A20E3C49A0070FECB /* imagesOverlays.html in Resources */ = {isa = PBXBuildFile; fileRef = FF149F4920E3C49A0070FECB /* imagesOverlays.html */; };
 		FF1FD05C20932EDE00186384 /* gutenberg.html in Resources */ = {isa = PBXBuildFile; fileRef = FF1FD05B20932EDE00186384 /* gutenberg.html */; };
+		FF1FEC7E2406E071006221AA /* underline.html in Resources */ = {isa = PBXBuildFile; fileRef = FF1FEC7D2406E071006221AA /* underline.html */; };
 		FF5CDACD239E78B200CF235B /* failedMedia.html in Resources */ = {isa = PBXBuildFile; fileRef = FF5CDACC239E78B200CF235B /* failedMedia.html */; };
 		FF629DC9223BC418004C4106 /* videoShortcodes.html in Resources */ = {isa = PBXBuildFile; fileRef = FF629DC8223BC418004C4106 /* videoShortcodes.html */; };
 		FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */; };
@@ -160,6 +161,7 @@
 		F1D360FC20929E6D00B4E7A5 /* WordPressEditor.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = WordPressEditor.xcodeproj; path = ../WordPressEditor/WordPressEditor.xcodeproj; sourceTree = "<group>"; };
 		FF149F4920E3C49A0070FECB /* imagesOverlays.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = imagesOverlays.html; sourceTree = "<group>"; };
 		FF1FD05B20932EDE00186384 /* gutenberg.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = gutenberg.html; sourceTree = "<group>"; };
+		FF1FEC7D2406E071006221AA /* underline.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = underline.html; sourceTree = "<group>"; };
 		FF5CDACC239E78B200CF235B /* failedMedia.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = failedMedia.html; sourceTree = "<group>"; };
 		FF629DC8223BC418004C4106 /* videoShortcodes.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = videoShortcodes.html; sourceTree = "<group>"; };
 		FF9AF5471DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = AttachmentDetailsViewController.storyboard; sourceTree = "<group>"; };
@@ -214,6 +216,7 @@
 				FF629DC8223BC418004C4106 /* videoShortcodes.html */,
 				FF5CDACC239E78B200CF235B /* failedMedia.html */,
 				FFC6772123D07E3E00B76815 /* bigLists.html */,
+				FF1FEC7D2406E071006221AA /* underline.html */,
 			);
 			path = SampleContent;
 			sourceTree = "<group>";
@@ -465,6 +468,7 @@
 				59280F2B1D47CAF40083FB59 /* SampleText.rtf in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
 				FF149F4A20E3C49A0070FECB /* imagesOverlays.html in Resources */,
+				FF1FEC7E2406E071006221AA /* underline.html in Resources */,
 				FFC41BDE20DBC7BA004DFB4D /* video.html in Resources */,
 				FF9AF5481DB0E4E200C42ED3 /* AttachmentDetailsViewController.storyboard in Resources */,
 			);

--- a/Example/Example/SampleContent/content.html
+++ b/Example/Example/SampleContent/content.html
@@ -13,7 +13,7 @@ Italic: <em>Italic text</em><br/>
 Underline: <u>Underlined text</u><br/>
 Strikethrough: <del>Strikethrough</del><br/>
 Colors: <span style="color: royalblue;">Royal Blue by name</span> <span style="color: #ff0000;">Red by hex</span><br/><br/>
-Undeline with CSS: <span style="text-decoration: underline;">Alternative underline text</span><br/>
+Underline with CSS: <span style="text-decoration: underline;">Alternative underline text</span><br/>
 Links: <a href="http://www.wordpress.com">I'm a link!</a><br/> <a href="http://www.wordpress.com" target="_blank">Open in new window link!</a> <br/>
 Code: <code>print("Hello world")</code>
 

--- a/Example/Example/SampleContent/underline.html
+++ b/Example/Example/SampleContent/underline.html
@@ -1,0 +1,4 @@
+<p><u>Hello&nbsp;world</u></p>
+<p><span style="text-decoration: underline;">Alternative&nbsp;underline&nbsp;text</span></p>
+<p>Before link <a href="www.wordpress.com">Link&nbsp;to&nbsp;WordPress</a></p>
+<p>Before link <a href="www.jetpack.com">Link&nbsp;to&nbsp;Jetpack</a> After link</p>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -21,6 +21,7 @@ class ViewController: UITableViewController
                 DemoRow(title: "Video Demo", action: { self.showEditorDemo(filename: "video", wordPressMode: false) }),
                 DemoRow(title: "Failed Media", action: { self.showEditorDemo(filename: "failedMedia") }),
                 DemoRow(title: "Big Lists", action: { self.showEditorDemo(filename: "bigLists") }),
+                DemoRow(title: "Underline NBSP", action: { self.showEditorDemo(filename: "underline")}),
                 DemoRow(title: "Empty Demo", action: { self.showEditorDemo() })
                 ]
             ),


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/gutenberg-mobile/issues/1218

Change the range were underlines are drawn to avoid them to span to the end of a line. This is a workaround a bug from the Apple CoreText layout system where underlines that contain the `&nbsp` character expand to the end of the line.

<table>
<tr><td><b>Before</b></td><td><b>After</b></td></tr>
<tr><td><img src="https://user-images.githubusercontent.com/651601/75396157-c8f0bb00-58eb-11ea-8b9a-4025a2e2ea08.png" ></td><td><img src="https://user-images.githubusercontent.com/651601/75396228-ee7dc480-58eb-11ea-814c-bf8f1ae0f375.png" ></td></tr>
</table>

To test:
 - Run the demo app
 - Open the content `Underline NBSP`
 - Check that underlines are draw correctly.

