### PR TITLE
Add option to disable collapsing of whitespaces.

### DIFF
--- a/Aztec/Classes/Libxml2/Converters/In/HTMLParser.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/HTMLParser.swift
@@ -8,6 +8,8 @@ open class HTMLParser {
         case NoRootNode = "No root node"
     }
 
+    var shouldCollapseSpaces: Bool = true
+
     /// Public initializer
     ///
     public init() { }
@@ -71,7 +73,7 @@ open class HTMLParser {
 
         let rootNodePtr = xmlDocGetRootElement(document)
         let nodeConverter = InNodeConverter()
-
+        nodeConverter.shouldCollapseSpaces = shouldCollapseSpaces
         guard let rootNode = rootNodePtr?.pointee,
             let node = nodeConverter.convert(rootNode) as? RootNode else {
                 return RootNode(children: [TextNode(text: "")])

--- a/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
@@ -3,6 +3,7 @@ import libxml2
 
 class InNodeConverter: SafeConverter {
     
+    var shouldCollapseSpaces: Bool = true
     /// Converts a single node (from libxml2) into an HTML.Node.
     ///
     /// - Parameters:
@@ -105,7 +106,7 @@ class InNodeConverter: SafeConverter {
     fileprivate func createTextNode(_ rawNode: xmlNode) -> TextNode {
         let text = String(cString: rawNode.content)
         let node = TextNode(text: text)
-
+        node.shouldCollapseSpaces = shouldCollapseSpaces
         return node
     }
 

--- a/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
@@ -84,7 +84,7 @@ class InNodeConverter: SafeConverter {
         var children = [Node]()
 
         if rawNode.children != nil {
-            let nodesConverter = InNodesConverter()
+            let nodesConverter = InNodesConverter(shouldCollapseSpaces: shouldCollapseSpaces)
             children.append(contentsOf: nodesConverter.convert(rawNode.children))
         }
 

--- a/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodeConverter.swift
@@ -2,7 +2,10 @@ import Foundation
 import libxml2
 
 class InNodeConverter: SafeConverter {
-    
+
+    init(shouldCollapseSpaces: Bool = true) {
+        self.shouldCollapseSpaces = shouldCollapseSpaces        
+    }
     var shouldCollapseSpaces: Bool = true
     /// Converts a single node (from libxml2) into an HTML.Node.
     ///
@@ -54,7 +57,7 @@ class InNodeConverter: SafeConverter {
         var children = [Node]()
 
         if rawNode.children != nil {
-            let nodesConverter = InNodesConverter()
+            let nodesConverter = InNodesConverter(shouldCollapseSpaces: shouldCollapseSpaces)
             children.append(contentsOf: nodesConverter.convert(rawNode.children))
         }
 

--- a/Aztec/Classes/Libxml2/Converters/In/InNodesConverter.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/InNodesConverter.swift
@@ -5,8 +5,11 @@ import libxml2
 /// Converts a C linked list of xmlNode to [HTML.Node].
 ///
 class InNodesConverter: SafeCLinkedListToArrayConverter<InNodeConverter> {
-    
-    required init() {
-        super.init(elementConverter: InNodeConverter(), next: { return $0.next })
+
+    let shouldCollapseSpaces: Bool
+
+    required init(shouldCollapseSpaces: Bool = true) {
+        self.shouldCollapseSpaces = shouldCollapseSpaces
+        super.init(elementConverter: InNodeConverter(shouldCollapseSpaces: shouldCollapseSpaces), next: { return $0.next })
     }
 }

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -7,6 +7,8 @@ public class TextNode: Node {
 
     let contents: String
 
+    let shouldRemoveExtraSpaces: Bool = false
+
     // MARK: - CustomReflectable
     
     override public var customMirror: Mirror {
@@ -92,10 +94,15 @@ extension TextNode {
         // U+000A, which is non-breaking space.  We need to maintain it.
         //
         let whitespace = CharacterSet.whitespacesAndNewlines
-        let whitespaceToKeep = CharacterSet(charactersIn: String(.nonBreakingSpace)+String(.lineSeparator))
+        var whitespaceToKeep = CharacterSet(charactersIn: String(.nonBreakingSpace)+String(.lineSeparator))
+        if ( !shouldRemoveExtraSpaces ) {
+            whitespaceToKeep.insert(charactersIn: String(.space))
+        }
         let whitespaceToRemove = whitespace.subtracting(whitespaceToKeep)
-        
         let trimmedText = text.trimmingCharacters(in: whitespaceToRemove)
+        if ( !shouldRemoveExtraSpaces ) {
+            return trimmedText
+        }
         var singleSpaceText = trimmedText
         let doubleSpace = "  "
         let singleSpace = " "
@@ -116,7 +123,6 @@ extension TextNode {
     /// - Returns: true if sanitization should happen, false otherwise
     ///
     private func shouldSanitizeText() -> Bool {
-        return false
-        //return !hasAncestor(ofType: .pre)
+        return !hasAncestor(ofType: .pre)
     }
 }

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -116,6 +116,7 @@ extension TextNode {
     /// - Returns: true if sanitization should happen, false otherwise
     ///
     private func shouldSanitizeText() -> Bool {
-        return !hasAncestor(ofType: .pre)
+        return false
+        //return !hasAncestor(ofType: .pre)
     }
 }

--- a/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
+++ b/Aztec/Classes/Libxml2/DOM/Data/TextNode.swift
@@ -7,7 +7,7 @@ public class TextNode: Node {
 
     let contents: String
 
-    let shouldRemoveExtraSpaces: Bool = false
+    var shouldCollapseSpaces: Bool = true
 
     // MARK: - CustomReflectable
     
@@ -95,12 +95,12 @@ extension TextNode {
         //
         let whitespace = CharacterSet.whitespacesAndNewlines
         var whitespaceToKeep = CharacterSet(charactersIn: String(.nonBreakingSpace)+String(.lineSeparator))
-        if ( !shouldRemoveExtraSpaces ) {
+        if ( !shouldCollapseSpaces ) {
             whitespaceToKeep.insert(charactersIn: String(.space))
         }
         let whitespaceToRemove = whitespace.subtracting(whitespaceToKeep)
         let trimmedText = text.trimmingCharacters(in: whitespaceToRemove)
-        if ( !shouldRemoveExtraSpaces ) {
+        if ( !shouldCollapseSpaces ) {
             return trimmedText
         }
         var singleSpaceText = trimmedText

--- a/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
+++ b/Aztec/Classes/NSAttributedString/Conversions/HTMLConverter.swift
@@ -25,6 +25,10 @@ public class HTMLConverter {
     ///
     open var characterToReplaceLastEmptyLine: Character?
 
+    /// If this value is set the converter will behave like a browser and collapse extra white spaces
+    ///
+    open var shouldCollapseSpaces: Bool = true
+
     let htmlToTree = HTMLParser()
     
     private(set) lazy var treeToAttributedString: AttributedStringSerializer = {
@@ -53,6 +57,7 @@ public class HTMLConverter {
     ///
     func attributedString(from html: String, defaultAttributes: [NSAttributedString.Key: Any]? = [:]) -> NSAttributedString {
         let processedHTML = pluginManager.process(html: html)
+        htmlToTree.shouldCollapseSpaces = shouldCollapseSpaces
         let rootNode = htmlToTree.parse(processedHTML)
         
         pluginManager.process(htmlTree: rootNode)

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -562,4 +562,21 @@ class TextStorageTests: XCTestCase {
             XCTAssert(font.pointSize == 14)
         }
     }
+
+    /// Verifies that spaces are not collapsed
+    ///
+    func testConverterCollapsesSpacesText() {
+        let initialHTML = "<p>  Hello  World  </p>"
+
+        // Setup
+        let defaultAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 14),
+                                                                .paragraphStyle: ParagraphStyle.default]
+
+        storage.htmlConverter.shouldCollapseSpaces = false
+        storage.setHTML(initialHTML, defaultAttributes: defaultAttributes)
+
+        let expectedResult = "<p>  Hello  World  </p>"
+        let result = storage.getHTML()
+        XCTAssertEqual(expectedResult, result)
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.18.0
+-------
+* Added an option to not colapse whitespaces when saving the HTML.
+
 1.17.1
 -----
 * Fix drawing of underlines when they include the last character of content.

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.17.1'
+  s.version          = '1.18.0'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.17.1'
+  s.version          = '1.18.0'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Create an option in Aztec to allow configuration of the whitespace removal, also known as text sanitization.

This shouldn't affect the Aztec editor and the option should only be activated on special use cases, for example, the Gutenberg editor: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2127

To test:
 - Start the demo app
 - See if all content still looks correct on the multiple demos

