### PR TITLE
[Gutenberg] Correct Color for RichText links in Dark Mode - Expose helper method

### DIFF
--- a/Aztec/Classes/Extensions/UIColor+Parsers.swift
+++ b/Aztec/Classes/Extensions/UIColor+Parsers.swift
@@ -5,7 +5,7 @@ public extension UIColor {
     /// Creates a color based on a hexString. If the string is not a valid hexColor it return nil
     /// Example of colors: #FF0000, #00FF0000
     ///
-    public convenience init?(hexString: String) {
+    convenience init?(hexString: String) {
 
         let hex = hexString.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
         var int = UInt32()

--- a/Aztec/Classes/Extensions/UIColor+Parsers.swift
+++ b/Aztec/Classes/Extensions/UIColor+Parsers.swift
@@ -1,11 +1,11 @@
 import UIKit
 
-extension UIColor {
+public extension UIColor {
 
     /// Creates a color based on a hexString. If the string is not a valid hexColor it return nil
     /// Example of colors: #FF0000, #00FF0000
     ///
-    convenience init?(hexString: String) {
+    public convenience init?(hexString: String) {
 
         let hex = hexString.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
         var int = UInt32()

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.19.2'
+  s.version          = '1.19.3'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.
@@ -41,5 +41,3 @@ Pod::Spec.new do |s|
   s.xcconfig = {'OTHER_LDFLAGS' => '-lxml2',
   				'HEADER_SEARCH_PATHS' => '/usr/include/libxml2'}
 end
-
-

--- a/WordPress-Aztec-iOS.podspec
+++ b/WordPress-Aztec-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Aztec-iOS'
-  s.version          = '1.19.3'
+  s.version          = '1.19.2'
   s.summary          = 'The native HTML Editor.'
 
 # This description is used to generate tags and improve search results.

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.19.2'
+  s.version          = '1.19.3'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.
@@ -39,5 +39,3 @@ Pod::Spec.new do |s|
 
   s.dependency "WordPress-Aztec-iOS", s.version.to_s
 end
-
-

--- a/WordPress-Editor-iOS.podspec
+++ b/WordPress-Editor-iOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'WordPress-Editor-iOS'
-  s.version          = '1.19.3'
+  s.version          = '1.19.2'
   s.summary          = 'The WordPress HTML Editor.'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2399

**Related PRs:**
`gutenberg` https://github.com/WordPress/gutenberg/pull/23289
`gutenberg-mobile` https://github.com/wordpress-mobile/gutenberg-mobile/pull/2404
~`WordPress-Android` https://github.com/wordpress-mobile/WordPress-Android/pull/12226~
~`WordPress-iOS` https://github.com/wordpress-mobile/WordPress-iOS/pull/14351~

## To test:
Please see the testing and overview in https://github.com/wordpress-mobile/gutenberg-mobile/pull/2404

This simply exposes the helper method to prevent duplication in order to allow the conversion of colors from a hex string for link attributes. 