### PR TITLE
Support Cover Block Uploads

### DIFF
--- a/Aztec/Classes/Processor/HTMLProcessor.swift
+++ b/Aztec/Classes/Processor/HTMLProcessor.swift
@@ -51,7 +51,7 @@ open class HTMLProcessor: Processor {
     /// 5. The closing tag.
     ///
     private lazy var htmlRegexProcessor: RegexProcessor = { [unowned self] in
-        let pattern = "\\<(\(element))(?![\\w-])([^\\>\\/]*(?:\\/(?!\\>)[^\\>\\/]*)*?)(?:(\\/)\\>|\\>(?:([^\\<]*(?:\\<(?!\\/\\1\\>)[^\\<]*)*)(\\<\\/\\1\\>))?)"
+        let pattern = "\\<(\(element))(?![\\w-])([^\\>\\/]*(?:\\/(?!\\>)[^\\>\\/]*)*?)(?:(\\/)\\>|\\>(?:([^\\<]*(?:\\<(?!(?:<\\/\\1\\>))[^\\<]*)*)(\\<\\/\\1\\>))?)"
         let regex = try! NSRegularExpression(pattern: pattern, options: .caseInsensitive)
         
         return RegexProcessor(regex: regex) { (match: NSTextCheckingResult, text: String) -> String? in

--- a/AztecTests/Processor/HTMLProcessorTests.swift
+++ b/AztecTests/Processor/HTMLProcessorTests.swift
@@ -35,4 +35,27 @@ class HTMLProcessorTests: XCTestCase {
         XCTAssertEqual(parsedText, "[wpvideo OcobLTqC width=\"640\" height=\"400\"/]")
     }
     
+    func testProcessorOfNestedDivs() {
+        let innerContent = """
+        <div class="wp-block-cover__inner-container">
+        <!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
+        <p class="has-text-align-center"></p>
+        <!-- /wp:paragraph -->
+        </div>
+        """
+        
+        let sampleText = """
+        <div class="wp-block-cover has-background-dim" style="background-image:url(file:///usr/tmp/-1175513456.jpg)">\(innerContent)</div>
+        """
+        
+        let processor = HTMLProcessor(for: "div", replacer:{ (divElement) in
+            XCTAssertEqual(divElement.tag, "div")
+            XCTAssertEqual(divElement.type, HTMLElement.TagType.closed)
+            XCTAssertEqual(divElement.content, innerContent)
+            return ""
+        })
+        
+        let _ = processor.process(sampleText)
+    }
+    
 }

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.17.1'
+  s.version          = '1.17.2-beta.1'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.
@@ -41,5 +41,3 @@ Pod::Spec.new do |s|
   s.xcconfig = {'OTHER_LDFLAGS' => '-lxml2',
   				'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'}
 end
-
-

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.17.1'
+  s.version          = '1.17.2-beta.1'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.
@@ -39,5 +39,3 @@ Pod::Spec.new do |s|
 
   s.dependency "WordPress-Aztec-iOS", s.version.to_s
 end
-
-


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1739

## Description:
In Gutenberg, we're adding support for CoverBlocks and uploading media outside of the editor. 

In the format, for Cover Blocks, we need to modify the Block Contents using `GutenbergBlockProcessor` as well as the HTML Contents using `HTMLProcessor`. As part of the processing for this block which has a nested `div` section, it was returning the contents to be 

```
<div class="wp-block-cover__inner-container">
    <!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
        <p class="has-text-align-center"></p>
    <!-- /wp:paragraph -->
```
Instead of including the nested escaping div for the nested block

```
<div class="wp-block-cover__inner-container">
    <!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
        <p class="has-text-align-center"></p>
    <!-- /wp:paragraph -->
</div>
```

This PR modifies the regex to look ahead and grab the outer closing `<\div>` instead of the inner one.

**Unparsed Cover Block:**
<details>

```
<!-- wp:cover {"url":"file:///usr/tmp/-1175513456.jpg","id":-1175513456} -->
    <div class="wp-block-cover has-background-dim" style="background-image:url(file:///usr/tmp/-1175513456.jpg)">
        <div class="wp-block-cover__inner-container">
            <!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
                <p class="has-text-align-center"></p>
            <!-- /wp:paragraph -->
         </div>
    </div>
<!-- /wp:cover -->
```

</details>

**Parsed Cover Block:**
<details>

```
<!-- wp:cover {"id":456,"url":"http:\\/\\/www.wordpress.com\\/logo.jpg"} -->
    <div class="wp-block-cover has-background-dim" style="background-image:url(http://www.wordpress.com/logo.jpg)">
        <div class="wp-block-cover__inner-container">
            <!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
                <p class="has-text-align-center"></p>
            <!-- /wp:paragraph -->
         </div>
    </div>
<!-- /wp:cover -->
```

</details>

## To test:
This can be tested with: 