### PR TITLE
Fix underline bug

### DIFF
--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -363,9 +363,15 @@ private extension LayoutManager {
 extension LayoutManager {
 
     override func underlineGlyphRange(_ glyphRange: NSRange, underlineType underlineVal: NSUnderlineStyle, lineFragmentRect lineRect: CGRect, lineFragmentGlyphRange lineGlyphRange: NSRange, containerOrigin: CGPoint) {
-
+        guard let textStorage = textStorage else {
+            return
+        }
+        let underlinedString = textStorage.attributedSubstring(from: glyphRange).string
         var updatedGlyphRange = glyphRange
-        if glyphRange.endLocation == lineGlyphRange.endLocation {
+        if glyphRange.endLocation == lineGlyphRange.endLocation,
+           underlinedString.contains(String.init(.nonBreakingSpace)),
+            underlinedString.hasSuffix(String.init(.paragraphSeparator))
+        {
             updatedGlyphRange = NSRange(location: glyphRange.location, length: glyphRange.length - 1)
         }
         drawUnderline(forGlyphRange: updatedGlyphRange, underlineType: underlineVal, baselineOffset: 0, lineFragmentRect: lineRect, lineFragmentGlyphRange: lineGlyphRange, containerOrigin: containerOrigin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.17.1
+-----
+* Fix drawing of underlines when they include the last character of content.
+
 1.17.0
 -----
  * Fix drawing of underlines when they have a nbsp and span to the end of a line

--- a/Example/Example/SampleContent/underline.html
+++ b/Example/Example/SampleContent/underline.html
@@ -2,3 +2,4 @@
 <p><span style="text-decoration: underline;">Alternative&nbsp;underline&nbsp;text</span></p>
 <p>Before link <a href="www.wordpress.com">Link&nbsp;to&nbsp;WordPress</a></p>
 <p>Before link <a href="www.jetpack.com">Link&nbsp;to&nbsp;Jetpack</a> After link</p>
+Link at end of text<a href="www.jetpack.com">Link&nbsp;to&nbsp;Jetpack</a>

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.17.0'
+  s.version          = '1.17.1'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.17.0'
+  s.version          = '1.17.1'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
It looks the [underline fix](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1271) introduced a bug when drawing links that are at the end of the content.
This PR checks the condition where the fix is applied to avoid using it on the wrong scenarios.

To test:
 - Start the demo app
 - Open the NBSP demo content
 - Move the cursor to the end of content ( last empty line)
 - Press backspace
 - Check that the underline is drawn to the end of the linked text

