### PR TITLE
Update gridicons to 1.0

### DIFF
--- a/Example/Cartfile.private
+++ b/Example/Cartfile.private
@@ -1,1 +1,1 @@
-github "Automattic/Gridicons-iOS" "0.18"
+github "Automattic/Gridicons-iOS" "1.0"

--- a/Example/Cartfile.resolved
+++ b/Example/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Automattic/Gridicons-iOS" "0.18"
+github "Automattic/Gridicons-iOS" "1.0"

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -1184,7 +1184,7 @@ extension FormattingIdentifier {
 
     private func gridicon(_ gridiconType: GridiconType) -> UIImage {
         let size = EditorDemoController.Constants.formatBarIconSize
-        return Gridicon.iconOfType(gridiconType, withSize: size)
+        return .gridicon(gridiconType, size: size)
     }
 
     var accessibilityIdentifier: String {

--- a/Example/Example/EditorDemoController.swift
+++ b/Example/Example/EditorDemoController.swift
@@ -994,7 +994,7 @@ extension EditorDemoController {
             toolbar.dividerTintColor = .gray
         }
 
-        toolbar.overflowToggleIcon = Gridicon.iconOfType(.ellipsis)
+        toolbar.overflowToggleIcon = .gridicon(.ellipsis)
         toolbar.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 44.0)
         toolbar.autoresizingMask = [ .flexibleHeight ]
         toolbar.formatter = self
@@ -1104,10 +1104,10 @@ extension EditorDemoController {
 
     static var tintedMissingImage: UIImage = {
         if #available(iOS 13.0, *) {
-            return Gridicon.iconOfType(.image).withTintColor(.label)
+            return UIImage.gridicon(.image).withTintColor(.label)
         } else {
             // Fallback on earlier versions
-            return Gridicon.iconOfType(.image)
+            return .gridicon(.image)
         }
     }()
 

--- a/Example/Example/MediaInserter.swift
+++ b/Example/Example/MediaInserter.swift
@@ -71,7 +71,7 @@ class MediaInserter
             timer.invalidate()
             let message = NSAttributedString(string: "Upload failed!", attributes: attachmentTextAttributes)
             attachment.message = message
-            attachment.overlayImage = Gridicon.iconOfType(.refresh)
+            attachment.overlayImage = .gridicon(.refresh)
         }
         if progress.fractionCompleted >= 1 {
             timer.invalidate()

--- a/Example/Example/TextViewAttachmentDelegateProvider.swift
+++ b/Example/Example/TextViewAttachmentDelegateProvider.swift
@@ -48,11 +48,11 @@ class TextViewAttachmentDelegateProvider: NSObject, TextViewAttachmentDelegate {
         var placeholderImage: UIImage
         switch attachment {
         case _ as ImageAttachment:
-            placeholderImage = Gridicon.iconOfType(.image, withSize: imageSize)
+            placeholderImage = .gridicon(.image, size: imageSize)
         case _ as VideoAttachment:
-            placeholderImage = Gridicon.iconOfType(.video, withSize: imageSize)
+            placeholderImage = .gridicon(.video, size: imageSize)
         default:
-            placeholderImage = Gridicon.iconOfType(.attachment, withSize: imageSize)
+            placeholderImage = .gridicon(.attachment, size: imageSize)
         }
         if #available(iOS 13.0, *) {
             placeholderImage = placeholderImage.withTintColor(.label)
@@ -106,7 +106,7 @@ class TextViewAttachmentDelegateProvider: NSObject, TextViewAttachmentDelegate {
                 let message = NSLocalizedString("Options", comment: "Options to show when tapping on a media object on the post/page editor.")
                 attachment.message = NSAttributedString(string: message, attributes: attachmentTextAttributes)
             }
-            attachment.overlayImage = Gridicon.iconOfType(.pencil, withSize: CGSize(width: 32.0, height: 32.0)).withRenderingMode(.alwaysTemplate)
+            attachment.overlayImage = UIImage.gridicon(.pencil, size: CGSize(width: 32.0, height: 32.0)).withRenderingMode(.alwaysTemplate)
             textView.refresh(attachment)
             currentSelectedAttachment = attachment
         }


### PR DESCRIPTION
Update the example app to use Gridicons library version 1.0

To test:
 - Just build and run locally.
 - See if icons on the toolbar look correct on the demo app.

