### PR TITLE
Fix collapse of white spaces when parsing HTML text.

### DIFF
--- a/Aztec/Classes/Libxml2/Converters/In/HTMLParser.swift
+++ b/Aztec/Classes/Libxml2/Converters/In/HTMLParser.swift
@@ -45,12 +45,16 @@ open class HTMLParser {
         //
         htmlHandleOmittedElem(0)
 
+        var parserOptions = HTML_PARSE_RECOVER.rawValue | HTML_PARSE_NODEFDTD.rawValue | HTML_PARSE_NOERROR.rawValue | HTML_PARSE_NOWARNING.rawValue | HTML_PARSE_NOIMPLIED.rawValue
+        if shouldCollapseSpaces {
+            parserOptions = parserOptions | HTML_PARSE_NOBLANKS.rawValue
+        }
         let document = htmlCtxtReadMemory(parserContext,
                                           htmlPtr,
                                           Int32(wrappedHTML.lengthOfBytes(using: String.Encoding.utf8)),
                                           "",
                                           "UTF-8",
-                                          Int32(HTML_PARSE_RECOVER.rawValue | HTML_PARSE_NODEFDTD.rawValue | HTML_PARSE_NOERROR.rawValue | HTML_PARSE_NOWARNING.rawValue | HTML_PARSE_NOIMPLIED.rawValue | HTML_PARSE_NOBLANKS.rawValue))
+                                          Int32(parserOptions))
         
         defer {
             xmlFreeDoc(document)

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -566,7 +566,7 @@ class TextStorageTests: XCTestCase {
     /// Verifies that spaces are not collapsed
     ///
     func testConverterCollapsesSpacesText() {
-        let initialHTML = "<p>  Hello  <br>   World  </p>"
+        let initialHTML = "<p>  Hello  <br>   <strong>World</strong>  </p>"
 
         // Setup
         let defaultAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 14),
@@ -575,7 +575,7 @@ class TextStorageTests: XCTestCase {
         storage.htmlConverter.shouldCollapseSpaces = false
         storage.setHTML(initialHTML, defaultAttributes: defaultAttributes)
 
-        let expectedResult = "<p>  Hello  <br>   World  </p>"
+        let expectedResult = "<p>  Hello  <br>   <strong>World</strong>  </p>"
         let result = storage.getHTML()
         XCTAssertEqual(expectedResult, result)
     }

--- a/AztecTests/TextKit/TextStorageTests.swift
+++ b/AztecTests/TextKit/TextStorageTests.swift
@@ -566,7 +566,7 @@ class TextStorageTests: XCTestCase {
     /// Verifies that spaces are not collapsed
     ///
     func testConverterCollapsesSpacesText() {
-        let initialHTML = "<p>  Hello  World  </p>"
+        let initialHTML = "<p>  Hello  <br>   World  </p>"
 
         // Setup
         let defaultAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 14),
@@ -575,7 +575,7 @@ class TextStorageTests: XCTestCase {
         storage.htmlConverter.shouldCollapseSpaces = false
         storage.setHTML(initialHTML, defaultAttributes: defaultAttributes)
 
-        let expectedResult = "<p>  Hello  World  </p>"
+        let expectedResult = "<p>  Hello  <br>   World  </p>"
         let result = storage.getHTML()
         XCTAssertEqual(expectedResult, result)
     }


### PR DESCRIPTION
Makes sure that collapsing/removal of whitespaces doesn't happen at the parser level

To test:
 - Check if CI server tests are green.

