### PR TITLE
Apply range correction even if no nbsp is present.

### DIFF
--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -368,7 +368,7 @@ extension LayoutManager {
         }
         let underlinedString = textStorage.attributedSubstring(from: glyphRange).string
         var updatedGlyphRange = glyphRange
-        if glyphRange.endLocation == lineGlyphRange.endLocation,            
+        if glyphRange.endLocation == lineGlyphRange.endLocation,
             underlinedString.hasSuffix(String.init(.paragraphSeparator)) || underlinedString.hasSuffix(String.init(.lineSeparator)) || underlinedString.hasSuffix(String.init(.carriageReturn)) || underlinedString.hasSuffix(String.init(.lineFeed))
         {
             updatedGlyphRange = NSRange(location: glyphRange.location, length: glyphRange.length - 1)

--- a/Aztec/Classes/TextKit/LayoutManager.swift
+++ b/Aztec/Classes/TextKit/LayoutManager.swift
@@ -368,9 +368,8 @@ extension LayoutManager {
         }
         let underlinedString = textStorage.attributedSubstring(from: glyphRange).string
         var updatedGlyphRange = glyphRange
-        if glyphRange.endLocation == lineGlyphRange.endLocation,
-           underlinedString.contains(String.init(.nonBreakingSpace)),
-            underlinedString.hasSuffix(String.init(.paragraphSeparator))
+        if glyphRange.endLocation == lineGlyphRange.endLocation,            
+            underlinedString.hasSuffix(String.init(.paragraphSeparator)) || underlinedString.hasSuffix(String.init(.lineSeparator)) || underlinedString.hasSuffix(String.init(.carriageReturn)) || underlinedString.hasSuffix(String.init(.lineFeed))
         {
             updatedGlyphRange = NSRange(location: glyphRange.location, length: glyphRange.length - 1)
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.19.2
+-------
+* Fix drawing of underlines when they include newlines.
+
 1.19.1
 -------
 * Fix a bug where collapse of whitespaces was happening for empty HTML nodes.

--- a/Example/Example/SampleContent/underline.html
+++ b/Example/Example/SampleContent/underline.html
@@ -1,4 +1,5 @@
-<p><u>Hello&nbsp;world</u></p>
+<p><u>No NBSP</u></p>
+<p><u>With&nbsp;NBSP</u></p>
 <p><span style="text-decoration: underline;">Alternative&nbsp;underline&nbsp;text</span></p>
 <p>Before link <a href="www.wordpress.com">Link&nbsp;to&nbsp;WordPress</a></p>
 <p>Before link <a href="www.jetpack.com">Link&nbsp;to&nbsp;Jetpack</a> After link</p>

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.19.1'
+  s.version          = '1.19.2'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.19.1'
+  s.version          = '1.19.2'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
The fix needs to be applied every time there is any kind of newline
characters at the end of the character range.

Fixes #1275 

To test:
 - Start the demo app
 - Select the Underline NBSP demo
 - Check that pressing Enter at the end of the lines does not make underlines expand across the whitespace of the line.

Like this:

<img src="https://user-images.githubusercontent.com/651601/82911656-14a31700-9f64-11ea-98d6-13a6cbf20e12.png" width=300>


